### PR TITLE
Fix labeling and remove custom card for excluded categories

### DIFF
--- a/src/components/manifold-sorted-categories/manifold-sorted-categories.tsx
+++ b/src/components/manifold-sorted-categories/manifold-sorted-categories.tsx
@@ -2,7 +2,7 @@ import { Component, Prop } from '@stencil/core';
 
 import Tunnel, { State } from '../../data/marketplace';
 import { themeIcons } from '../../assets/icons';
-import { categories, formatCategoryLabel } from '../../utils/marketplace';
+import { categories, formatCategoryLabel, customCardExcludeList } from '../../utils/marketplace';
 
 @Component({ tag: 'manifold-sorted-categories' })
 export class ManifoldSortedCategories {
@@ -28,15 +28,17 @@ export class ManifoldSortedCategories {
                     featured={state.featured}
                     service-link={state.serviceLink}
                   >
-                    <manifold-service-card
-                      description={`Add your own ${formatCategoryLabel(tag)} service`}
-                      label={'bring-your-own'}
-                      logo={themeIcons[tag]}
-                      name={`Bring your own ${formatCategoryLabel(tag)} service`}
-                      is-custom={true}
-                      is-featured={false}
-                      slot="custom-card"
-                    />
+                    {!customCardExcludeList.includes(tag) && (
+                      <manifold-service-card
+                        description={`Add your own ${formatCategoryLabel(tag)} service`}
+                        label={'bring-your-own'}
+                        logo={themeIcons[tag]}
+                        name={`Bring your own ${formatCategoryLabel(tag)} service`}
+                        is-custom={true}
+                        is-featured={false}
+                        slot="custom-card"
+                      />
+                    )}
                   </manifold-marketplace-results>
                 </manifold-service-category>
               ))}

--- a/src/utils/marketplace.ts
+++ b/src/utils/marketplace.ts
@@ -9,9 +9,11 @@ export function formatCategoryLabel(tag: string): string {
     case 'ai-ml':
       return 'AI/ML';
     default:
-      return tag.replace('-', ' ');
+      return tag.replace(/-/g, ' ');
   }
 }
+
+export const customCardExcludeList = ['sell-your-service'];
 
 export function categories(services?: Catalog.Product[]): CategoryMap {
   const categoryMap: CategoryMap = {};


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

This PR accomplishes two things:

1. Fix the category labeling so it replaces all hyphens, not just the first
2. Remove the custom card from excluded categories, i.e. `sell-your-service`

## Testing

The provider dashboard category should now read 'Sell Your Service' and should no longer show a custom card.

![image](https://user-images.githubusercontent.com/374078/55802728-6f4a8c80-5a9e-11e9-8960-47673d6e6aab.png)
