### PR TITLE
Bring up numpad on iOS Safari 12

### DIFF
--- a/src/components/manifold-number-input/manifold-number-input.tsx
+++ b/src/components/manifold-number-input/manifold-number-input.tsx
@@ -78,7 +78,6 @@ export class ManifoldNumberInput {
         <input
           class="field"
           type="number"
-          inputmode="numeric"
           max={this.max}
           min={this.min}
           pattern="[0-9]*"

--- a/src/components/manifold-number-input/mf-number-input.css
+++ b/src/components/manifold-number-input/mf-number-input.css
@@ -15,6 +15,7 @@
   background: var(--mf-c-white);
   border: 1px solid var(--mf-c-border);
   border-radius: var(--mf-radius-default);
+  -webkit-appearance: none;
   -moz-appearance: textfield; /* hides up/down buttons on firefox */
   font-variant-ligatures: none;
 


### PR DESCRIPTION
## Reason for change
On iOS Safari 12, specifying `inputmode="number"` strangely brings up the text field rather than the number pad. Supposedly this is the way forward, but current Safari hasn’t hopped aboard the standards train yet. This is an annoying fix but it was the only way I could bring up the number pad while keeping it `type="number"`.

## Testing
Bring up the site on iOS