### PR TITLE
Add JSON parsing concept

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -196,12 +196,12 @@ export namespace Components {
   }
 
   interface ManifoldMarketplaceResults {
-    'featured'?: string;
+    'featured': string[];
     'linkFormat'?: string;
     'services': Catalog.Product[];
   }
   interface ManifoldMarketplaceResultsAttributes extends StencilHTMLAttributes {
-    'featured'?: string;
+    'featured'?: string[];
     'linkFormat'?: string;
     'services'?: Catalog.Product[];
   }
@@ -454,12 +454,12 @@ export namespace Components {
   interface ManifoldServiceGridAttributes extends StencilHTMLAttributes {}
 
   interface ManifoldServicesTunnel {
-    'featured'?: string;
+    'featured': string[];
     'linkFormat'?: string;
     'services': Catalog.Product[];
   }
   interface ManifoldServicesTunnelAttributes extends StencilHTMLAttributes {
-    'featured'?: string;
+    'featured'?: string[];
     'linkFormat'?: string;
     'services'?: Catalog.Product[];
   }

--- a/src/components/manifold-marketplace-results/manifold-marketplace-results.tsx
+++ b/src/components/manifold-marketplace-results/manifold-marketplace-results.tsx
@@ -2,7 +2,7 @@ import { Component, Prop } from '@stencil/core';
 
 @Component({ tag: 'manifold-marketplace-results', styleUrl: 'marketplace-results.css' })
 export class ManifoldMarketplace {
-  @Prop() featured?: string;
+  @Prop() featured: string[] = [];
   @Prop() linkFormat?: string;
   @Prop() services: Catalog.Product[] = [];
 
@@ -13,9 +13,7 @@ export class ManifoldMarketplace {
   }
 
   private isFeatured(label: string) {
-    if (typeof this.featured !== 'string') return false;
-    const parsedFeatures = this.featured.split(',').map(featureList => featureList.trim());
-    return parsedFeatures.includes(label);
+    return this.featured.map(product => product.toLowerCase()).includes(label);
   }
 
   render() {

--- a/src/components/manifold-marketplace-results/readme.md
+++ b/src/components/manifold-marketplace-results/readme.md
@@ -9,7 +9,7 @@
 
 | Property     | Attribute     | Description | Type                  | Default     |
 | ------------ | ------------- | ----------- | --------------------- | ----------- |
-| `featured`   | `featured`    |             | `string \| undefined` | `undefined` |
+| `featured`   | --            |             | `string[]`            | `[]`        |
 | `linkFormat` | `link-format` |             | `string \| undefined` | `undefined` |
 | `services`   | --            |             | `Product[]`           | `[]`        |
 

--- a/src/components/manifold-marketplace/manifold-marketplace.tsx
+++ b/src/components/manifold-marketplace/manifold-marketplace.tsx
@@ -1,8 +1,9 @@
-import { Component, Prop, State, Element } from '@stencil/core';
+import { Component, Prop, State, Element, Watch } from '@stencil/core';
 
 import Tunnel from '../../data/connection';
 import { withAuth } from '../../utils/auth';
 import { Connection, connections, Env } from '../../utils/connections';
+import { toJSON } from '../../utils/json';
 
 @Component({ tag: 'manifold-marketplace' })
 export class ManifoldMarketplace {
@@ -14,8 +15,14 @@ export class ManifoldMarketplace {
   /** _(optional)_ Comma-separated list of featured products (labels) */
   @Prop() featured?: string;
   @State() services: Catalog.Product[] = [];
+  @State() parsedFeatured: string[] = [];
+  @Watch('featured') parseFeatures(newFeatures: string) {
+    if (newFeatures) this.parsedFeatured = toJSON(newFeatures);
+  }
 
   componentWillLoad() {
+    if (this.featured) this.parseFeatures(this.featured)
+
     return fetch(`${this.connection.catalog}/products`, withAuth())
       .then(response => response.json())
       .then(data => {
@@ -28,7 +35,7 @@ export class ManifoldMarketplace {
       <manifold-services-tunnel
         services={this.services}
         linkFormat={this.linkFormat}
-        featured={this.featured}
+        featured={this.parsedFeatured}
       >
         <manifold-service-grid slot="marketplace-content" />
       </manifold-services-tunnel>

--- a/src/components/manifold-marketplace/readme.md
+++ b/src/components/manifold-marketplace/readme.md
@@ -45,6 +45,14 @@ render() {
 }
 ```
 
+## Featured
+
+You can add a “featured” tag to services by specifying URL slugs in JSON format:
+
+```html
+<manifold-marketplace featured="['iron_cache', 'iron_mq', 'iron_worker']" />
+```
+
 <!-- Auto Generated Below -->
 
 

--- a/src/components/manifold-services-tunnel/manifold-services-tunnel.tsx
+++ b/src/components/manifold-services-tunnel/manifold-services-tunnel.tsx
@@ -5,7 +5,7 @@ import Tunnel from '../../data/marketplace';
 @Component({ tag: 'manifold-services-tunnel' })
 export class ManiTunnel {
   @Prop() linkFormat?: string;
-  @Prop() featured?: string;
+  @Prop() featured: string[] = [];
   @Prop() services: Catalog.Product[] = [];
 
   render() {

--- a/src/components/manifold-services-tunnel/readme.md
+++ b/src/components/manifold-services-tunnel/readme.md
@@ -9,7 +9,7 @@
 
 | Property     | Attribute     | Description | Type                  | Default     |
 | ------------ | ------------- | ----------- | --------------------- | ----------- |
-| `featured`   | `featured`    |             | `string \| undefined` | `undefined` |
+| `featured`   | --            |             | `string[]`            | `[]`        |
 | `linkFormat` | `link-format` |             | `string \| undefined` | `undefined` |
 | `services`   | --            |             | `Product[]`           | `[]`        |
 

--- a/src/data/marketplace.tsx
+++ b/src/data/marketplace.tsx
@@ -3,14 +3,14 @@ import { createProviderConsumer } from '@stencil/state-tunnel';
 export interface State {
   services: Catalog.Product[];
   linkFormat?: string;
-  featured?: string;
+  featured: string[];
 }
 
 export default createProviderConsumer<State>(
   {
     services: [],
     linkFormat: undefined,
-    featured: undefined,
+    featured: [],
   },
   (subscribe, child) => <context-consumer subscribe={subscribe} renderer={child} />
 );

--- a/src/index.html
+++ b/src/index.html
@@ -278,6 +278,12 @@ render() {
   return &lt;manifold-marketplace ref={this.marketplaceLoaded} /&gt;;
 }
 </code></pre>
+              <h2 id="featured">Featured</h2>
+              <p>
+                You can add a “featured” tag to services by specifying URL slugs in JSON format:
+              </p>
+              <pre><code class="html language-html">&lt;manifold-marketplace featured="['iron_cache', 'iron_mq', 'iron_worker']" /&gt;
+</code></pre>
               <!-- Auto Generated Below -->
               <h2 id="properties">Properties</h2>
               <table>
@@ -323,7 +329,7 @@ render() {
             <h2>Example</h2>
             <div class="docs-example">
               <div class="docs-example-inner">
-                <manifold-marketplace featured="piio,zerosix" />
+                <manifold-marketplace featured="['piio','zerosix']" />
               </div>
             </div>
           </section>
@@ -489,9 +495,9 @@ render() {
                     <td><code>connections[Env.Prod]</code></td>
                   </tr>
                   <tr>
-                    <td><code>hideProvisionButton</code></td>
-                    <td><code>hide-provision-button</code></td>
-                    <td><em>(optional)</em> Hide button?</td>
+                    <td><code>hideCta</code></td>
+                    <td><code>hide-cta</code></td>
+                    <td><em>(optional)</em> Hide CTA?</td>
                     <td><code>boolean | undefined</code></td>
                     <td><code>undefined</code></td>
                   </tr>

--- a/src/utils/json.spec.ts
+++ b/src/utils/json.spec.ts
@@ -1,0 +1,7 @@
+import { toJSON } from './json';
+
+describe('toJSON method', () => {
+  it('converts single-quoted strings to double-quoted', () => {
+    expect(toJSON("['one', 'two']")).toEqual(['one', 'two']);
+  });
+});

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,0 +1,13 @@
+/**
+ * Make JSON parsing safer and easier
+ */
+export function toJSON(input: string) {
+  const sanitized = input.replace(/'/g, '"');
+  let result;
+  try {
+    result = JSON.parse(sanitized);
+  } finally {
+    console.warn(`Unable to parse as JSON: ${input}`);
+  }
+  return result;
+}


### PR DESCRIPTION
## Reason for change
While browsing the [JS Integration docs](https://stenciljs.com/docs/javascript) for Stencil, this line caught my eye:

```html
<todo-list my-object="{}" my-array="[]"></todo-list>
```

“Oh! Stencil can just parse attributes as JSON! Neat”

Well, there’s a reason why that object & array is empty—in order for it to work, you have to do gross things like this: `my-array="[&quot;itemOne&quot;,&quot;itemTwo&quot;]"`. Hooray! 🙃

Still, Vue.js does support JSON attributes (as long as the attribute name is prefixed with `:`), and I like the idea. This is a stab at implementing that concept in Stencil (especially since the docs seem to hint that it’s easy).

An alternate method is to use a parser like [JSON5](https://github.com/json5/json5), but that’s ~`30 KB` of weight.

### Sidenote:

We should probably make more liberal use of `@Watch`, at least for the entry components. Our components are not good at listening to changes after initialization, and that would really improve support.