### PR TITLE
Improve display of regions & pricing

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -53,13 +53,13 @@ export namespace Components {
     'baseCost'?: number;
     'compact'?: boolean;
     'isCustomizable'?: boolean;
-    'measuredCosts': [number, string][];
+    'measuredFeatures': Catalog.ExpandedFeature[];
   }
   interface ManifoldCostDisplayAttributes extends StencilHTMLAttributes {
     'baseCost'?: number;
     'compact'?: boolean;
     'isCustomizable'?: boolean;
-    'measuredCosts'?: [number, string][];
+    'measuredFeatures'?: Catalog.ExpandedFeature[];
   }
 
   interface ManifoldDataProductLogo {

--- a/src/components/manifold-cost-display/readme.md
+++ b/src/components/manifold-cost-display/readme.md
@@ -7,12 +7,12 @@
 
 ## Properties
 
-| Property         | Attribute         | Description | Type                   | Default     |
-| ---------------- | ----------------- | ----------- | ---------------------- | ----------- |
-| `baseCost`       | `base-cost`       |             | `number \| undefined`  | `undefined` |
-| `compact`        | `compact`         |             | `boolean \| undefined` | `false`     |
-| `isCustomizable` | `is-customizable` |             | `boolean \| undefined` | `false`     |
-| `measuredCosts`  | --                |             | `[number, string][]`   | `[]`        |
+| Property           | Attribute         | Description | Type                   | Default     |
+| ------------------ | ----------------- | ----------- | ---------------------- | ----------- |
+| `baseCost`         | `base-cost`       |             | `number \| undefined`  | `undefined` |
+| `compact`          | `compact`         |             | `boolean \| undefined` | `false`     |
+| `isCustomizable`   | `is-customizable` |             | `boolean \| undefined` | `false`     |
+| `measuredFeatures` | --                |             | `ExpandedFeature[]`    | `[]`        |
 
 
 ----------------------------------------------

--- a/src/components/manifold-plan-cost/manifold-plan-cost.spec.ts
+++ b/src/components/manifold-plan-cost/manifold-plan-cost.spec.ts
@@ -1,0 +1,39 @@
+import { ManifoldPlanCost } from './manifold-plan-cost';
+import {
+  NumberFeatureCustom,
+  NumberFeatureMeasurable,
+  NumberFeatureStatic,
+  NumberFeatureMeasurableValueTiered,
+} from '../../spec/mock/catalog';
+
+const measuredFree = {
+  ...NumberFeatureMeasurable,
+  value: {
+    ...NumberFeatureMeasurable.value,
+    numeric_details: {
+      ...NumberFeatureMeasurable.value.numeric_details,
+      cost_ranges: [],
+    },
+  },
+};
+
+const measuredPaid = {
+  ...NumberFeatureMeasurable,
+  value: NumberFeatureMeasurableValueTiered,
+};
+
+describe('manifold-plan-cost', () => {
+  it('measuredFeatures filters out non-measurable features', () => {
+    const planCost = new ManifoldPlanCost();
+
+    expect(
+      planCost.measuredFeatures([NumberFeatureCustom, measuredPaid, NumberFeatureStatic])
+    ).toEqual([measuredPaid]);
+  });
+
+  it('measuredFeatures only returns paid features', () => {
+    const planCost = new ManifoldPlanCost();
+
+    expect(planCost.measuredFeatures([measuredFree, measuredPaid])).toEqual([measuredPaid]);
+  });
+});

--- a/src/components/manifold-plan-details/manifold-plan-details.tsx
+++ b/src/components/manifold-plan-details/manifold-plan-details.tsx
@@ -19,7 +19,7 @@ interface EventDetail {
   shadow: true,
 })
 export class ManifoldPlanDetails {
-  @Prop() isExistingResource?: boolean;
+  @Prop() isExistingResource?: boolean = false;
   @Prop() hideCta?: boolean = false;
   @Prop() linkFormat?: string;
   @Prop() plan?: Catalog.ExpandedPlan;
@@ -181,7 +181,13 @@ export class ManifoldPlanDetails {
   get regionSelector() {
     if (!this.plan) return null;
 
+    // Don’t show the non-region
+    if (this.plan.body.regions.length === 1 && this.plan.body.regions[0] === globalRegion.id) {
+      return null;
+    }
+
     const name = `${this.plan.body.label}-region`;
+
     return (
       <div class="region">
         <label class="region-label" id={name}>

--- a/src/components/manifold-plan-details/plan-details.css
+++ b/src/components/manifold-plan-details/plan-details.css
@@ -98,9 +98,21 @@
   font-size: var(--mf-font-d1);
 }
 
-.feature-value {
-  display: grid;
-  justify-content: start;
+.feature-table {
+  width: 100%;
+  min-width: 100%;
+  line-height: 1;
+  border-collapse: collapse;
+
+  & td {
+    width: 50%;
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
+  }
+
+  & tr:nth-of-type(odd) td {
+    background-color: rgba(0, 0, 0, 0.03);
+  }
 }
 
 .icon {

--- a/src/components/manifold-plan-details/readme.md
+++ b/src/components/manifold-plan-details/readme.md
@@ -10,7 +10,7 @@
 | Property             | Attribute              | Description | Type                        | Default     |
 | -------------------- | ---------------------- | ----------- | --------------------------- | ----------- |
 | `hideCta`            | `hide-cta`             |             | `boolean \| undefined`      | `false`     |
-| `isExistingResource` | `is-existing-resource` |             | `boolean \| undefined`      | `undefined` |
+| `isExistingResource` | `is-existing-resource` |             | `boolean \| undefined`      | `false`     |
 | `linkFormat`         | `link-format`          |             | `string \| undefined`       | `undefined` |
 | `plan`               | --                     |             | `ExpandedPlan \| undefined` | `undefined` |
 | `product`            | --                     |             | `Product \| undefined`      | `undefined` |

--- a/src/index.html
+++ b/src/index.html
@@ -962,6 +962,10 @@ defineCustomElements(window);</code></pre>
             const productPage = document.createElement('manifold-product');
             productPage.productLabel = e.detail.productLabel;
             modal.appendChild(productPage);
+            const planSelector = document.createElement('manifold-plan-selector');
+            planSelector.productLabel = e.detail.productLabel;
+            planSelector.style.marginTop = 32;
+            modal.appendChild(planSelector);
             document.body.appendChild(overlay);
 
             modal.addEventListener('click', e => {

--- a/src/spec/mock/catalog.ts
+++ b/src/spec/mock/catalog.ts
@@ -18,7 +18,11 @@ interface TNumberFeature extends Catalog.ExpandedFeature {
 }
 
 interface TNumberFeatureDetails extends Catalog.FeatureValueDetails {
-  numeric_details: Catalog.FeatureNumericDetails;
+  numeric_details: TNumberNumericDetails;
+}
+
+interface TNumberNumericDetails extends Catalog.FeatureNumericDetails {
+  cost_ranges: Catalog.FeatureNumericRange[];
 }
 
 export const StringFeatureStatic: TExpandedFeature = {
@@ -122,7 +126,7 @@ export const NumberFeatureMeasurableValuePaid: TNumberFeatureDetails = {
 export const NumberFeatureMeasurableValueUnavailable: TNumberFeatureDetails = {
   label: 'too-expensive-4u',
   name: 'No GPU',
-  numeric_details: { increment: 1, suffix: 'hour' },
+  numeric_details: { cost_ranges: [], increment: 1, suffix: 'hour' },
 };
 
 export const NumberFeatureMeasurableValueTiered: TNumberFeatureDetails = {
@@ -743,3 +747,500 @@ export const Regions: Catalog.Region[] = [
     version: 1,
   },
 ];
+
+export const ZiggeoPlan: Catalog.ExpandedPlan = {
+  body: {
+    cost: 99900,
+    features: [
+      { feature: 'recording_sd', value: 'enterprise-seconds' },
+      { feature: 'recording_hd', value: 'enterprise-seconds' },
+      { feature: 'playing_sd', value: 'enterprise-seconds' },
+      { feature: 'playing_hd', value: 'enterprise-seconds' },
+      { feature: 'storage_sd', value: 'enterprise-seconds' },
+      { feature: 'storage_hd', value: 'enterprise-seconds' },
+      { feature: 'effects_sd', value: 'enterprise-seconds' },
+      { feature: 'effects_hd', value: 'enterprise-seconds' },
+      { feature: 'analysis', value: 'enterprise-seconds' },
+      { feature: 'secure-video-access', value: 'true' },
+      { feature: 'screen-capture', value: 'true' },
+      { feature: 'video-profiles', value: 'true' },
+      { feature: 'nsfw-detection', value: 'true' },
+      { feature: 'sub-accounts', value: 'unlimited' },
+      { feature: 'on-the-fly-transcoding', value: 'true' },
+      { feature: 'webhooks', value: 'true' },
+      { feature: '3rd-party-integrations', value: 'true' },
+      { feature: 'easy-share', value: 'true' },
+    ],
+    label: 'enterprise',
+    name: 'Enterprise',
+    product_id: '234yycr3mf5f2hrw045vuxeatnd50',
+    provider_id: '234a33rd2pxfzq9qfk0v5qdrykhcp',
+    regions: ['235n4f9pxf8eyraj3y159x89z6jer'],
+    state: 'available',
+    trial_days: 0,
+    defaultCost: 99900,
+    expanded_features: [
+      {
+        label: 'recording_sd',
+        measurable: true,
+        name: 'Video Recorder - SD',
+        type: 'number',
+        values: [
+          {
+            label: 'standard-seconds',
+            name: 'Standard Seconds',
+            numeric_details: {
+              cost_ranges: [{ limit: 202680 }, { cost_multiple: 300000, limit: -1 }],
+              increment: 1,
+              suffix: 'Seconds',
+            },
+          },
+          {
+            label: 'pro-seconds',
+            name: 'Pro Seconds',
+            numeric_details: {
+              cost_ranges: [{ limit: 210000 }, { cost_multiple: 200000, limit: -1 }],
+              increment: 1,
+              suffix: 'Seconds',
+            },
+          },
+          {
+            label: 'enterprise-seconds',
+            name: 'Enterprise Seconds',
+            numeric_details: {
+              cost_ranges: [{ limit: 666660 }, { cost_multiple: 150000, limit: -1 }],
+              increment: 1,
+              suffix: 'Seconds',
+            },
+          },
+        ],
+        value: {
+          label: 'enterprise-seconds',
+          name: 'Enterprise Seconds',
+          numeric_details: {
+            cost_ranges: [{ limit: 666660 }, { cost_multiple: 150000, limit: -1 }],
+            increment: 1,
+            suffix: 'Seconds',
+          },
+        },
+        value_string: 'Enterprise Seconds',
+      },
+      {
+        label: 'recording_hd',
+        measurable: true,
+        name: 'Video Recorder - HD',
+        type: 'number',
+        values: [
+          {
+            label: 'standard-no-recording',
+            name: 'No Recording',
+            numeric_details: { cost_ranges: [], suffix: 'Seconds' },
+          },
+          {
+            label: 'pro-seconds',
+            name: 'Pro Seconds',
+            numeric_details: {
+              cost_ranges: [{ limit: 125640 }, { cost_multiple: 400000, limit: -1 }],
+              increment: 1,
+              suffix: 'Seconds',
+            },
+          },
+          {
+            label: 'enterprise-seconds',
+            name: 'Enterprise Seconds',
+            numeric_details: {
+              cost_ranges: [{ limit: 422520 }, { cost_multiple: 300000, limit: -1 }],
+              increment: 1,
+              suffix: 'Seconds',
+            },
+          },
+        ],
+        value: {
+          label: 'enterprise-seconds',
+          name: 'Enterprise Seconds',
+          numeric_details: {
+            cost_ranges: [{ limit: 422520 }, { cost_multiple: 300000, limit: -1 }],
+            increment: 1,
+            suffix: 'Seconds',
+          },
+        },
+        value_string: 'Enterprise Seconds',
+      },
+      {
+        label: 'playing_sd',
+        measurable: true,
+        name: 'Video Player - SD',
+        type: 'number',
+        values: [
+          {
+            label: 'standard-seconds',
+            name: 'Standard Seconds',
+            numeric_details: {
+              cost_ranges: [{ limit: 1014000 }, { cost_multiple: 11667, limit: -1 }],
+              increment: 1,
+              suffix: 'Seconds',
+            },
+          },
+          {
+            label: 'pro-seconds',
+            name: 'Pro Seconds',
+            numeric_details: {
+              cost_ranges: [{ limit: 807000 }, { cost_multiple: 6667, limit: -1 }],
+              increment: 1,
+              suffix: 'Seconds',
+            },
+          },
+          {
+            label: 'enterprise-seconds',
+            name: 'Enterprise Seconds',
+            numeric_details: {
+              cost_ranges: [{ limit: 3000000 }, { cost_multiple: 6667, limit: -1 }],
+              increment: 1,
+              suffix: 'Seconds',
+            },
+          },
+        ],
+        value: {
+          label: 'enterprise-seconds',
+          name: 'Enterprise Seconds',
+          numeric_details: {
+            cost_ranges: [{ limit: 3000000 }, { cost_multiple: 6667, limit: -1 }],
+            increment: 1,
+            suffix: 'Seconds',
+          },
+        },
+        value_string: 'Enterprise Seconds',
+      },
+      {
+        label: 'playing_hd',
+        measurable: true,
+        name: 'Video Player - HD',
+        type: 'number',
+        values: [
+          {
+            label: 'standard-no-playing',
+            name: 'No Playing',
+            numeric_details: { cost_ranges: [], suffix: 'Seconds' },
+          },
+          {
+            label: 'pro-seconds',
+            name: 'Pro Seconds',
+            numeric_details: {
+              cost_ranges: [{ limit: 750000 }, { cost_multiple: 13334, limit: -1 }],
+              increment: 1,
+              suffix: 'Seconds',
+            },
+          },
+          {
+            label: 'enterprise-seconds',
+            name: 'Enterprise Seconds',
+            numeric_details: {
+              cost_ranges: [{ limit: 2064840 }, { cost_multiple: 11667, limit: -1 }],
+              increment: 1,
+              suffix: 'Seconds',
+            },
+          },
+        ],
+        value: {
+          label: 'enterprise-seconds',
+          name: 'Enterprise Seconds',
+          numeric_details: {
+            cost_ranges: [{ limit: 2064840 }, { cost_multiple: 11667, limit: -1 }],
+            increment: 1,
+            suffix: 'Seconds',
+          },
+        },
+        value_string: 'Enterprise Seconds',
+      },
+      {
+        label: 'storage_sd',
+        measurable: true,
+        name: 'Video Storage - SD',
+        type: 'number',
+        values: [
+          {
+            label: 'standard-seconds',
+            name: 'Standard Seconds',
+            numeric_details: {
+              cost_ranges: [{ limit: 1216560 }, { cost_multiple: 21667, limit: -1 }],
+              increment: 1,
+              suffix: 'Seconds',
+            },
+          },
+          {
+            label: 'pro-seconds',
+            name: 'Pro Seconds',
+            numeric_details: {
+              cost_ranges: [{ limit: 1333320 }, { cost_multiple: 15000, limit: -1 }],
+              increment: 1,
+              suffix: 'Seconds',
+            },
+          },
+          {
+            label: 'enterprise-seconds',
+            name: 'Enterprise Seconds',
+            numeric_details: {
+              cost_ranges: [{ limit: 3000000 }, { cost_multiple: 10000, limit: -1 }],
+              increment: 1,
+              suffix: 'Seconds',
+            },
+          },
+        ],
+        value: {
+          label: 'enterprise-seconds',
+          name: 'Enterprise Seconds',
+          numeric_details: {
+            cost_ranges: [{ limit: 3000000 }, { cost_multiple: 10000, limit: -1 }],
+            increment: 1,
+            suffix: 'Seconds',
+          },
+        },
+        value_string: 'Enterprise Seconds',
+      },
+      {
+        label: 'storage_hd',
+        measurable: true,
+        name: 'Video Storage - HD',
+        type: 'number',
+        values: [
+          {
+            label: 'standard-no-storage',
+            name: 'No Storage',
+            numeric_details: { cost_ranges: [], suffix: 'Seconds' },
+          },
+          {
+            label: 'pro-seconds',
+            name: 'Pro Seconds',
+            numeric_details: {
+              cost_ranges: [{ limit: 717300 }, { cost_multiple: 30000, limit: -1 }],
+              increment: 1,
+              suffix: 'Seconds',
+            },
+          },
+          {
+            label: 'enterprise-seconds',
+            name: 'Enterprise Seconds',
+            numeric_details: {
+              cost_ranges: [{ limit: 3150420 }, { cost_multiple: 21667, limit: -1 }],
+              increment: 1,
+              suffix: 'Seconds',
+            },
+          },
+        ],
+        value: {
+          label: 'enterprise-seconds',
+          name: 'Enterprise Seconds',
+          numeric_details: {
+            cost_ranges: [{ limit: 3150420 }, { cost_multiple: 21667, limit: -1 }],
+            increment: 1,
+            suffix: 'Seconds',
+          },
+        },
+        value_string: 'Enterprise Seconds',
+      },
+      {
+        label: 'effects_sd',
+        measurable: true,
+        name: 'Video Effects - SD',
+        type: 'number',
+        values: [
+          {
+            label: 'standard-no-effects',
+            name: 'No Effects',
+            numeric_details: { cost_ranges: [], suffix: 'Seconds' },
+          },
+          {
+            label: 'pro-seconds',
+            name: 'Pro Seconds',
+            numeric_details: {
+              cost_ranges: [{ limit: 191280 }, { cost_multiple: 333334, limit: -1 }],
+              increment: 1,
+              suffix: 'Seconds',
+            },
+          },
+          {
+            label: 'enterprise-seconds',
+            name: 'Enterprise Seconds',
+            numeric_details: {
+              cost_ranges: [{ limit: 511740 }, { cost_multiple: 250000, limit: -1 }],
+              increment: 1,
+              suffix: 'Seconds',
+            },
+          },
+        ],
+        value: {
+          label: 'enterprise-seconds',
+          name: 'Enterprise Seconds',
+          numeric_details: {
+            cost_ranges: [{ limit: 511740 }, { cost_multiple: 250000, limit: -1 }],
+            increment: 1,
+            suffix: 'Seconds',
+          },
+        },
+        value_string: 'Enterprise Seconds',
+      },
+      {
+        label: 'effects_hd',
+        measurable: true,
+        name: 'Video Effects - HD',
+        type: 'number',
+        values: [
+          {
+            label: 'standard-no-effects',
+            name: 'No Effects',
+            numeric_details: { cost_ranges: [], suffix: 'Seconds' },
+          },
+          {
+            label: 'pro-seconds',
+            name: 'Pro Seconds',
+            numeric_details: {
+              cost_ranges: [{ limit: 135000 }, { cost_multiple: 666667, limit: -1 }],
+              increment: 1,
+              suffix: 'Seconds',
+            },
+          },
+          {
+            label: 'enterprise-seconds',
+            name: 'Enterprise Seconds',
+            numeric_details: {
+              cost_ranges: [{ limit: 499980 }, { cost_multiple: 500000, limit: -1 }],
+              increment: 1,
+              suffix: 'Seconds',
+            },
+          },
+        ],
+        value: {
+          label: 'enterprise-seconds',
+          name: 'Enterprise Seconds',
+          numeric_details: {
+            cost_ranges: [{ limit: 499980 }, { cost_multiple: 500000, limit: -1 }],
+            increment: 1,
+            suffix: 'Seconds',
+          },
+        },
+        value_string: 'Enterprise Seconds',
+      },
+      {
+        label: 'analysis',
+        measurable: true,
+        name: 'A.I. Video Analysis',
+        type: 'number',
+        values: [
+          {
+            label: 'standard-no-analysis',
+            name: 'No Analysis',
+            numeric_details: { cost_ranges: [], suffix: 'Seconds' },
+          },
+          {
+            label: 'pro-seconds',
+            name: 'Pro Seconds',
+            numeric_details: {
+              cost_ranges: [{ limit: 230640 }, { cost_multiple: 416667, limit: -1 }],
+              increment: 1,
+              suffix: 'Seconds',
+            },
+          },
+          {
+            label: 'enterprise-seconds',
+            name: 'Enterprise Seconds',
+            numeric_details: {
+              cost_ranges: [{ limit: 755880 }, { cost_multiple: 333334, limit: -1 }],
+              increment: 1,
+              suffix: 'Seconds',
+            },
+          },
+        ],
+        value: {
+          label: 'enterprise-seconds',
+          name: 'Enterprise Seconds',
+          numeric_details: {
+            cost_ranges: [{ limit: 755880 }, { cost_multiple: 333334, limit: -1 }],
+            increment: 1,
+            suffix: 'Seconds',
+          },
+        },
+        value_string: 'Enterprise Seconds',
+      },
+      {
+        label: 'secure-video-access',
+        name: 'Secure Video Access',
+        type: 'boolean',
+        values: [{ label: 'true', name: 'true' }, { label: 'false', name: 'false' }],
+        value: { label: 'true', name: 'true' },
+        value_string: 'true',
+      },
+      {
+        label: 'screen-capture',
+        name: 'Screen Capture',
+        type: 'boolean',
+        values: [{ label: 'true', name: 'true' }, { label: 'false', name: 'false' }],
+        value: { label: 'true', name: 'true' },
+        value_string: 'true',
+      },
+      {
+        label: 'video-profiles',
+        name: 'Video Profiles',
+        type: 'boolean',
+        values: [{ label: 'true', name: 'true' }, { label: 'false', name: 'false' }],
+        value: { label: 'true', name: 'true' },
+        value_string: 'true',
+      },
+      {
+        label: 'nsfw-detection',
+        name: 'Not - Safe for Work Detection',
+        type: 'boolean',
+        values: [{ label: 'true', name: 'true' }, { label: 'false', name: 'false' }],
+        value: { label: 'true', name: 'true' },
+        value_string: 'true',
+      },
+      {
+        label: 'sub-accounts',
+        name: 'Sub Accounts',
+        type: 'string',
+        values: [
+          { label: 'none', name: 'None' },
+          { label: 'five-shared-apps', name: 'Up to 5 shared apps only' },
+          { label: 'unlimited', name: 'Unlimited' },
+        ],
+        value: { label: 'unlimited', name: 'Unlimited' },
+        value_string: 'Unlimited',
+      },
+      {
+        label: 'on-the-fly-transcoding',
+        name: 'On Fly Transcoding',
+        type: 'boolean',
+        values: [{ label: 'true', name: 'true' }, { label: 'false', name: 'false' }],
+        value: { label: 'true', name: 'true' },
+        value_string: 'true',
+      },
+      {
+        label: 'webhooks',
+        name: 'Webhooks',
+        type: 'boolean',
+        values: [{ label: 'true', name: 'true' }, { label: 'false', name: 'false' }],
+        value: { label: 'true', name: 'true' },
+        value_string: 'true',
+      },
+      {
+        label: '3rd-party-integrations',
+        name: '3rd Party Integrations',
+        type: 'boolean',
+        values: [{ label: 'true', name: 'true' }, { label: 'false', name: 'false' }],
+        value: { label: 'true', name: 'true' },
+        value_string: 'true',
+      },
+      {
+        label: 'easy-share',
+        name: 'Easy Share',
+        type: 'boolean',
+        values: [{ label: 'true', name: 'true' }, { label: 'false', name: 'false' }],
+        value: { label: 'true', name: 'true' },
+        value_string: 'true',
+      },
+    ],
+    free: false,
+  },
+  id: '235f9mmmc7qg4h5zzg8mrqxer5acp',
+  type: 'plan',
+  version: 1,
+};

--- a/src/utils/currency.spec.ts
+++ b/src/utils/currency.spec.ts
@@ -1,7 +1,7 @@
 import { $ } from './currency';
 
 describe('$ function', () => {
-  it('formats cents into a dollar value', () => expect($(100)).toBe('$1.00'));
-  it('rounds down correctly', () => expect($(100.4)).toBe('$1.00'));
+  it('formats cents into a dollar value', () => expect($(100)).toBe('$1'));
+  it('rounds down correctly', () => expect($(100.4)).toBe('$1'));
   it('rounds up correctly', () => expect($(100.5)).toBe('$1.01'));
 });

--- a/src/utils/currency.ts
+++ b/src/utils/currency.ts
@@ -2,7 +2,7 @@
  * Display cents as a dollar value
  */
 export const $ = (amount: number, options: object = {}): string => {
-  return Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', ...options }).format(
-    amount / 100
-  );
+  return Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', ...options })
+    .format(amount / 100)
+    .replace(/\.00$/, '');
 };

--- a/src/utils/string.spec.ts
+++ b/src/utils/string.spec.ts
@@ -9,4 +9,5 @@ describe('singularize', () => {
 describe('pluralize', () => {
   it('pluralizes normal words with an “s”', () => expect(pluralize('moose')).toBe('mooses'));
   it('pluralizes words ending in “s” with “es“', () => expect(pluralize('class')).toBe('classes'));
+  it('pluralizes words ending in “y” with “ies“', () => expect(pluralize('piggy')).toBe('piggies'));
 });

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,3 +1,7 @@
 export const singularize = (word: string) => word.replace(/s$/i, '');
 
-export const pluralize = (word: string) => (word.endsWith('s') ? `${word}es` : `${word}s`);
+export const pluralize = (word: string) => {
+  if (word.endsWith('s')) return `${word}es`;
+  if (word.endsWith('y')) return `${word.replace(/y$/, '')}ies`;
+  return `${word}s`;
+};


### PR DESCRIPTION
## Reason for change
- Hides regions if it’s regionless
- Further improves cost display

<img width="1127" alt="Screen Shot 2019-04-22 at 22 32 48" src="https://user-images.githubusercontent.com/1369770/56586363-d38c4680-659c-11e9-92cf-6e00b882c8ee.png">

<img width="1135" alt="Screen Shot 2019-04-23 at 07 48 49" src="https://user-images.githubusercontent.com/1369770/56586367-d5eea080-659c-11e9-862e-8df01dc15f6f.png">

<img width="1126" alt="Screen Shot 2019-04-23 at 07 49 22" src="https://user-images.githubusercontent.com/1369770/56586373-d8e99100-659c-11e9-999c-122e08016e6c.png">

<img width="1132" alt="Screen Shot 2019-04-23 at 07 49 54" src="https://user-images.githubusercontent.com/1369770/56586376-dbe48180-659c-11e9-90c2-56aded85fd46.png">

## Testing
<!-- For someone unfamiliar with the issue, how should this be tested? -->
