### PR TITLE
Propose event standard

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
+__mocks__
 dist/
 www/
 

--- a/__mocks__/@stencil/state-tunnel/index.ts
+++ b/__mocks__/@stencil/state-tunnel/index.ts
@@ -1,0 +1,85 @@
+import { FunctionalComponent, HTMLStencilElement } from '@stencil/core';
+import { SubscribeCallback, ConsumerRenderer, PropList } from '../declarations';
+
+export const createProviderConsumer = <T extends { [key: string]: any }>(
+  defaultState: T,
+  consumerRender: ConsumerRenderer<T>
+) => {
+  let listeners: Map<HTMLStencilElement, PropList<T>> = new Map();
+  let currentState: T = defaultState;
+
+  const updateListener = (fields: PropList<T>, listener: HTMLStencilElement) => {
+    if (Array.isArray(fields)) {
+      [...fields].forEach(fieldName => {
+        (listener as any)[fieldName] = currentState[fieldName];
+      });
+    } else {
+      (listener as any)[fields] = {
+        ...(currentState as object),
+      } as T;
+    }
+    listener.forceUpdate();
+  };
+
+  const subscribe: SubscribeCallback<T> = (el: HTMLStencilElement, propList: PropList<T>) => {
+    if (listeners.has(el)) {
+      return () => {};
+    }
+    listeners.set(el, propList);
+    updateListener(propList, el);
+
+    return () => {
+      listeners.delete(el);
+    };
+  };
+
+  const Provider: FunctionalComponent<{ state: T }> = ({ state }, children) => {
+    currentState = state;
+    listeners.forEach(updateListener);
+    return children;
+  };
+
+  const Consumer: FunctionalComponent<{}> = (props, children) => {
+    // The casting on subscribe is to allow for crossover through the stencil compiler
+    // In the future we should allow for generics in components.
+    return consumerRender(subscribe, children[0] as any);
+  };
+
+  const injectProps = (childComponent: any, fieldList: PropList<T>) => {
+    let unsubscribe: any = null;
+
+    const elementRefName = Object.keys(childComponent.properties).find(propName => {
+      return childComponent.properties[propName].elementRef == true;
+    });
+    if (elementRefName == undefined) {
+      throw new Error(
+        `Please ensure that your Component ${
+          childComponent.is
+        } has an attribute with an "@Element" decorator. ` +
+          `This is required to be able to inject properties.`
+      );
+    }
+
+    const prevComponentWillLoad = childComponent.prototype.componentWillLoad;
+    childComponent.prototype.componentWillLoad = function() {
+      unsubscribe = subscribe(this[elementRefName], fieldList);
+      if (prevComponentWillLoad) {
+        return prevComponentWillLoad.bind(this)();
+      }
+    };
+
+    const prevComponentDidUnload = childComponent.prototype.componentDidUnload;
+    childComponent.prototype.componentDidUnload = function() {
+      unsubscribe();
+      if (prevComponentDidUnload) {
+        return prevComponentDidUnload.bind(this)();
+      }
+    };
+  };
+
+  return {
+    Provider,
+    Consumer,
+    injectProps,
+  };
+};

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -323,8 +323,9 @@ export namespace Components {
     'hideCta'?: boolean;
     'isExistingResource'?: boolean;
     'linkFormat'?: string;
-    'onManifold-planCTA-click'?: (event: CustomEvent) => void;
-    'onManifold-planUpdated'?: (event: CustomEvent) => void;
+    'onManifold-planSelector-change'?: (event: CustomEvent) => void;
+    'onManifold-planSelector-click'?: (event: CustomEvent) => void;
+    'onManifold-planSelector-load'?: (event: CustomEvent) => void;
     'plan'?: Catalog.ExpandedPlan;
     'product'?: Catalog.Product;
   }
@@ -475,7 +476,7 @@ export namespace Components {
     'linkFormat'?: string;
     'logo'?: string;
     'name'?: string;
-    'onManifold-serviceCard-click'?: (event: CustomEvent) => void;
+    'onManifold-marketplace-click'?: (event: CustomEvent) => void;
     'productId'?: string;
   }
 
@@ -486,7 +487,7 @@ export namespace Components {
   interface ManifoldTemplateCardAttributes extends StencilHTMLAttributes {
     'category'?: string;
     'linkFormat'?: string;
-    'onManifold-templateCard-click'?: (event: CustomEvent) => void;
+    'onManifold-template-click'?: (event: CustomEvent) => void;
   }
 
   interface ManifoldToast {

--- a/src/components/manifold-marketplace/readme.md
+++ b/src/components/manifold-marketplace/readme.md
@@ -60,47 +60,38 @@ comma-separated list:
 <manifold-marketplace featured="piio,zerosix" />
 ```
 
-## Navigation
+## Events
 
-When users click on a product card, you expect something to happen, right? By
-default, service cards will emit a `manifold-serviceCard-click` custom event
-whenever a user clicks anywhere on a card. You can listen for it like so,
-and use this value to navigate client-side or perform some other action of
-your choice:
+This component emits [custom
+events](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent)
+when it updates. To listen to those events, add an event listener either on
+the component itself, or `document`.
 
 ```js
-document.addEventListener('manifold-serviceCard-click', { detail: { label } } => {
-  alert(`You clicked the card for ${label}`);
+document.addEventListener('manifold-marketplace-click', { detail: { productLabel } } => {
+  alert(`You clicked the card for ${productLabel}`);
 });
 ```
 
-Alternately, if you’d like the service cards to be plain, ol’ `<a>` tags, you
-can specify a `link-format` attribute, where `:product` will be substituted
-with each product’s URL-friendly slug:
+The following events are emitted:
+
+| Event Name                   | Description                                             | Data                        |
+| :--------------------------- | :------------------------------------------------------ | :-------------------------- |
+| `manifold-marketplace-click` | Fires whenever a user has clicked on a product.         | `productId`, `productLabel` |
+| `manifold-template-click`    | Fires whenever a user has clicked on a custom template. | `category`                  |
+
+## Navigation
+
+By default, service cards will only emit the `manifold-marketplace-click`
+event (above). But it can also be turned into an `<a>` tag by specifying
+`link-format`:
 
 ```html
 <manifold-marketplace link-format="/product/:product" />
 <!-- <a href="/product/jawsdb-mysql"> -->
 ```
 
-Note that template cards also emit an event as well:
-`manifold-templateCard-click`.
-
-#### Handling Events in React
-
-Attaching listeners to custom components in React [requires the use of refs](https://custom-elements-everywhere.com/). Example:
-
-```js
-marketplaceLoaded(node) {
-  node.addEventListener("manifold-serviceCard-click", ({ detail: { label } }) => {
-    alert(`You clicked the card for ${label}`);
-  });
-}
-
-render() {
-  return <manifold-marketplace ref={this.marketplaceLoaded} />;
-}
-```
+`:product` will be replaced with the url-friendly slug for the product.
 
 <!-- Auto Generated Below -->
 

--- a/src/components/manifold-plan-details/manifold-plan-details.spec.ts
+++ b/src/components/manifold-plan-details/manifold-plan-details.spec.ts
@@ -24,20 +24,60 @@ describe(`<manifold-plan-details>`, () => {
     });
   });
 
-  it('dispatches update event when loaded', () => {
+  it('dispatches load event', () => {
     const planDetails = new PlanDetails();
     planDetails.plan = ExpandedPlanCustom;
     planDetails.product = Product;
 
     const mock = { emit: jest.fn() };
-    planDetails.planUpdated = mock;
+    planDetails.planLoad = mock;
 
     planDetails.componentWillLoad();
     expect(mock.emit).toHaveBeenCalledWith({
       features: { instance_class: 'db.t2.micro', redundancy: false, storage: 5 },
-      id: '235exy25wvzpxj52p87bh87gbnj4y',
-      label: 'custom',
-      product: 'jawsdb-mysql',
+      planId: '235exy25wvzpxj52p87bh87gbnj4y',
+      planLabel: 'custom',
+      productLabel: 'jawsdb-mysql',
+    });
+  });
+
+  it('dispatches update event', () => {
+    const planDetails = new PlanDetails();
+    planDetails.plan = ExpandedPlanCustom;
+    planDetails.product = Product;
+    planDetails.planLoad = { emit: jest.fn() };
+    planDetails.componentWillLoad(); // Set initial features
+
+    const mock = { emit: jest.fn() };
+    planDetails.planUpdate = mock;
+
+    // Set redundancy: true
+    const e = new CustomEvent('', { detail: { name: 'redundancy', value: true } });
+    planDetails.handleChangeValue(e);
+    expect(mock.emit).toHaveBeenCalledWith({
+      features: { redundancy: true, instance_class: 'db.t2.micro', storage: 5 },
+      planId: '235exy25wvzpxj52p87bh87gbnj4y',
+      planLabel: 'custom',
+      productLabel: 'jawsdb-mysql',
+    });
+  });
+
+  it('dispatches click event', () => {
+    const planDetails = new PlanDetails();
+    planDetails.plan = ExpandedPlanCustom;
+    planDetails.product = Product;
+    planDetails.planLoad = { emit: jest.fn() };
+    planDetails.componentWillLoad(); // Set initial features
+
+    const mock = { emit: jest.fn() };
+    planDetails.planClick = mock;
+
+    planDetails.onClick(new Event('click'));
+    expect(mock.emit).toHaveBeenCalledWith({
+      features: { instance_class: 'db.t2.micro', redundancy: false, storage: 5 },
+      planId: '235exy25wvzpxj52p87bh87gbnj4y',
+      planLabel: 'custom',
+      productLabel: 'jawsdb-mysql',
     });
   });
 });

--- a/src/components/manifold-plan-details/manifold-plan-details.tsx
+++ b/src/components/manifold-plan-details/manifold-plan-details.tsx
@@ -42,7 +42,7 @@ export class ManifoldPlanDetails {
     const features = this.initialFeatures();
     this.features = features; // Set default features the first time
     if (this.plan && this.product) {
-      // Drew: not sure how to tell Stencil that these should always be here on load
+      // This conditional should always fire on component load
       const detail: EventDetail = {
         planId: this.plan.id,
         planLabel: this.plan.body.label,
@@ -57,7 +57,7 @@ export class ManifoldPlanDetails {
     const features = { ...this.features, [name]: value };
     this.features = features; // User-selected features
     if (this.plan && this.product) {
-      // Same as above: parent prevents loading this component till these are set
+      // Same as above: this should always fire; just needed for TS
       const detail: EventDetail = {
         planId: this.plan.id,
         planLabel: this.plan.body.label,

--- a/src/components/manifold-plan-details/readme.md
+++ b/src/components/manifold-plan-details/readme.md
@@ -18,10 +18,11 @@
 
 ## Events
 
-| Event                    | Description | Type                |
-| ------------------------ | ----------- | ------------------- |
-| `manifold-planCTA-click` |             | `CustomEvent<void>` |
-| `manifold-planUpdated`   |             | `CustomEvent<void>` |
+| Event                          | Description | Type                |
+| ------------------------------ | ----------- | ------------------- |
+| `manifold-planSelector-change` |             | `CustomEvent<void>` |
+| `manifold-planSelector-click`  |             | `CustomEvent<void>` |
+| `manifold-planSelector-load`   |             | `CustomEvent<void>` |
 
 
 ----------------------------------------------

--- a/src/components/manifold-plan-selector/readme.md
+++ b/src/components/manifold-plan-selector/readme.md
@@ -6,44 +6,36 @@ Display the plans for a product.
 <manifold-plan-selector product-label="jawsdb-mysql" />
 ```
 
-## Product Label
+You can find the `:product` label for each at
+`https://manifold.co/services/:product`.
 
-You can find the `:product` label for each at `https://manifold.co/services/:product`.
+## Events
 
-## Detecting changes
-
-Events are dispatched on the `manifold-planUpdated` custom event. To listen
-for that, listen for the event on `document` like so:
+This component emits [custom
+events](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent)
+when it updates. To listen to those events, add an event listener either on
+the component itself, or `document`.
 
 ```js
-document.addEventListener('manifold-planUpdated', ({ detail }) => {
+document.addEventListener('manifold-planSelector-change', ({ detail }) => {
   console.log(detail);
 });
-// { id: "2357v8j36f5h866c32ddwwjxvfe8j", label: "nvidia-1080ti-100gb-ssd", product: "zerosix", features: { … } } }
+// { planId: "2357v8j36f5h866c32ddwwjxvfe8j", planLabel: "nvidia-1080ti-100gb-ssd", productLabel: "zerosix", features: { … } } }
 ```
+
+The following events are emitted:
+
+| Event Name                     | Description                                                                                                                | Data                                              |
+| :----------------------------- | :------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------ |
+| `manifold-planSelector-change` | Fires whenever a user makes a change.                                                                                      | `planID`, `planLabel`, `productLabel`, `features` |
+| `manifold-planSelector-load`   | Identical to `-update` above, but this fires once on DOM mount to set the initial state (i.e. user hasn’t interacted yet). | `planID`, `planLabel`, `productLabel`, `features` |
+| `manifold-planSelector-click`  | If the CTA is showing (see `hide-cta` below), this will fire when clicked.                                                 | `planID`, `planLabel`, `productLabel`, `features` |
 
 ## Navigation
 
-The large CTA in the bottom-right
-is configurable. By default, this component emits a
-`manifold-planCTA-click` custom event whenever the main CTA is clicked.
-Listen for it like so:
-
-```js
-document.addEventListener(
-  'manifold-productCTA-click',
-  ({ detail: { product, plan, features } }) => {
-    alert(
-      `You clicked the CTA for the ${plan} plan on ${product} with these features: ${JSON.stringify(
-        features
-      )}`
-    );
-  }
-);
-```
-
-To turn the CTA into an `<a>` tag, specify a `link-format` attribute, using
-`:product`, `:plan`, and `:features` as placeholders:
+By default, the CTA bottom-right will fire the `manifold-planSelector-click`
+event (above). But it can also be turned into an `<a>` tag by specifying
+`link-format`:
 
 ```html
 <manifold-product
@@ -53,7 +45,11 @@ To turn the CTA into an `<a>` tag, specify a `link-format` attribute, using
 <!-- <a href="/product/aiven-redis?plan=startup-4&cpus=1"> -->
 ```
 
-### Hiding provision button
+`:plan`, `:product`, and `:features` (for customizable plans) will all be
+replaced with url-friendly slugs for each. In most cases, these are all
+passable to [**data components**](#data-components).
+
+### Hiding CTA
 
 If you would like to hide the CTA altogether, specify `hide-cta`:
 

--- a/src/components/manifold-service-card/ manifold-service-card.spec.ts
+++ b/src/components/manifold-service-card/ manifold-service-card.spec.ts
@@ -1,0 +1,20 @@
+import { ManifoldServiceCard } from './manifold-service-card';
+import { Product } from '../../spec/mock/catalog';
+
+it('dispatches click event', () => {
+  const serviceCard = new ManifoldServiceCard();
+  serviceCard.label = Product.body.label;
+  serviceCard.productId = Product.id;
+  serviceCard.logo = Product.body.logo_url;
+  serviceCard.name = Product.body.name;
+  serviceCard.description = Product.body.tagline;
+
+  const mock = { emit: jest.fn() };
+  serviceCard.marketplaceClick = mock;
+
+  serviceCard.onClick(new Event('click'));
+  expect(mock.emit).toHaveBeenCalledWith({
+    productId: Product.id,
+    productLabel: Product.body.label,
+  });
+});

--- a/src/components/manifold-service-card/manifold-service-card.tsx
+++ b/src/components/manifold-service-card/manifold-service-card.tsx
@@ -4,6 +4,11 @@ import Tunnel from '../../data/connection';
 import { withAuth } from '../../utils/auth';
 import { Connection, connections } from '../../utils/connections';
 
+interface EventDetail {
+  productId?: string;
+  productLabel?: string;
+}
+
 @Component({
   tag: 'manifold-service-card',
   styleUrl: 'manifold-service-card.css',
@@ -11,11 +16,6 @@ import { Connection, connections } from '../../utils/connections';
 })
 export class ManifoldServiceCard {
   @Element() el: HTMLElement;
-  @Event({
-    eventName: 'manifold-serviceCard-click',
-    bubbles: true,
-  })
-  cardClicked: EventEmitter;
   @Prop() name?: string;
   @Prop() connection: Connection = connections.prod;
   @Prop() description?: string;
@@ -25,7 +25,9 @@ export class ManifoldServiceCard {
   @Prop() productId?: string;
   @Prop() linkFormat?: string;
   @State() isFree: boolean = false;
-  @Watch('productId') watchHandler(newProductId: string) {
+  @Event({ eventName: 'manifold-marketplace-click', bubbles: true }) marketplaceClick: EventEmitter;
+  @Watch('productId')
+  watchHandler(newProductId: string) {
     this.fetchIsFree(newProductId);
   }
 
@@ -53,7 +55,11 @@ export class ManifoldServiceCard {
   onClick = (e: Event): void => {
     if (!this.linkFormat) {
       e.preventDefault();
-      this.cardClicked.emit({ label: this.label });
+      const detail: EventDetail = {
+        productId: this.productId,
+        productLabel: this.label,
+      };
+      this.marketplaceClick.emit(detail);
     }
   };
 

--- a/src/components/manifold-service-card/readme.md
+++ b/src/components/manifold-service-card/readme.md
@@ -23,7 +23,7 @@ Clickable service cards.
 
 | Event                        | Description | Type                |
 | ---------------------------- | ----------- | ------------------- |
-| `manifold-serviceCard-click` |             | `CustomEvent<void>` |
+| `manifold-marketplace-click` |             | `CustomEvent<void>` |
 
 
 ----------------------------------------------

--- a/src/components/manifold-template-card.tsx/manifold-template-card.tsx
+++ b/src/components/manifold-template-card.tsx/manifold-template-card.tsx
@@ -2,17 +2,17 @@ import { Component, Prop, Event, EventEmitter } from '@stencil/core';
 import { categoryIcon } from '../../utils/marketplace';
 import serviceTemplates from '../../data/templates';
 
+interface EventDetail {
+  category: string;
+}
+
 @Component({
   tag: 'manifold-template-card',
   styleUrl: 'manifold-template-card.css',
   shadow: true,
 })
 export class ManifoldTemplateCard {
-  @Event({
-    eventName: 'manifold-templateCard-click',
-    bubbles: true,
-  })
-  cardClicked: EventEmitter;
+  @Event({ eventName: 'manifold-template-click', bubbles: true }) templateClick: EventEmitter;
   @Prop() category: string;
   @Prop() linkFormat?: string;
 
@@ -24,7 +24,8 @@ export class ManifoldTemplateCard {
   onClick = (e: Event): void => {
     if (!this.linkFormat) {
       e.preventDefault();
-      this.cardClicked.emit({ label: this.category });
+      const detail: EventDetail = { category: this.category };
+      this.templateClick.emit(detail);
     }
   };
 

--- a/src/components/manifold-template-card.tsx/readme.md
+++ b/src/components/manifold-template-card.tsx/readme.md
@@ -15,9 +15,9 @@
 
 ## Events
 
-| Event                         | Description | Type                |
-| ----------------------------- | ----------- | ------------------- |
-| `manifold-templateCard-click` |             | `CustomEvent<void>` |
+| Event                     | Description | Type                |
+| ------------------------- | ----------- | ------------------- |
+| `manifold-template-click` |             | `CustomEvent<void>` |
 
 
 ----------------------------------------------

--- a/src/index.html
+++ b/src/index.html
@@ -949,14 +949,14 @@ defineCustomElements(window);</code></pre>
 
         document
           .querySelector('manifold-marketplace')
-          .addEventListener('manifold-serviceCard-click', e => {
+          .addEventListener('manifold-marketplace-click', e => {
             const overlay = document.createElement('div');
             overlay.className = 'overlay';
             const modal = document.createElement('div');
             modal.className = 'modal';
             overlay.appendChild(modal);
             const productPage = document.createElement('manifold-product');
-            productPage.productLabel = e.detail.label;
+            productPage.productLabel = e.detail.productLabel;
             modal.appendChild(productPage);
             document.body.appendChild(overlay);
 

--- a/src/index.html
+++ b/src/index.html
@@ -318,46 +318,59 @@ defineCustomElements(window);</code></pre>
               </p>
               <pre><code class="html language-html">&lt;manifold-marketplace featured="piio,zerosix" /&gt;
 </code></pre>
-              <h2 id="navigation">Navigation</h2>
+              <h2 id="events">Events</h2>
               <p>
-                When users click on a product card, you expect something to happen, right? By
-                default, service cards will emit a <code>manifold-serviceCard-click</code> custom
-                event whenever a user clicks anywhere on a card. You can listen for it like so, and
-                use this value to navigate client-side or perform some other action of your choice:
+                This component emits
+                <a href="https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent"
+                  >custom events</a
+                >
+                when it updates. To listen to those events, add an event listener either on the
+                component itself, or <code>document</code>.
               </p>
-              <pre><code class="js language-js">document.addEventListener('manifold-serviceCard-click', { detail: { label } } =&gt; {
-  alert(`You clicked the card for ${label}`);
+              <pre><code class="js language-js">document.addEventListener('manifold-marketplace-click', { detail: { productLabel } } =&gt; {
+  alert(`You clicked the card for ${productLabel}`);
 });
 </code></pre>
+              <p>The following events are emitted:</p>
+              <table>
+                <thead>
+                  <tr>
+                    <th style="text-align:left;">Event Name</th>
+                    <th style="text-align:left;">Description</th>
+                    <th style="text-align:left;">Data</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td style="text-align:left;"><code>manifold-marketplace-click</code></td>
+                    <td style="text-align:left;">
+                      Fires whenever a user has clicked on a product.
+                    </td>
+                    <td style="text-align:left;">
+                      <code>productId</code>, <code>productLabel</code>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>manifold-template-click</code></td>
+                    <td style="text-align:left;">
+                      Fires whenever a user has clicked on a custom template.
+                    </td>
+                    <td style="text-align:left;"><code>category</code></td>
+                  </tr>
+                </tbody>
+              </table>
+              <h2 id="navigation">Navigation</h2>
               <p>
-                Alternately, if you’d like the service cards to be plain, ol’
-                <code>&lt;a&gt;</code> tags, you can specify a <code>link-format</code> attribute,
-                where <code>:product</code> will be substituted with each product’s URL-friendly
-                slug:
+                By default, service cards will only emit the
+                <code>manifold-marketplace-click</code> event (above). But it can also be turned
+                into an <code>&lt;a&gt;</code> tag by specifying <code>link-format</code>:
               </p>
               <pre><code class="html language-html">&lt;manifold-marketplace link-format="/product/:product" /&gt;
 &lt;!-- &lt;a href="/product/jawsdb-mysql"&gt; --&gt;
 </code></pre>
               <p>
-                Note that template cards also emit an event as well:
-                <code>manifold-templateCard-click</code>.
+                <code>:product</code> will be replaced with the url-friendly slug for the product.
               </p>
-              <h4 id="handlingeventsinreact">Handling Events in React</h4>
-              <p>
-                Attaching listeners to custom components in React
-                <a href="https://custom-elements-everywhere.com/">requires the use of refs</a>.
-                Example:
-              </p>
-              <pre><code class="js language-js">marketplaceLoaded(node) {
-  node.addEventListener("manifold-serviceCard-click", ({ detail: { label } }) =&gt; {
-    alert(`You clicked the card for ${label}`);
-  });
-}
-
-render() {
-  return &lt;manifold-marketplace ref={this.marketplaceLoaded} /&gt;;
-}
-</code></pre>
               <!-- Auto Generated Below -->
               <h2 id="properties">Properties</h2>
               <table>
@@ -539,42 +552,71 @@ render() {
               <p>Display the plans for a product.</p>
               <pre><code class="html language-html">&lt;manifold-plan-selector product-label="jawsdb-mysql" /&gt;
 </code></pre>
-              <h2 id="productlabel">Product Label</h2>
               <p>
                 You can find the <code>:product</code> label for each at
                 <code>https://manifold.co/services/:product</code>.
               </p>
-              <h2 id="detectingchanges">Detecting changes</h2>
+              <h2 id="events">Events</h2>
               <p>
-                Events are dispatched on the <code>manifold-planUpdated</code> custom event. To
-                listen for that, listen for the event on <code>document</code> like so:
+                This component emits
+                <a href="https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent"
+                  >custom events</a
+                >
+                when it updates. To listen to those events, add an event listener either on the
+                component itself, or <code>document</code>.
               </p>
-              <pre><code class="js language-js">document.addEventListener('manifold-planUpdated', ({ detail }) =&gt; {
+              <pre><code class="js language-js">document.addEventListener('manifold-planSelector-change', ({ detail }) =&gt; {
   console.log(detail);
 });
-// { id: "2357v8j36f5h866c32ddwwjxvfe8j", label: "nvidia-1080ti-100gb-ssd", product: "zerosix", features: { … } } }
+// { planId: "2357v8j36f5h866c32ddwwjxvfe8j", planLabel: "nvidia-1080ti-100gb-ssd", productLabel: "zerosix", features: { … } } }
 </code></pre>
+              <p>The following events are emitted:</p>
+              <table>
+                <thead>
+                  <tr>
+                    <th style="text-align:left;">Event Name</th>
+                    <th style="text-align:left;">Description</th>
+                    <th style="text-align:left;">Data</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td style="text-align:left;"><code>manifold-planSelector-change</code></td>
+                    <td style="text-align:left;">Fires whenever a user makes a change.</td>
+                    <td style="text-align:left;">
+                      <code>planID</code>, <code>planLabel</code>, <code>productLabel</code>,
+                      <code>features</code>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>manifold-planSelector-load</code></td>
+                    <td style="text-align:left;">
+                      Identical to <code>-update</code> above, but this fires once on DOM mount to
+                      set the initial state (i.e. user hasn’t interacted yet).
+                    </td>
+                    <td style="text-align:left;">
+                      <code>planID</code>, <code>planLabel</code>, <code>productLabel</code>,
+                      <code>features</code>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>manifold-planSelector-click</code></td>
+                    <td style="text-align:left;">
+                      If the CTA is showing (see <code>hide-cta</code> below), this will fire when
+                      clicked.
+                    </td>
+                    <td style="text-align:left;">
+                      <code>planID</code>, <code>planLabel</code>, <code>productLabel</code>,
+                      <code>features</code>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
               <h2 id="navigation">Navigation</h2>
               <p>
-                The large CTA in the bottom-right is configurable. By default, this component emits
-                a <code>manifold-planCTA-click</code> custom event whenever the main CTA is clicked.
-                Listen for it like so:
-              </p>
-              <pre><code class="js language-js">document.addEventListener(
-  'manifold-productCTA-click',
-  ({ detail: { product, plan, features } }) =&gt; {
-    alert(
-      `You clicked the CTA for the ${plan} plan on ${product} with these features: ${JSON.stringify(
-        features
-      )}`
-    );
-  }
-);
-</code></pre>
-              <p>
-                To turn the CTA into an <code>&lt;a&gt;</code> tag, specify a
-                <code>link-format</code> attribute, using <code>:product</code>, <code>:plan</code>,
-                and <code>:features</code> as placeholders:
+                By default, the CTA bottom-right will fire the
+                <code>manifold-planSelector-click</code> event (above). But it can also be turned
+                into an <code>&lt;a&gt;</code> tag by specifying <code>link-format</code>:
               </p>
               <pre><code class="html language-html">&lt;manifold-product
   product-label="aiven-redis"
@@ -582,7 +624,14 @@ render() {
 /&gt;
 &lt;!-- &lt;a href="/product/aiven-redis?plan=startup-4&amp;cpus=1"&gt; --&gt;
 </code></pre>
-              <h3 id="hidingprovisionbutton">Hiding provision button</h3>
+              <p>
+                <code>:plan</code>, <code>:product</code>, and <code>:features</code> (for
+                customizable plans) will all be replaced with url-friendly slugs for each. In most
+                cases, these are all passable to
+                <a href="#data-components"><strong>data components</strong></a
+                >.
+              </p>
+              <h3 id="hidingcta">Hiding CTA</h3>
               <p>If you would like to hide the CTA altogether, specify <code>hide-cta</code>:</p>
               <pre><code class="html language-html">&lt;manifold-product product-label="till" hide-cta /&gt;
 </code></pre>


### PR DESCRIPTION
## Reason for change
I’m working on a provision button, and when surveying the events I’m finding what @davidleger95 pointed out a while ago: we have a few events now which don’t stick to a standard. I propose:

`manifold-[componentName]-[event]`

Example: `manifold-marketplace-click` or `manifold-planSelector-change`.

The only exception to that is the template cards in `manifold-marketplace`, which I felt should get a different event from 'manifold-marketplace-click' because they’re not products, and emit a different value. For those, I have `manifold-template-click` as the event.

Also adds tests for events, and updates the READMEs with better documentation on events.

<img width="893" alt="Screen Shot 2019-04-22 at 11 27 52" src="https://user-images.githubusercontent.com/1369770/56514136-b2bae700-64f1-11e9-9b92-1c1d07bbc6db.png">