### PR TITLE
[Tiny] Fix package.json warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,14 @@
   },
   "author": "manifoldco",
   "license": "ISC",
+  "files": [
+    "dist/"
+  ],
+  "main": "dist/index.js",
+  "esnext": "dist/esm",
+  "module": "dist/esm",
+  "types": "dist/types/components.d.ts",
+  "collection": "dist/collection/collection-manifest.json",
   "scripts": {
     "build": "stencil build",
     "dev": "stencil build --dev --docs --watch --serve",

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -27,11 +27,12 @@ if (flag && flag[0].length > 1) {
 
 // 3. Generate package.json for npm
 const packageJSON = JSON.parse(readFileSync(resolve(__dirname, '..', 'package.json'), 'utf8'));
+// These have to be overridden to work on npm, and Stencil complains about these values
 const newPackageJSON = {
   ...packageJSON,
   version,
   files: ['*'],
-  main: './manifold.js',
+  main: './index.js',
   esnext: './esm',
   module: './esm',
   types: './types/components.d.ts',


### PR DESCRIPTION
## Reason for change
Silences the console warnings on local dev:

```bash
[ WARN  ]  build warn
           package.json "collection" property is required when generating a distribution and must be set to:
           dist/collection/collection-manifest.json

[ WARN  ]  build warn
           package.json "types" property is required when generating a distribution. It's recommended to set the
           "types" property to: dist/types/components.d.ts

[ WARN  ]  build warn
           package.json "module" property is required when generating a distribution. It's recommended to set the
           "module" property to: dist/esm/es5/index.js

[ WARN  ]  build warn
           package.json "main" property is required when generating a distribution. It's recommended to set the "main"
           property to: dist/index.js
```

## Testing
Pull down, run `npm run dev` & make sure none of the above warnings appear (or any new warnings, for that matter)
