### PR TITLE
Lower threshold and check ratio to tighten up intersection logic

### DIFF
--- a/src/components/service-grid/service-grid.tsx
+++ b/src/components/service-grid/service-grid.tsx
@@ -21,7 +21,7 @@ export class ServiceGrid {
   componentWillLoad() {
     this.observer = new IntersectionObserver(this.observe, {
       root: null,
-      threshold: 1.0,
+      threshold: 0.9,
     });
   }
 
@@ -43,7 +43,7 @@ export class ServiceGrid {
     entries: IntersectionObserverEntry[],
     _observer: IntersectionObserver
   ): void => {
-    const visibleEntry = entries.find(e => e.isIntersecting);
+    const visibleEntry = entries.find(e => e.isIntersecting && e.intersectionRatio > 0.99);
     if (visibleEntry) {
       const [, ...rest] = visibleEntry.target.id.split('-');
       const category = rest.join('-');


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

The intersection observer was a little glitchy in FF, presumably because the events fire differently / more often / in a funny order. Limiting side effects to elements with a higher intersection ratio and changing the threshold to 90% works a lot better for me. 

## Testing

Test on FF to make sure the issue is fixed there, but please test other browsers too.