### PR TITLE
Lazy load images on service cards

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -96,6 +96,17 @@ export namespace Components {
     'title'?: string;
   }
 
+  interface ManifoldLazyImage {
+    'alt': string;
+    'itemprop': string;
+    'src': string;
+  }
+  interface ManifoldLazyImageAttributes extends StencilHTMLAttributes {
+    'alt'?: string;
+    'itemprop'?: string;
+    'src'?: string;
+  }
+
   interface ManifoldLinkButton {
     'href': string;
     'rel'?: string;
@@ -311,6 +322,7 @@ declare global {
     'ManifoldFeaturedService': Components.ManifoldFeaturedService;
     'ManifoldIcon': Components.ManifoldIcon;
     'ManifoldImageGallery': Components.ManifoldImageGallery;
+    'ManifoldLazyImage': Components.ManifoldLazyImage;
     'ManifoldLinkButton': Components.ManifoldLinkButton;
     'ManifoldMarketplaceResults': Components.ManifoldMarketplaceResults;
     'ManifoldMarketplace': Components.ManifoldMarketplace;
@@ -338,6 +350,7 @@ declare global {
     'manifold-featured-service': Components.ManifoldFeaturedServiceAttributes;
     'manifold-icon': Components.ManifoldIconAttributes;
     'manifold-image-gallery': Components.ManifoldImageGalleryAttributes;
+    'manifold-lazy-image': Components.ManifoldLazyImageAttributes;
     'manifold-link-button': Components.ManifoldLinkButtonAttributes;
     'manifold-marketplace-results': Components.ManifoldMarketplaceResultsAttributes;
     'manifold-marketplace': Components.ManifoldMarketplaceAttributes;
@@ -393,6 +406,12 @@ declare global {
   var HTMLManifoldImageGalleryElement: {
     prototype: HTMLManifoldImageGalleryElement;
     new (): HTMLManifoldImageGalleryElement;
+  };
+
+  interface HTMLManifoldLazyImageElement extends Components.ManifoldLazyImage, HTMLStencilElement {}
+  var HTMLManifoldLazyImageElement: {
+    prototype: HTMLManifoldLazyImageElement;
+    new (): HTMLManifoldLazyImageElement;
   };
 
   interface HTMLManifoldLinkButtonElement extends Components.ManifoldLinkButton, HTMLStencilElement {}
@@ -510,6 +529,7 @@ declare global {
     'manifold-featured-service': HTMLManifoldFeaturedServiceElement
     'manifold-icon': HTMLManifoldIconElement
     'manifold-image-gallery': HTMLManifoldImageGalleryElement
+    'manifold-lazy-image': HTMLManifoldLazyImageElement
     'manifold-link-button': HTMLManifoldLinkButtonElement
     'manifold-marketplace-results': HTMLManifoldMarketplaceResultsElement
     'manifold-marketplace': HTMLManifoldMarketplaceElement
@@ -537,6 +557,7 @@ declare global {
     'manifold-featured-service': HTMLManifoldFeaturedServiceElement;
     'manifold-icon': HTMLManifoldIconElement;
     'manifold-image-gallery': HTMLManifoldImageGalleryElement;
+    'manifold-lazy-image': HTMLManifoldLazyImageElement;
     'manifold-link-button': HTMLManifoldLinkButtonElement;
     'manifold-marketplace-results': HTMLManifoldMarketplaceResultsElement;
     'manifold-marketplace': HTMLManifoldMarketplaceElement;

--- a/src/components/manifold-lazy-image/manifold-lazy-image.tsx
+++ b/src/components/manifold-lazy-image/manifold-lazy-image.tsx
@@ -1,0 +1,45 @@
+import { Component, Prop, State } from '@stencil/core';
+
+@Component({ tag: 'manifold-lazy-image' })
+export class ManifoldLazyImage {
+  @Prop() src: string;
+  @Prop() itemprop: string;
+  @Prop() alt: string;
+  @State() observer: IntersectionObserver;
+
+  componentWillLoad() {
+    this.observer = new IntersectionObserver(this.observe, {
+      rootMargin: '0px 0px 50px 0px',
+      threshold: 0,
+    });
+  }
+
+  private observe = (
+    entries: IntersectionObserverEntry[],
+    observer: IntersectionObserver
+  ): void => {
+    const entry = entries[0];
+    if (entry && entry.isIntersecting) {
+      const image = entry.target as HTMLImageElement;
+      const source = image.getAttribute('data-src');
+
+      if (source) {
+        image.src = source;
+      }
+
+      observer.unobserve(image);
+    }
+  };
+
+  private observeImage = (el?: HTMLElement) => {
+    if (el) {
+      this.observer.observe(el);
+    }
+  };
+
+  render() {
+    return (
+      <img data-src={this.src} alt={this.alt} itemprop={this.itemprop} ref={this.observeImage} />
+    );
+  }
+}

--- a/src/components/manifold-lazy-image/readme.md
+++ b/src/components/manifold-lazy-image/readme.md
@@ -1,0 +1,19 @@
+# manifold-lazy-image
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property   | Attribute  | Description | Type     | Default     |
+| ---------- | ---------- | ----------- | -------- | ----------- |
+| `alt`      | `alt`      |             | `string` | `undefined` |
+| `itemprop` | `itemprop` |             | `string` | `undefined` |
+| `src`      | `src`      |             | `string` | `undefined` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/manifold-service-card/manifold-service-card.tsx
+++ b/src/components/manifold-service-card/manifold-service-card.tsx
@@ -42,7 +42,7 @@ export class ManifoldServiceCard {
               <manifold-icon class="icon" icon={this.logo} />
             </div>
           ) : (
-            <img src={this.logo} alt={this.name} itemprop="image" />
+            <manifold-lazy-image src={this.logo} alt={this.name} itemprop="image" />
           )}
         </div>
         <h3 class="name" itemprop="name">


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

This is actually needed for www as described in https://github.com/manifoldco/engineering/issues/7683

I thought it would be prudent to add it here first for a couple of reasons:

1. It was easier for me to prove that the technique works
2. We'll eventually be using this in www anyway

It seems to be working great so we should be able to easily port this over to Fondant in the interim.

## Testing
<!-- For someone unfamiliar with the issue, how should this be tested? -->

Start at the top of the docs page and clear your network tab. As you scroll down and the discover interface shows up on the screen, you'll start seeing the network calls for the images get fired off. For me, the images display instantly, so it should be completely unnoticeable to the user that they are being lazy loaded.