### PR TITLE
Scroll selected category to top of view

### DIFF
--- a/src/components/service-grid/service-grid.tsx
+++ b/src/components/service-grid/service-grid.tsx
@@ -31,7 +31,7 @@ export class ServiceGrid {
         const heading = this.root.shadowRoot.querySelector(`#category-${this.scrollToCategory}`);
 
         if (heading) {
-          heading.scrollIntoView({ behavior: 'smooth' });
+          heading.scrollIntoView({ behavior: 'smooth', block: 'start' });
         }
       }
 


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

`scrollIntoView` was putting the selected category into position at the middle of the screen, rather than the top.

## Testing

Click on a category in the left menu. The corresponding category header should scroll into view at the top.