### PR TITLE
Allow region sorting, rename blacklist & whitelist

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -24,6 +24,7 @@ export namespace Components {
     'linkFormat'?: string;
     'plans': Catalog.ExpandedPlan[];
     'product'?: Catalog.ExpandedProduct;
+    'regions'?: string[];
   }
   interface ManifoldActivePlanAttributes extends StencilHTMLAttributes {
     'hideCta'?: boolean;
@@ -31,6 +32,7 @@ export namespace Components {
     'linkFormat'?: string;
     'plans'?: Catalog.ExpandedPlan[];
     'product'?: Catalog.ExpandedProduct;
+    'regions'?: string[];
   }
 
   interface ManifoldBadge {}
@@ -233,34 +235,34 @@ export namespace Components {
   }
 
   interface ManifoldMarketplaceGrid {
-    'blacklist'?: string[];
+    'excludes'?: string[];
     'featured'?: string[];
     'hideCategories'?: boolean;
     'hideTemplates'?: boolean;
     'linkFormat'?: string;
+    'products'?: string[];
     'services'?: Catalog.Product[];
-    'whitelist'?: string[];
   }
   interface ManifoldMarketplaceGridAttributes extends StencilHTMLAttributes {
-    'blacklist'?: string[];
+    'excludes'?: string[];
     'featured'?: string[];
     'hideCategories'?: boolean;
     'hideTemplates'?: boolean;
     'linkFormat'?: string;
+    'products'?: string[];
     'services'?: Catalog.Product[];
-    'whitelist'?: string[];
   }
 
   interface ManifoldMarketplace {
-    /**
-    * Comma-separated list of hidden products (labels)
-    */
-    'blacklist'?: string;
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
     'connection': Connection;
     /**
+    * Comma-separated list of hidden products (labels)
+    */
+    'excludes'?: string;
+    /**
     * Comma-separated list of featured products (labels)
     */
     'featured'?: string;
@@ -277,20 +279,20 @@ export namespace Components {
     */
     'linkFormat'?: string;
     /**
-    * Comma-separated list of allowed products (labels)
+    * Comma-separated list of shown products (labels)
     */
-    'whitelist'?: string;
+    'products'?: string;
   }
   interface ManifoldMarketplaceAttributes extends StencilHTMLAttributes {
-    /**
-    * Comma-separated list of hidden products (labels)
-    */
-    'blacklist'?: string;
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
     'connection'?: Connection;
     /**
+    * Comma-separated list of hidden products (labels)
+    */
+    'excludes'?: string;
+    /**
     * Comma-separated list of featured products (labels)
     */
     'featured'?: string;
@@ -307,9 +309,9 @@ export namespace Components {
     */
     'linkFormat'?: string;
     /**
-    * Comma-separated list of allowed products (labels)
+    * Comma-separated list of shown products (labels)
     */
-    'whitelist'?: string;
+    'products'?: string;
   }
 
   interface ManifoldNumberInput {
@@ -359,6 +361,7 @@ export namespace Components {
     'linkFormat'?: string;
     'plan'?: Catalog.ExpandedPlan;
     'product'?: Catalog.Product;
+    'regions'?: string[];
   }
   interface ManifoldPlanDetailsAttributes extends StencilHTMLAttributes {
     'hideCta'?: boolean;
@@ -369,6 +372,7 @@ export namespace Components {
     'onManifold-planSelector-load'?: (event: CustomEvent) => void;
     'plan'?: Catalog.ExpandedPlan;
     'product'?: Catalog.Product;
+    'regions'?: string[];
   }
 
   interface ManifoldPlanMenu {
@@ -400,6 +404,10 @@ export namespace Components {
     */
     'productLabel': string;
     /**
+    * Specify region order
+    */
+    'regions'?: string;
+    /**
     * _(optional)_ Is this modifying an existing resource?
     */
     'resourceId'?: string;
@@ -421,6 +429,10 @@ export namespace Components {
     * URL-friendly slug (e.g. `"jawsdb-mysql"`)
     */
     'productLabel'?: string;
+    /**
+    * Specify region order
+    */
+    'regions'?: string;
     /**
     * _(optional)_ Is this modifying an existing resource?
     */
@@ -490,6 +502,7 @@ export namespace Components {
     'ariaLabel': string;
     'connection': Connection;
     'name': string;
+    'preferredRegions'?: string[];
     'value'?: string;
   }
   interface ManifoldRegionSelectorAttributes extends StencilHTMLAttributes {
@@ -498,6 +511,7 @@ export namespace Components {
     'connection'?: Connection;
     'name'?: string;
     'onChange'?: (event: CustomEvent) => void;
+    'preferredRegions'?: string[];
     'value'?: string;
   }
 

--- a/src/components/manifold-active-plan/manifold-active-plan.tsx
+++ b/src/components/manifold-active-plan/manifold-active-plan.tsx
@@ -6,11 +6,12 @@ import { Component, State, Prop } from '@stencil/core';
   shadow: true,
 })
 export class ManifoldActivePlan {
+  @Prop() hideCta?: boolean;
   @Prop() isExistingResource?: boolean;
   @Prop() linkFormat?: string;
-  @Prop() product?: Catalog.ExpandedProduct;
   @Prop() plans: Catalog.ExpandedPlan[] = [];
-  @Prop() hideCta?: boolean;
+  @Prop() product?: Catalog.ExpandedProduct;
+  @Prop() regions?: string[];
   @State() selectedPlanId: string;
 
   componentWillLoad() {
@@ -37,6 +38,7 @@ export class ManifoldActivePlan {
           linkFormat={this.linkFormat}
           plan={this.plans.find(plan => plan.id === this.selectedPlanId)}
           product={this.product}
+          regions={this.regions}
         />
       </div>,
     ];

--- a/src/components/manifold-active-plan/readme.md
+++ b/src/components/manifold-active-plan/readme.md
@@ -14,6 +14,7 @@ Hello
 | `linkFormat`         | `link-format`          |             | `string \| undefined`          | `undefined` |
 | `plans`              | --                     |             | `ExpandedPlan[]`               | `[]`        |
 | `product`            | --                     |             | `ExpandedProduct \| undefined` | `undefined` |
+| `regions`            | --                     |             | `string[] \| undefined`        | `undefined` |
 
 
 ----------------------------------------------

--- a/src/components/manifold-data-provision-button/readme.md
+++ b/src/components/manifold-data-provision-button/readme.md
@@ -51,6 +51,8 @@ success:
 
 You can style or hide these as desired.
 
+_Note: the error message for the input hides/shows on input blur_
+
 ## Styling
 
 Whereas other components in this system take advantage of [Shadow

--- a/src/components/manifold-marketplace-grid/manifold-marketplace-grid.e2e.ts
+++ b/src/components/manifold-marketplace-grid/manifold-marketplace-grid.e2e.ts
@@ -74,56 +74,56 @@ describe('manifold-marketplace-grid', () => {
     );
   });
 
-  it('accepts blacklist of products', async () => {
-    const blacklist = ['service-messaging', 'service-optimization'];
+  it('accepts exclusion list of products', async () => {
+    const excludes = ['service-messaging', 'service-optimization'];
 
     const page = await newE2EPage({ html: `<manifold-marketplace-grid />` });
     await page.$eval(
       'manifold-marketplace-grid',
       (elm: any, props: any) => {
         elm.services = props.services;
-        elm.blacklist = props.blacklist;
+        elm.excludes = props.excludes;
       },
-      { services, blacklist }
+      { services, excludes }
     );
     await page.waitForChanges();
 
-    const notBlacklisted = testCategories
+    const notExcluded = testCategories
       .map(category => `service-${category}`)
-      .filter(category => !blacklist.includes(category));
-    notBlacklisted.forEach(async service =>
+      .filter(category => !excludes.includes(category));
+    notExcluded.forEach(async product =>
       expect(
-        await page.find(`manifold-marketplace-grid >>> [data-label="${service}"]`)
+        await page.find(`manifold-marketplace-grid >>> [data-label="${product}"]`)
       ).not.toBeNull()
     );
-    blacklist.forEach(async service =>
-      expect(await page.find(`manifold-marketplace-grid >>> [data-label="${service}"]`)).toBeNull()
+    excludes.forEach(async product =>
+      expect(await page.find(`manifold-marketplace-grid >>> [data-label="${product}"]`)).toBeNull()
     );
   });
 
-  it('accepts whitelist of products', async () => {
-    const whitelist = ['service-ai-ml', 'service-utility'];
+  it('accepts manual product list', async () => {
+    const products = ['service-ai-ml', 'service-utility'];
 
     const page = await newE2EPage({ html: `<manifold-marketplace-grid />` });
     await page.$eval(
       'manifold-marketplace-grid',
       (elm: any, props: any) => {
         elm.services = props.services;
-        elm.whitelist = props.whitelist;
+        elm.products = props.products;
       },
-      { services, whitelist }
+      { services, products }
     );
     await page.waitForChanges();
 
-    const notWhitelisted = testCategories
+    const notIncluded = testCategories
       .map(category => `service-${category}`)
-      .filter(category => !whitelist.includes(category));
-    notWhitelisted.forEach(async service =>
-      expect(await page.find(`manifold-marketplace-grid >>> [data-label="${service}"]`)).toBeNull()
+      .filter(category => !products.includes(category));
+    notIncluded.forEach(async product =>
+      expect(await page.find(`manifold-marketplace-grid >>> [data-label="${product}"]`)).toBeNull()
     );
-    whitelist.forEach(async service =>
+    products.forEach(async product =>
       expect(
-        await page.find(`manifold-marketplace-grid >>> [data-label="${service}"]`)
+        await page.find(`manifold-marketplace-grid >>> [data-label="${product}"]`)
       ).not.toBeNull()
     );
   });

--- a/src/components/manifold-marketplace-grid/manifold-marketplace-grid.tsx
+++ b/src/components/manifold-marketplace-grid/manifold-marketplace-grid.tsx
@@ -14,13 +14,13 @@ import {
 })
 export class ManifoldMarketplaceGrid {
   @Element() el: HTMLElement;
-  @Prop() blacklist?: string[] = [];
+  @Prop() excludes?: string[] = [];
   @Prop() featured?: string[] = [];
   @Prop() hideCategories?: boolean = false;
   @Prop() hideTemplates?: boolean = false;
   @Prop() linkFormat?: string;
+  @Prop() products?: string[] = [];
   @Prop() services?: Catalog.Product[] = [];
-  @Prop() whitelist?: string[] = [];
   @State() filter: string | null;
   @State() activeCategory?: string;
   @State() observer: IntersectionObserver;
@@ -70,21 +70,21 @@ export class ManifoldMarketplaceGrid {
 
   get filteredServices(): Catalog.Product[] {
     let services: Catalog.Product[] = [];
-    // If not whitelisting, start out with all services
-    if (this.whitelist && !this.whitelist.length && this.services) services = this.services; // eslint-disable-line prefer-destructuring
+    // If not including, start out with all services
+    if (this.products && !this.products.length && this.services) services = this.services; // eslint-disable-line prefer-destructuring
 
-    // Handle whitelist
-    if (Array.isArray(this.whitelist))
-      this.whitelist.forEach(whitelisted => {
+    // Handle includes
+    if (Array.isArray(this.products))
+      this.products.forEach(product => {
         const service =
-          this.services && this.services.find(({ body: { label } }) => label === whitelisted);
+          this.services && this.services.find(({ body: { label } }) => label === product);
         if (service) services.push(service);
       });
 
-    // Handle blacklist
-    if (Array.isArray(this.blacklist))
+    // Handle excludes
+    if (Array.isArray(this.excludes))
       services = services.filter(
-        ({ body: { label } }) => this.blacklist && !this.blacklist.includes(label)
+        ({ body: { label } }) => this.excludes && !this.excludes.includes(label)
       );
 
     // Handle search

--- a/src/components/manifold-marketplace-grid/readme.md
+++ b/src/components/manifold-marketplace-grid/readme.md
@@ -9,13 +9,13 @@
 
 | Property         | Attribute         | Description | Type                     | Default     |
 | ---------------- | ----------------- | ----------- | ------------------------ | ----------- |
-| `blacklist`      | --                |             | `string[] \| undefined`  | `[]`        |
+| `excludes`       | --                |             | `string[] \| undefined`  | `[]`        |
 | `featured`       | --                |             | `string[] \| undefined`  | `[]`        |
 | `hideCategories` | `hide-categories` |             | `boolean \| undefined`   | `false`     |
 | `hideTemplates`  | `hide-templates`  |             | `boolean \| undefined`   | `false`     |
 | `linkFormat`     | `link-format`     |             | `string \| undefined`    | `undefined` |
+| `products`       | --                |             | `string[] \| undefined`  | `[]`        |
 | `services`       | --                |             | `Product[] \| undefined` | `[]`        |
-| `whitelist`      | --                |             | `string[] \| undefined`  | `[]`        |
 
 
 ----------------------------------------------

--- a/src/components/manifold-marketplace/manifold-marketplace.tsx
+++ b/src/components/manifold-marketplace/manifold-marketplace.tsx
@@ -7,10 +7,10 @@ import { Connection, connections } from '../../utils/connections';
 @Component({ tag: 'manifold-marketplace' })
 export class ManifoldMarketplace {
   @Element() el: HTMLElement;
-  /** Comma-separated list of hidden products (labels) */
-  @Prop() blacklist?: string;
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() connection: Connection = connections.prod;
+  /** Comma-separated list of hidden products (labels) */
+  @Prop() excludes?: string;
   /** Comma-separated list of featured products (labels) */
   @Prop() featured?: string;
   /** Hide template cards? */
@@ -19,22 +19,20 @@ export class ManifoldMarketplace {
   @Prop() hideCategories?: boolean = false;
   /** Link format structure, with `:product` placeholder */
   @Prop() linkFormat?: string;
-  /** Comma-separated list of allowed products (labels) */
-  @Prop() whitelist?: string;
-  @State() parsedBlacklist: string[] = [];
+  /** Comma-separated list of shown products (labels) */
+  @Prop() products?: string;
+  @State() parsedExcludes: string[] = [];
   @State() parsedFeatured: string[] = [];
-  @State() parsedWhitelist: string[] = [];
+  @State() parsedProducts: string[] = [];
   @State() services: Catalog.Product[] = [];
 
-  componentWillLoad() {
+  async componentWillLoad() {
     this.parseProps();
 
-    return fetch(`${this.connection.catalog}/products`, withAuth())
-      .then(response => response.json())
-      .then((products: Catalog.Product[]) => {
-        // Alphabetize once, then don’t worry about it
-        this.services = [...products].sort((a, b) => a.body.name.localeCompare(b.body.name));
-      });
+    const response = await fetch(`${this.connection.catalog}/products`, withAuth());
+    const products: Catalog.Product[] = await response.json();
+    // Alphabetize once, then don’t worry about it
+    this.services = [...products].sort((a, b) => a.body.name.localeCompare(b.body.name));
   }
 
   private parse(list: string): string[] {
@@ -43,20 +41,20 @@ export class ManifoldMarketplace {
 
   private parseProps() {
     if (typeof this.featured === 'string') this.parsedFeatured = this.parse(this.featured);
-    if (typeof this.blacklist === 'string') this.parsedBlacklist = this.parse(this.blacklist);
-    if (typeof this.whitelist === 'string') this.parsedWhitelist = this.parse(this.whitelist);
+    if (typeof this.excludes === 'string') this.parsedExcludes = this.parse(this.excludes);
+    if (typeof this.products === 'string') this.parsedProducts = this.parse(this.products);
   }
 
   render() {
     return (
       <manifold-marketplace-grid
-        blacklist={this.parsedBlacklist}
+        excludes={this.parsedExcludes}
         featured={this.parsedFeatured}
         hideCategories={this.hideCategories}
         hideTemplates={this.hideTemplates}
         linkFormat={this.linkFormat}
+        products={this.parsedProducts}
         services={this.services}
-        whitelist={this.parsedWhitelist}
       />
     );
   }

--- a/src/components/manifold-marketplace/readme.md
+++ b/src/components/manifold-marketplace/readme.md
@@ -6,37 +6,38 @@ A list of all Manifold services.
 <manifold-marketplace />
 ```
 
-## Blacklist/whitelist
+## Catalog curation
 
-Blacklists (hidden products) and whitelists (allowed services) are two ways
-to filter the services you’d like to display to users. Use either `blacklist`
-or `whitelist`; **don’t use both**.
+Our marketplace offers 2 options, either to show all services excluding a
+few, or manually specifying the products that should be shown. For either
+option there is either the `excludes` or `products` options—use either, but
+not both in the same instance.
 
-#### Blacklist
+#### Excludes
 
-Blacklist will start with **all products**, but let you specify which ones
+Excludes will start with **all products**, but let you specify which ones
 you’d like to hide:
 
 ```html
-<manifold-marketplace blacklist="manifold-provider" />
+<manifold-marketplace excludes="manifold-provider" />
 ```
 
-#### Whitelist
+#### Products
 
-Conversely, whitelisting will start with **no products**, and let you
-manually specify every product that should be shown.
+Conversely, manually specifying products will start with **no products**, and
+let you manually specify every product that should be shown.
 
-A common usecase is using `whitelist` in conjuction with `hide-categories` (below).
+A common usecase is using `products` in conjuction with `hide-categories` (below).
 
 ```html
-<manifold-marketplace whitelist="aiven-redis,cloudamqp,iron_cache,iron_mq,memcachier-cache" />
+<manifold-marketplace products="aiven-redis,cloudamqp,iron_cache,iron_mq,memcachier-cache" />
 ```
 
 ## Hide categories
 
 Hiding the categories is a great way to have a more compact display. It’s
 recommended to use this if you’re only displaying a few products via
-`whitelist` (above):
+`products` (above):
 
 ```html
 <manifold-marketplace hide-categories />
@@ -45,7 +46,8 @@ recommended to use this if you’re only displaying a few products via
 ## Hide template cards
 
 Add the `hide-templates` attribute to hide external service template cards
-(GitHub, Stripe, etc.):
+(GitHub, Stripe, etc.). This will also hide their respective categories if no
+other products are using them.
 
 ```html
 <manifold-marketplace hide-templates />
@@ -75,10 +77,10 @@ document.addEventListener('manifold-marketplace-click', { detail: { productLabel
 
 The following events are emitted:
 
-| Event Name                   | Description                                             | Data                        |
-| :--------------------------- | :------------------------------------------------------ | :-------------------------- |
-| `manifold-marketplace-click` | Fires whenever a user has clicked on a product.         | `productId`, `productLabel` |
-| `manifold-template-click`    | Fires whenever a user has clicked on a custom template. | `category`                  |
+| Event Name                   | Description                                                                                              | Data                        |
+| :--------------------------- | :------------------------------------------------------------------------------------------------------- | :-------------------------- |
+| `manifold-marketplace-click` | Fires whenever a user has clicked on a product.                                                          | `productId`, `productLabel` |
+| `manifold-template-click`    | Fires whenever a user has clicked on a custom template (assuming it’s not hidden with `hide-templates`). | `category`                  |
 
 ## Navigation
 
@@ -100,13 +102,13 @@ event (above). But it can also be turned into an `<a>` tag by specifying
 
 | Property         | Attribute         | Description                                        | Type                   | Default            |
 | ---------------- | ----------------- | -------------------------------------------------- | ---------------------- | ------------------ |
-| `blacklist`      | `blacklist`       | Comma-separated list of hidden products (labels)   | `string \| undefined`  | `undefined`        |
 | `connection`     | --                | _(hidden)_ Passed by `<manifold-connection>`       | `Connection`           | `connections.prod` |
+| `excludes`       | `excludes`        | Comma-separated list of hidden products (labels)   | `string \| undefined`  | `undefined`        |
 | `featured`       | `featured`        | Comma-separated list of featured products (labels) | `string \| undefined`  | `undefined`        |
 | `hideCategories` | `hide-categories` | Hide categories & side menu?                       | `boolean \| undefined` | `false`            |
 | `hideTemplates`  | `hide-templates`  | Hide template cards?                               | `boolean \| undefined` | `false`            |
 | `linkFormat`     | `link-format`     | Link format structure, with `:product` placeholder | `string \| undefined`  | `undefined`        |
-| `whitelist`      | `whitelist`       | Comma-separated list of allowed products (labels)  | `string \| undefined`  | `undefined`        |
+| `products`       | `products`        | Comma-separated list of shown products (labels)    | `string \| undefined`  | `undefined`        |
 
 
 ----------------------------------------------

--- a/src/components/manifold-plan-details/manifold-plan-details.tsx
+++ b/src/components/manifold-plan-details/manifold-plan-details.tsx
@@ -19,11 +19,12 @@ interface EventDetail {
   shadow: true,
 })
 export class ManifoldPlanDetails {
-  @Prop() isExistingResource?: boolean = false;
   @Prop() hideCta?: boolean = false;
+  @Prop() isExistingResource?: boolean = false;
   @Prop() linkFormat?: string;
   @Prop() plan?: Catalog.ExpandedPlan;
   @Prop() product?: Catalog.Product;
+  @Prop() regions?: string[];
   @State() regionId: string = globalRegion.id;
   @State() features: UserFeatures = {};
   @Event({ eventName: 'manifold-planSelector-change', bubbles: true }) planUpdate: EventEmitter;
@@ -209,6 +210,7 @@ export class ManifoldPlanDetails {
           ariaLabel={name}
           name={name}
           onChange={e => this.handleChangeRegion(e)}
+          preferredRegions={this.regions}
           value={this.regionId}
         />
       </div>

--- a/src/components/manifold-plan-details/manifold-plan-details.tsx
+++ b/src/components/manifold-plan-details/manifold-plan-details.tsx
@@ -25,7 +25,7 @@ export class ManifoldPlanDetails {
   @Prop() plan?: Catalog.ExpandedPlan;
   @Prop() product?: Catalog.Product;
   @Prop() regions?: string[];
-  @State() regionId: string = globalRegion.id;
+  @State() regionId: string = globalRegion.id; // default will always be overridden if a plan has regions
   @State() features: UserFeatures = {};
   @Event({ eventName: 'manifold-planSelector-change', bubbles: true }) planUpdate: EventEmitter;
   @Event({ eventName: 'manifold-planSelector-click', bubbles: true }) planClick: EventEmitter;
@@ -232,9 +232,13 @@ export class ManifoldPlanDetails {
   };
 
   updateRegionId = (newPlan: Catalog.ExpandedPlan) => {
-    // Only change regionID if it doesn’t exist on the new plan
+    // If region already set and changing plans, keep it
     if (!newPlan.body.regions.includes(this.regionId)) {
-      const [firstRegion] = newPlan.body.regions;
+      // If user has specified regions, try and find the first
+      let firstRegion =
+        this.regions && this.regions.find(region => newPlan.body.regions.includes(region));
+      // Otherwise pick the first region from the plan
+      if (!firstRegion) [firstRegion] = newPlan.body.regions;
       if (firstRegion) this.regionId = firstRegion;
     }
   };

--- a/src/components/manifold-plan-details/readme.md
+++ b/src/components/manifold-plan-details/readme.md
@@ -14,6 +14,7 @@
 | `linkFormat`         | `link-format`          |             | `string \| undefined`       | `undefined` |
 | `plan`               | --                     |             | `ExpandedPlan \| undefined` | `undefined` |
 | `product`            | --                     |             | `Product \| undefined`      | `undefined` |
+| `regions`            | --                     |             | `string[] \| undefined`     | `undefined` |
 
 
 ## Events

--- a/src/components/manifold-plan-selector/readme.md
+++ b/src/components/manifold-plan-selector/readme.md
@@ -38,7 +38,7 @@ event (above). But it can also be turned into an `<a>` tag by specifying
 `link-format`:
 
 ```html
-<manifold-product
+<manifold-plan-selector
   product-label="aiven-redis"
   link-format="/create/:product/?plan=:plan&:features"
 />
@@ -49,13 +49,69 @@ event (above). But it can also be turned into an `<a>` tag by specifying
 replaced with url-friendly slugs for each. In most cases, these are all
 passable to [**data components**](#data-components).
 
-### Hiding CTA
+## Hiding CTA
 
 If you would like to hide the CTA altogether, specify `hide-cta`:
 
 ```html
-<manifold-product product-label="till" hide-cta />
+<manifold-plan-selector product-label="till" hide-cta />
 ```
+
+## Regions
+
+Most of our products are regionless, but some plans let users specify the
+region. In this case, you may optionally want to order the regions with the
+`regions` attribute:
+
+```html
+<manifold-plan-selector regions="aws-eu-west-1,aws-eu-west-2,aws-us-east-1,aws-us-east-2" />
+```
+
+Regions will be ordered in the order specified. Any regions not mentioned
+will come at the end, alphabetically. Any regions not supported by the plan
+will simply be ignored (in this sense, you could even pass the same ordered
+list to all plans regardless, if you’d like them always to display in the
+same order).
+
+### Supported regions
+
+| Label                | Name                                       |
+| :------------------- | :----------------------------------------- |
+| `aws-ap-northeast-1` | AWS - Asia Pacific Northeast 1 (Tokyo)     |
+| `aws-ap-northeast-2` | AWS - Asia Pacific Northeast 2 (Seoul)     |
+| `aws-ap-south-1`     | AWS - Asia South 1 (Mumbai)                |
+| `aws-ap-southeast-1` | AWS - Asia Pacific Southeast 1 (Singapore) |
+| `aws-ap-southeast-2` | AWS - Asia Pacific Southeast 2 (Sydney)    |
+| `aws-ca-central-1`   | AWS - CA Central 1 (Canada Central)        |
+| `aws-eu-central-1`   | AWS - EU Central 1 (Frankfurt)             |
+| `aws-eu-west-1`      | AWS - EU West 1 (Ireland)                  |
+| `aws-eu-west-2`      | AWS - EU West 2 (London)                   |
+| `aws-sa-east-1`      | AWS - South America East 1 (Sao Paulo)     |
+| `aws-us-east-1`      | AWS - US East 1 (N. Virginia)              |
+| `aws-us-east-2`      | AWS - US East 2 (Ohio)                     |
+| `aws-us-west-1`      | AWS - US West 1 (N. California)            |
+| `aws-us-west-2`      | AWS - US West 2 (Oregon)                   |
+| `do-ams2`            | Digital Ocean - Amsterdam 2                |
+| `do-ams3`            | Digital Ocean - Amsterdam 3                |
+| `do-blr1`            | Digital Ocean - Bangalore 1                |
+| `do-fra1`            | Digital Ocean - Frankfurt 1                |
+| `do-lon1`            | Digital Ocean - London 1                   |
+| `do-nyc1`            | Digital Ocean - New York 1                 |
+| `do-nyc2`            | Digital Ocean - New York 2                 |
+| `do-nyc3`            | Digital Ocean - New York 3                 |
+| `do-sfo1`            | Digital Ocean - San Francisco 1            |
+| `do-sfo2`            | Digital Ocean - San Francisco 2            |
+| `do-sgp1`            | Digital Ocean - Singapore 1                |
+| `do-tor1`            | Digital Ocean - Toronto 1                  |
+| `gcp-eu-west-1`      | Google Cloud - Europe West 1               |
+| `gcp-eu-west-2`      | Google Cloud - Europe West 2               |
+| `gcp-eu-west-3`      | Google Cloud - Europe West 3               |
+| `gcp-us-central-1`   | Google Cloud - US Central 1                |
+| `gcp-us-east-1`      | Google Cloud - US East 1                   |
+| `gcp-us-east-4`      | Google Cloud - US East 4                   |
+| `gcp-us-west-1`      | Google Cloud - US West 1                   |
+| `gcp-us-west-2`      | Google Cloud - US West 2                   |
+| `rs-dallas-1`        | Rackspace - Dallas 1                       |
 
 <!-- Auto Generated Below -->
 
@@ -68,6 +124,7 @@ If you would like to hide the CTA altogether, specify `hide-cta`:
 | `hideCta`      | `hide-cta`      | _(optional)_ Hide CTA?                                                                     | `boolean \| undefined` | `undefined`        |
 | `linkFormat`   | `link-format`   | _(optional)_ Link format structure, with `:product`, `:plan`, and `:features` placeholders | `string \| undefined`  | `undefined`        |
 | `productLabel` | `product-label` | URL-friendly slug (e.g. `"jawsdb-mysql"`)                                                  | `string`               | `undefined`        |
+| `regions`      | `regions`       | Specify region order                                                                       | `string \| undefined`  | `undefined`        |
 | `resourceId`   | `resource-id`   | _(optional)_ Is this modifying an existing resource?                                       | `string \| undefined`  | `undefined`        |
 
 

--- a/src/components/manifold-region-selector/manifold-region-selector.spec.ts
+++ b/src/components/manifold-region-selector/manifold-region-selector.spec.ts
@@ -11,4 +11,49 @@ describe('manifold-region-selector', () => {
 
     expect(regionSelector.filterRegions(Regions)).toEqual([one, two, three]);
   });
+
+  it('generates region codes like aws-us-east-1', () => {
+    const regionSelector = new ManifoldRegionSelector();
+
+    const nyc1: Catalog.Region = {
+      body: {
+        location: 'nyc1',
+        name: 'Digital Ocean - New York 1',
+        platform: 'digital-ocean',
+        priority: 95,
+      },
+      id: '235j17hyc3kw0bd5bgh799xdugq7a',
+      type: 'region',
+      version: 1,
+    };
+
+    expect(regionSelector.regionCode(nyc1)).toEqual('do-nyc1');
+  });
+
+  it('sorts regions based on preference, and includes ommitted at the end', () => {
+    const regionSelector = new ManifoldRegionSelector();
+
+    // Grab 7 regions
+    const regions = Regions.slice(0, 7);
+    const [one, two, three, four, five, six, seven] = Regions;
+    // Order: 3, 2, 1, 6, 4, 5 (7 omitted, but should be at the end)
+    const order = [
+      regionSelector.regionCode(three),
+      regionSelector.regionCode(two),
+      regionSelector.regionCode(one),
+      regionSelector.regionCode(six),
+      regionSelector.regionCode(four),
+      regionSelector.regionCode(five),
+    ];
+
+    expect(regionSelector.sortRegions(regions, order)).toEqual([
+      three,
+      two,
+      one,
+      six,
+      four,
+      five,
+      seven,
+    ]);
+  });
 });

--- a/src/components/manifold-region-selector/readme.md
+++ b/src/components/manifold-region-selector/readme.md
@@ -7,13 +7,14 @@
 
 ## Properties
 
-| Property         | Attribute    | Description | Type                  | Default            |
-| ---------------- | ------------ | ----------- | --------------------- | ------------------ |
-| `allowedRegions` | --           |             | `string[]`            | `[]`               |
-| `ariaLabel`      | `aria-label` |             | `string`              | `undefined`        |
-| `connection`     | --           |             | `Connection`          | `connections.prod` |
-| `name`           | `name`       |             | `string`              | `undefined`        |
-| `value`          | `value`      |             | `string \| undefined` | `undefined`        |
+| Property           | Attribute    | Description | Type                    | Default            |
+| ------------------ | ------------ | ----------- | ----------------------- | ------------------ |
+| `allowedRegions`   | --           |             | `string[]`              | `[]`               |
+| `ariaLabel`        | `aria-label` |             | `string`                | `undefined`        |
+| `connection`       | --           |             | `Connection`            | `connections.prod` |
+| `name`             | `name`       |             | `string`                | `undefined`        |
+| `preferredRegions` | --           |             | `string[] \| undefined` | `undefined`        |
+| `value`            | `value`      |             | `string \| undefined`   | `undefined`        |
 
 
 ## Events

--- a/src/index.html
+++ b/src/index.html
@@ -359,7 +359,8 @@ defineCustomElements(window);</code></pre>
                   <tr>
                     <td style="text-align:left;"><code>manifold-template-click</code></td>
                     <td style="text-align:left;">
-                      Fires whenever a user has clicked on a custom template.
+                      Fires whenever a user has clicked on a custom template (assuming it’s not
+                      hidden with <code>hide-templates</code>).
                     </td>
                     <td style="text-align:left;"><code>category</code></td>
                   </tr>
@@ -872,7 +873,10 @@ defineCustomElements(window);</code></pre>
             <h2>Example</h2>
             <div class="docs-example">
               <div class="docs-example-inner">
-                <manifold-plan-selector product-label="aiven-cassandra" regions="aws-us-east-2,gcp-us-east-1"/>
+                <manifold-plan-selector
+                  product-label="aiven-cassandra"
+                  regions="gcp-us-east-1,gcp-us-east-4,gcp-us-central-1,gcp-us-west-1,gcp-us-west-2,gcp-eu-west-1,gcp-eu-west-2,gcp-eu-west-3"
+                />
               </div>
             </div>
           </section>

--- a/src/index.html
+++ b/src/index.html
@@ -276,42 +276,45 @@ defineCustomElements(window);</code></pre>
               <p>A list of all Manifold services.</p>
               <pre><code class="html language-html">&lt;manifold-marketplace /&gt;
 </code></pre>
-              <h2 id="blacklistwhitelist">Blacklist/whitelist</h2>
+              <h2 id="catalogcuration">Catalog curation</h2>
               <p>
-                Blacklists (hidden products) and whitelists (allowed services) are two ways to
-                filter the services you’d like to display to users. Use either
-                <code>blacklist</code> or <code>whitelist</code>; <strong>don’t use both</strong>.
+                Our marketplace offers 2 options, either to show all services excluding a few, or
+                manually specifying the products that should be shown. For either option there is
+                either the <code>excludes</code> or <code>products</code> options—use either, but
+                not both in the same instance.
               </p>
-              <h4 id="blacklist">Blacklist</h4>
+              <h4 id="excludes">Excludes</h4>
               <p>
-                Blacklist will start with <strong>all products</strong>, but let you specify which
+                Excludes will start with <strong>all products</strong>, but let you specify which
                 ones you’d like to hide:
               </p>
-              <pre><code class="html language-html">&lt;manifold-marketplace blacklist="manifold-provider" /&gt;
+              <pre><code class="html language-html">&lt;manifold-marketplace excludes="manifold-provider" /&gt;
 </code></pre>
-              <h4 id="whitelist">Whitelist</h4>
+              <h4 id="products">Products</h4>
               <p>
-                Conversely, whitelisting will start with <strong>no products</strong>, and let you
-                manually specify every product that should be shown.
+                Conversely, manually specifying products will start with
+                <strong>no products</strong>, and let you manually specify every product that should
+                be shown.
               </p>
               <p>
-                A common usecase is using <code>whitelist</code> in conjuction with
+                A common usecase is using <code>products</code> in conjuction with
                 <code>hide-categories</code> (below).
               </p>
-              <pre><code class="html language-html">&lt;manifold-marketplace whitelist="aiven-redis,cloudamqp,iron_cache,iron_mq,memcachier-cache" /&gt;
+              <pre><code class="html language-html">&lt;manifold-marketplace products="aiven-redis,cloudamqp,iron_cache,iron_mq,memcachier-cache" /&gt;
 </code></pre>
               <h2 id="hidecategories">Hide categories</h2>
               <p>
                 Hiding the categories is a great way to have a more compact display. It’s
                 recommended to use this if you’re only displaying a few products via
-                <code>whitelist</code> (above):
+                <code>products</code> (above):
               </p>
               <pre><code class="html language-html">&lt;manifold-marketplace hide-categories /&gt;
 </code></pre>
               <h2 id="hidetemplatecards">Hide template cards</h2>
               <p>
                 Add the <code>hide-templates</code> attribute to hide external service template
-                cards (GitHub, Stripe, etc.):
+                cards (GitHub, Stripe, etc.). This will also hide their respective categories if no
+                other products are using them.
               </p>
               <pre><code class="html language-html">&lt;manifold-marketplace hide-templates /&gt;
 </code></pre>
@@ -388,18 +391,18 @@ defineCustomElements(window);</code></pre>
                 </thead>
                 <tbody>
                   <tr>
-                    <td><code>blacklist</code></td>
-                    <td><code>blacklist</code></td>
-                    <td>Comma-separated list of hidden products (labels)</td>
-                    <td><code>string | undefined</code></td>
-                    <td><code>undefined</code></td>
-                  </tr>
-                  <tr>
                     <td><code>connection</code></td>
                     <td>--</td>
                     <td><em>(hidden)</em> Passed by <code>&lt;manifold-connection&gt;</code></td>
                     <td><code>Connection</code></td>
                     <td><code>connections.prod</code></td>
+                  </tr>
+                  <tr>
+                    <td><code>excludes</code></td>
+                    <td><code>excludes</code></td>
+                    <td>Comma-separated list of hidden products (labels)</td>
+                    <td><code>string | undefined</code></td>
+                    <td><code>undefined</code></td>
                   </tr>
                   <tr>
                     <td><code>featured</code></td>
@@ -430,9 +433,9 @@ defineCustomElements(window);</code></pre>
                     <td><code>undefined</code></td>
                   </tr>
                   <tr>
-                    <td><code>whitelist</code></td>
-                    <td><code>whitelist</code></td>
-                    <td>Comma-separated list of allowed products (labels)</td>
+                    <td><code>products</code></td>
+                    <td><code>products</code></td>
+                    <td>Comma-separated list of shown products (labels)</td>
                     <td><code>string | undefined</code></td>
                     <td><code>undefined</code></td>
                   </tr>
@@ -621,7 +624,7 @@ defineCustomElements(window);</code></pre>
                 <code>manifold-planSelector-click</code> event (above). But it can also be turned
                 into an <code>&lt;a&gt;</code> tag by specifying <code>link-format</code>:
               </p>
-              <pre><code class="html language-html">&lt;manifold-product
+              <pre><code class="html language-html">&lt;manifold-plan-selector
   product-label="aiven-redis"
   link-format="/create/:product/?plan=:plan&amp;:features"
 /&gt;
@@ -634,10 +637,175 @@ defineCustomElements(window);</code></pre>
                 <a href="#data-components"><strong>data components</strong></a
                 >.
               </p>
-              <h3 id="hidingcta">Hiding CTA</h3>
+              <h2 id="hidingcta">Hiding CTA</h2>
               <p>If you would like to hide the CTA altogether, specify <code>hide-cta</code>:</p>
-              <pre><code class="html language-html">&lt;manifold-product product-label="till" hide-cta /&gt;
+              <pre><code class="html language-html">&lt;manifold-plan-selector product-label="till" hide-cta /&gt;
 </code></pre>
+              <h2 id="regions">Regions</h2>
+              <p>
+                Most of our products are regionless, but some plans let users specify the region. In
+                this case, you may optionally want to order the regions with the
+                <code>regions</code> attribute:
+              </p>
+              <pre><code class="html language-html">&lt;manifold-plan-selector regions="aws-eu-west-1,aws-eu-west-2,aws-us-east-1,aws-us-east-2" /&gt;
+</code></pre>
+              <p>
+                Regions will be ordered in the order specified. Any regions not mentioned will come
+                at the end, alphabetically. Any regions not supported by the plan will simply be
+                ignored (in this sense, you could even pass the same ordered list to all plans
+                regardless, if you’d like them always to display in the same order).
+              </p>
+              <h3 id="supportedregions">Supported regions</h3>
+              <table>
+                <thead>
+                  <tr>
+                    <th style="text-align:left;">Label</th>
+                    <th style="text-align:left;">Name</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td style="text-align:left;"><code>aws-ap-northeast-1</code></td>
+                    <td style="text-align:left;">AWS - Asia Pacific Northeast 1 (Tokyo)</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>aws-ap-northeast-2</code></td>
+                    <td style="text-align:left;">AWS - Asia Pacific Northeast 2 (Seoul)</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>aws-ap-south-1</code></td>
+                    <td style="text-align:left;">AWS - Asia South 1 (Mumbai)</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>aws-ap-southeast-1</code></td>
+                    <td style="text-align:left;">AWS - Asia Pacific Southeast 1 (Singapore)</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>aws-ap-southeast-2</code></td>
+                    <td style="text-align:left;">AWS - Asia Pacific Southeast 2 (Sydney)</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>aws-ca-central-1</code></td>
+                    <td style="text-align:left;">AWS - CA Central 1 (Canada Central)</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>aws-eu-central-1</code></td>
+                    <td style="text-align:left;">AWS - EU Central 1 (Frankfurt)</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>aws-eu-west-1</code></td>
+                    <td style="text-align:left;">AWS - EU West 1 (Ireland)</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>aws-eu-west-2</code></td>
+                    <td style="text-align:left;">AWS - EU West 2 (London)</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>aws-sa-east-1</code></td>
+                    <td style="text-align:left;">AWS - South America East 1 (Sao Paulo)</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>aws-us-east-1</code></td>
+                    <td style="text-align:left;">AWS - US East 1 (N. Virginia)</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>aws-us-east-2</code></td>
+                    <td style="text-align:left;">AWS - US East 2 (Ohio)</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>aws-us-west-1</code></td>
+                    <td style="text-align:left;">AWS - US West 1 (N. California)</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>aws-us-west-2</code></td>
+                    <td style="text-align:left;">AWS - US West 2 (Oregon)</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>do-ams2</code></td>
+                    <td style="text-align:left;">Digital Ocean - Amsterdam 2</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>do-ams3</code></td>
+                    <td style="text-align:left;">Digital Ocean - Amsterdam 3</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>do-blr1</code></td>
+                    <td style="text-align:left;">Digital Ocean - Bangalore 1</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>do-fra1</code></td>
+                    <td style="text-align:left;">Digital Ocean - Frankfurt 1</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>do-lon1</code></td>
+                    <td style="text-align:left;">Digital Ocean - London 1</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>do-nyc1</code></td>
+                    <td style="text-align:left;">Digital Ocean - New York 1</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>do-nyc2</code></td>
+                    <td style="text-align:left;">Digital Ocean - New York 2</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>do-nyc3</code></td>
+                    <td style="text-align:left;">Digital Ocean - New York 3</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>do-sfo1</code></td>
+                    <td style="text-align:left;">Digital Ocean - San Francisco 1</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>do-sfo2</code></td>
+                    <td style="text-align:left;">Digital Ocean - San Francisco 2</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>do-sgp1</code></td>
+                    <td style="text-align:left;">Digital Ocean - Singapore 1</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>do-tor1</code></td>
+                    <td style="text-align:left;">Digital Ocean - Toronto 1</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>gcp-eu-west-1</code></td>
+                    <td style="text-align:left;">Google Cloud - Europe West 1</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>gcp-eu-west-2</code></td>
+                    <td style="text-align:left;">Google Cloud - Europe West 2</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>gcp-eu-west-3</code></td>
+                    <td style="text-align:left;">Google Cloud - Europe West 3</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>gcp-us-central-1</code></td>
+                    <td style="text-align:left;">Google Cloud - US Central 1</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>gcp-us-east-1</code></td>
+                    <td style="text-align:left;">Google Cloud - US East 1</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>gcp-us-east-4</code></td>
+                    <td style="text-align:left;">Google Cloud - US East 4</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>gcp-us-west-1</code></td>
+                    <td style="text-align:left;">Google Cloud - US West 1</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>gcp-us-west-2</code></td>
+                    <td style="text-align:left;">Google Cloud - US West 2</td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>rs-dallas-1</code></td>
+                    <td style="text-align:left;">Rackspace - Dallas 1</td>
+                  </tr>
+                </tbody>
+              </table>
               <!-- Auto Generated Below -->
               <h2 id="properties">Properties</h2>
               <table>
@@ -683,6 +851,13 @@ defineCustomElements(window);</code></pre>
                     <td><code>undefined</code></td>
                   </tr>
                   <tr>
+                    <td><code>regions</code></td>
+                    <td><code>regions</code></td>
+                    <td>Specify region order</td>
+                    <td><code>string | undefined</code></td>
+                    <td><code>undefined</code></td>
+                  </tr>
+                  <tr>
                     <td><code>resourceId</code></td>
                     <td><code>resource-id</code></td>
                     <td><em>(optional)</em> Is this modifying an existing resource?</td>
@@ -697,7 +872,7 @@ defineCustomElements(window);</code></pre>
             <h2>Example</h2>
             <div class="docs-example">
               <div class="docs-example-inner">
-                <manifold-plan-selector product-label="logdna" />
+                <manifold-plan-selector product-label="aiven-cassandra" regions="aws-us-east-2,gcp-us-east-1"/>
               </div>
             </div>
           </section>
@@ -995,6 +1170,7 @@ document.addEventListener('manifold-planSelector-change', updateButton);
 &lt;div role="alert" data-success&gt;This is success message&lt;/div&gt;
 </code></pre>
               <p>You can style or hide these as desired.</p>
+              <p><em>Note: the error message for the input hides/shows on input blur</em></p>
               <h2 id="styling">Styling</h2>
               <p>
                 Whereas other components in this system take advantage of


### PR DESCRIPTION
## Reason for change
Allow consumers to specify region order.

Also rename `blacklist` and `whitelist` to the much-friendlier `excludes` and `products` (not technically _including_, you’re specifying every product that goes in the store manually, so `products` felt more to-the-point).

GCP appears first, even though it comes alphabetically after AWS 👇 

<img width="1193" alt="Screen Shot 2019-04-24 at 17 21 53" src="https://user-images.githubusercontent.com/1369770/56700246-8603fc80-66b6-11e9-939c-5a5002061584.png">
