### PR TITLE
Fix too long name

### DIFF
--- a/src/components/service-card/service-card.css
+++ b/src/components/service-card/service-card.css
@@ -136,7 +136,7 @@
   align-self: center;
   margin-top: 0;
   margin-bottom: 0;
-  padding-right: 5px;
+  padding-right: 0.5rem;
   color: var(--text-color);
   font-weight: 400;
   font-size: 1em;


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

Occasionally the name is too long and overlaps the gear icon. Add right padding to name.

## Testing
<!-- For someone unfamiliar with the issue, how should this be tested? -->
Ensure this:
![card_bug](https://user-images.githubusercontent.com/2334167/54985833-d03a7680-4f6e-11e9-82fd-9fae0d18058f.png)
is now:
<img width="339" alt="Screen Shot 2019-03-26 at 2 27 15 AM" src="https://user-images.githubusercontent.com/2334167/54985811-c31d8780-4f6e-11e9-935b-b49acf70e1c7.png">
