### PR TITLE
[small PR] remove native number spinner on firefox

### DIFF
--- a/src/components/manifold-number-input/mf-number-input.css
+++ b/src/components/manifold-number-input/mf-number-input.css
@@ -12,6 +12,7 @@
   background: var(--mf-c-white);
   border: 1px solid var(--mf-c-border);
   border-radius: var(--mf-radius-default);
+  -moz-appearance: textfield; /* hides up/down buttons on firefox */
   appearance: none;
   font-variant-ligatures: none;
 

--- a/src/components/manifold-number-input/mf-number-input.css
+++ b/src/components/manifold-number-input/mf-number-input.css
@@ -6,6 +6,9 @@
 }
 
 .field {
+  box-sizing: border-box;
+  width: auto;
+  min-width: 4rem;
   padding: 0.5em 0.75em;
   font-size: 1em;
   text-align: center;
@@ -13,7 +16,6 @@
   border: 1px solid var(--mf-c-border);
   border-radius: var(--mf-radius-default);
   -moz-appearance: textfield; /* hides up/down buttons on firefox */
-  appearance: none;
   font-variant-ligatures: none;
 
   &::placeholder {


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

Removes native number arrows on number input for firefox.

## Testing
<!-- For someone unfamiliar with the issue, how should this be tested? -->
1. Go to custom plan selector in firefox.
2. Ensure number input field doesn't have the native up/down arrows on the right of the number field.