### PR TITLE
Rename hide-provision-button to hide-cta

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -23,14 +23,14 @@ import {
 export namespace Components {
 
   interface ManifoldActivePlan {
-    'hideProvisionButton'?: boolean;
+    'hideCta'?: boolean;
     'isExistingResource'?: boolean;
     'linkFormat'?: string;
     'plans': Catalog.ExpandedPlan[];
     'product'?: Catalog.ExpandedProduct;
   }
   interface ManifoldActivePlanAttributes extends StencilHTMLAttributes {
-    'hideProvisionButton'?: boolean;
+    'hideCta'?: boolean;
     'isExistingResource'?: boolean;
     'linkFormat'?: string;
     'plans'?: Catalog.ExpandedPlan[];
@@ -277,14 +277,14 @@ export namespace Components {
   }
 
   interface ManifoldPlanDetails {
-    'hideProvisionButton': boolean;
+    'hideCta'?: boolean;
     'isExistingResource'?: boolean;
     'linkFormat'?: string;
     'plan'?: Catalog.ExpandedPlan;
     'product'?: Catalog.Product;
   }
   interface ManifoldPlanDetailsAttributes extends StencilHTMLAttributes {
-    'hideProvisionButton'?: boolean;
+    'hideCta'?: boolean;
     'isExistingResource'?: boolean;
     'linkFormat'?: string;
     'onManifold-planCTA-click'?: (event: CustomEvent) => void;
@@ -310,9 +310,9 @@ export namespace Components {
     */
     'connection': Connection;
     /**
-    * _(optional)_ Hide button?
+    * _(optional)_ Hide CTA?
     */
-    'hideProvisionButton'?: boolean;
+    'hideCta'?: boolean;
     /**
     * _(optional)_ Link format structure, with `:product`, `:plan`, and `:features` placeholders
     */
@@ -332,9 +332,9 @@ export namespace Components {
     */
     'connection'?: Connection;
     /**
-    * _(optional)_ Hide button?
+    * _(optional)_ Hide CTA?
     */
-    'hideProvisionButton'?: boolean;
+    'hideCta'?: boolean;
     /**
     * _(optional)_ Link format structure, with `:product`, `:plan`, and `:features` placeholders
     */

--- a/src/components/manifold-active-plan/manifold-active-plan.tsx
+++ b/src/components/manifold-active-plan/manifold-active-plan.tsx
@@ -10,7 +10,7 @@ export class ManifoldActivePlan {
   @Prop() linkFormat?: string;
   @Prop() product?: Catalog.ExpandedProduct;
   @Prop() plans: Catalog.ExpandedPlan[] = [];
-  @Prop() hideProvisionButton?: boolean;
+  @Prop() hideCta?: boolean;
   @State() selectedPlanId: string;
 
   componentWillLoad() {
@@ -32,7 +32,7 @@ export class ManifoldActivePlan {
       />,
       <div>
         <manifold-plan-details
-          hideProvisionButton={this.hideProvisionButton}
+          hideCta={this.hideCta}
           isExistingResource={this.isExistingResource}
           linkFormat={this.linkFormat}
           plan={this.plans.find(plan => plan.id === this.selectedPlanId)}

--- a/src/components/manifold-active-plan/readme.md
+++ b/src/components/manifold-active-plan/readme.md
@@ -7,13 +7,13 @@ Hello
 
 ## Properties
 
-| Property              | Attribute               | Description | Type                           | Default     |
-| --------------------- | ----------------------- | ----------- | ------------------------------ | ----------- |
-| `hideProvisionButton` | `hide-provision-button` |             | `boolean \| undefined`         | `undefined` |
-| `isExistingResource`  | `is-existing-resource`  |             | `boolean \| undefined`         | `undefined` |
-| `linkFormat`          | `link-format`           |             | `string \| undefined`          | `undefined` |
-| `plans`               | --                      |             | `ExpandedPlan[]`               | `[]`        |
-| `product`             | --                      |             | `ExpandedProduct \| undefined` | `undefined` |
+| Property             | Attribute              | Description | Type                           | Default     |
+| -------------------- | ---------------------- | ----------- | ------------------------------ | ----------- |
+| `hideCta`            | `hide-cta`             |             | `boolean \| undefined`         | `undefined` |
+| `isExistingResource` | `is-existing-resource` |             | `boolean \| undefined`         | `undefined` |
+| `linkFormat`         | `link-format`          |             | `string \| undefined`          | `undefined` |
+| `plans`              | --                     |             | `ExpandedPlan[]`               | `[]`        |
+| `product`            | --                     |             | `ExpandedProduct \| undefined` | `undefined` |
 
 
 ----------------------------------------------

--- a/src/components/manifold-plan-details/manifold-plan-details.e2e.ts
+++ b/src/components/manifold-plan-details/manifold-plan-details.e2e.ts
@@ -169,7 +169,7 @@ describe(`<manifold-plan-details>`, () => {
       expect(toggle).not.toBeNull();
     });
 
-    it('provision button is shown by default', async () => {
+    it('cta is shown by default', async () => {
       const page = await newE2EPage({ html: `<manifold-plan-details />` });
 
       const props = { plan: booleanPlanCustom, product: Product };
@@ -188,7 +188,7 @@ describe(`<manifold-plan-details>`, () => {
       expect(button).toBeDefined();
     });
 
-    it('provision button hides with prop', async () => {
+    it('cta button hides with prop', async () => {
       const page = await newE2EPage({
         html: `<manifold-plan-details />`,
       });
@@ -199,7 +199,7 @@ describe(`<manifold-plan-details>`, () => {
         (elm: any, { plan, product }: any) => {
           elm.plan = plan;
           elm.product = product;
-          elm.hideProvisionButton = true;
+          elm.hideCta = true;
         },
         props
       );

--- a/src/components/manifold-plan-details/manifold-plan-details.tsx
+++ b/src/components/manifold-plan-details/manifold-plan-details.tsx
@@ -14,7 +14,7 @@ export class ManifoldPlanDetails {
   @Prop() plan?: Catalog.ExpandedPlan;
   @Prop() linkFormat?: string;
   @Prop() product?: Catalog.Product;
-  @Prop() hideProvisionButton: boolean = false;
+  @Prop() hideCta?: boolean = false;
   @State() features: UserFeatures = {};
   @Event({
     eventName: 'manifold-planUpdated',
@@ -127,7 +127,7 @@ export class ManifoldPlanDetails {
           allFeatures={expanded_features}
           selectedFeatures={this.features}
         />
-        {!this.hideProvisionButton && (
+        {this.hideCta !== true && (
           <manifold-link-button
             onClick={this.onClick}
             href={this.ctaLink}

--- a/src/components/manifold-plan-details/readme.md
+++ b/src/components/manifold-plan-details/readme.md
@@ -7,13 +7,13 @@
 
 ## Properties
 
-| Property              | Attribute               | Description | Type                        | Default     |
-| --------------------- | ----------------------- | ----------- | --------------------------- | ----------- |
-| `hideProvisionButton` | `hide-provision-button` |             | `boolean`                   | `false`     |
-| `isExistingResource`  | `is-existing-resource`  |             | `boolean \| undefined`      | `undefined` |
-| `linkFormat`          | `link-format`           |             | `string \| undefined`       | `undefined` |
-| `plan`                | --                      |             | `ExpandedPlan \| undefined` | `undefined` |
-| `product`             | --                      |             | `Product \| undefined`      | `undefined` |
+| Property             | Attribute              | Description | Type                        | Default     |
+| -------------------- | ---------------------- | ----------- | --------------------------- | ----------- |
+| `hideCta`            | `hide-cta`             |             | `boolean \| undefined`      | `false`     |
+| `isExistingResource` | `is-existing-resource` |             | `boolean \| undefined`      | `undefined` |
+| `linkFormat`         | `link-format`          |             | `string \| undefined`       | `undefined` |
+| `plan`               | --                     |             | `ExpandedPlan \| undefined` | `undefined` |
+| `product`            | --                     |             | `Product \| undefined`      | `undefined` |
 
 
 ## Events

--- a/src/components/manifold-plan-selector/manifold-plan-selector.tsx
+++ b/src/components/manifold-plan-selector/manifold-plan-selector.tsx
@@ -12,8 +12,8 @@ export class ManifoldPlanSelector {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() connection: Connection = connections[Env.Prod];
-  /** _(optional)_ Hide button? */
-  @Prop() hideProvisionButton?: boolean;
+  /** _(optional)_ Hide CTA? */
+  @Prop() hideCta?: boolean;
   /** _(optional)_ Link format structure, with `:product`, `:plan`, and `:features` placeholders */
   @Prop() linkFormat?: string;
   /** URL-friendly slug (e.g. `"jawsdb-mysql"`) */
@@ -41,7 +41,7 @@ export class ManifoldPlanSelector {
     if (!this.product || !this.plans) return null;
     return (
       <manifold-active-plan
-        hideProvisionButton={this.hideProvisionButton}
+        hideCta={this.hideCta}
         isExistingResource={!!this.resourceId}
         linkFormat={this.linkFormat}
         plans={this.plans}

--- a/src/components/manifold-plan-selector/readme.md
+++ b/src/components/manifold-plan-selector/readme.md
@@ -55,10 +55,10 @@ To turn the CTA into an `<a>` tag, specify a `link-format` attribute, using
 
 ### Hiding provision button
 
-If you would like to hide the CTA altogether, specify `hide-provision-button`:
+If you would like to hide the CTA altogether, specify `hide-cta`:
 
 ```html
-<manifold-product product-label="till" hide-provision-button />
+<manifold-product product-label="till" hide-cta />
 ```
 
 <!-- Auto Generated Below -->
@@ -66,13 +66,13 @@ If you would like to hide the CTA altogether, specify `hide-provision-button`:
 
 ## Properties
 
-| Property              | Attribute               | Description                                                                                | Type                   | Default                 |
-| --------------------- | ----------------------- | ------------------------------------------------------------------------------------------ | ---------------------- | ----------------------- |
-| `connection`          | --                      | _(hidden)_ Passed by `<manifold-connection>`                                               | `Connection`           | `connections[Env.Prod]` |
-| `hideProvisionButton` | `hide-provision-button` | _(optional)_ Hide button?                                                                  | `boolean \| undefined` | `undefined`             |
-| `linkFormat`          | `link-format`           | _(optional)_ Link format structure, with `:product`, `:plan`, and `:features` placeholders | `string \| undefined`  | `undefined`             |
-| `productLabel`        | `product-label`         | URL-friendly slug (e.g. `"jawsdb-mysql"`)                                                  | `string`               | `undefined`             |
-| `resourceId`          | `resource-id`           | _(optional)_ Is this modifying an existing resource?                                       | `string \| undefined`  | `undefined`             |
+| Property       | Attribute       | Description                                                                                | Type                   | Default                 |
+| -------------- | --------------- | ------------------------------------------------------------------------------------------ | ---------------------- | ----------------------- |
+| `connection`   | --              | _(hidden)_ Passed by `<manifold-connection>`                                               | `Connection`           | `connections[Env.Prod]` |
+| `hideCta`      | `hide-cta`      | _(optional)_ Hide CTA?                                                                     | `boolean \| undefined` | `undefined`             |
+| `linkFormat`   | `link-format`   | _(optional)_ Link format structure, with `:product`, `:plan`, and `:features` placeholders | `string \| undefined`  | `undefined`             |
+| `productLabel` | `product-label` | URL-friendly slug (e.g. `"jawsdb-mysql"`)                                                  | `string`               | `undefined`             |
+| `resourceId`   | `resource-id`   | _(optional)_ Is this modifying an existing resource?                                       | `string \| undefined`  | `undefined`             |
 
 
 ----------------------------------------------

--- a/src/index.html
+++ b/src/index.html
@@ -465,11 +465,8 @@ render() {
 &lt;!-- &lt;a href="/product/aiven-redis?plan=startup-4&amp;cpus=1"&gt; --&gt;
 </code></pre>
               <h3 id="hidingprovisionbutton">Hiding provision button</h3>
-              <p>
-                If you would like to hide the CTA altogether, specify
-                <code>hide-provision-button</code>:
-              </p>
-              <pre><code class="html language-html">&lt;manifold-product product-label="till" hide-provision-button /&gt;
+              <p>If you would like to hide the CTA altogether, specify <code>hide-cta</code>:</p>
+              <pre><code class="html language-html">&lt;manifold-product product-label="till" hide-cta /&gt;
 </code></pre>
               <!-- Auto Generated Below -->
               <h2 id="properties">Properties</h2>


### PR DESCRIPTION
## Reason for change
Renames `hide-provision-button` to `hide-cta`. `hide-cta` is shorter, technically more accurate (button doesn’t always provision), and is more reusable across components. But still maintains clarity and doesn’t conflict with core HTML attributes.

## Testing
I accidentally messed up the boolean, and confirmed the test was working 😬. Yay tests! Anyway the test does catch if this attribute works or not.
