### PR TITLE
Emit events on provision button

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -145,6 +145,9 @@ export namespace Components {
     */
     'formLabel'?: string;
     'inputId'?: string;
+    'onManifold-provisionButton-error'?: (event: CustomEvent) => void;
+    'onManifold-provisionButton-invalid'?: (event: CustomEvent) => void;
+    'onManifold-provisionButton-success'?: (event: CustomEvent) => void;
     'ownerId'?: string;
     'planId'?: string;
     'productId'?: string;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -145,6 +145,7 @@ export namespace Components {
     */
     'formLabel'?: string;
     'inputId'?: string;
+    'onManifold-provisionButton-click'?: (event: CustomEvent) => void;
     'onManifold-provisionButton-error'?: (event: CustomEvent) => void;
     'onManifold-provisionButton-invalid'?: (event: CustomEvent) => void;
     'onManifold-provisionButton-success'?: (event: CustomEvent) => void;

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
@@ -6,6 +6,18 @@ import { Connection, connections } from '../../utils/connections';
 
 /* eslint-disable no-console */
 
+interface SuccessMessage {
+  createdAt: string;
+  resourceName: string;
+  resourceId: string;
+  message: string;
+}
+
+interface ErrorMessage {
+  message: string;
+  resourceName: string;
+}
+
 @Component({ tag: 'manifold-data-provision-button' })
 export class ManifoldDataProvisionButton {
   @Element() el: HTMLElement;
@@ -63,22 +75,21 @@ export class ManifoldDataProvisionButton {
 
     // If successful, this will return 200 and stop here
     if (response.status >= 200 && response.status < 300) {
-      this.successEvent.emit({
+      const success: SuccessMessage = {
         createdAt: body.created_at,
         message: `${this.resourceName} successfully provisioned`,
         resourceId: body.id,
         resourceName: body.label,
-      });
-    } else if (Array.isArray(body)) {
-      this.errorEvent.emit({
-        message: body[0].message,
-        resourceName: this.resourceName,
-      });
+      };
+      this.successEvent.emit(success);
     } else {
-      this.errorEvent.emit({
-        message: body.message,
+      // Sometimes messages are an array, sometimes they aren’t. Different strokes!
+      const message = Array.isArray(body) ? body[0].message : body.message;
+      const error: ErrorMessage = {
+        message,
         resourceName: this.resourceName,
-      });
+      };
+      this.errorEvent.emit(error);
     }
   }
 

--- a/src/components/manifold-data-provision-button/readme.md
+++ b/src/components/manifold-data-provision-button/readme.md
@@ -39,19 +39,25 @@ Set the CTA text by adding anything between the opening and closing tags:
 
 `slot` can be attached to any HTML or JSX element. To read more about slots, see [Stencil’s Documentation][stencil-slot]
 
-## Error & success messages
+## Events
 
-An error or status message will display below the component, indicating
-success:
+For validation, error, and success messages, it will emit custom events.
 
-```html
-<div role="alert" data-error>This is an error message</div>
-<div role="alert" data-success>This is success message</div>
+```js
+document.addEventListener('manifold-provisionButton-success', ({ detail: { resourceName } }) =>
+  alert(`${resourceName} provisioned successfully! 🎉`)
+);
+document.addEventListener('manifold-provisionButton-error', ({ detail }) => console.log(detail));
+// {message: "bad_request: bad_request: No plan_id provided", resourceName: "auauau"}
+document.addEventListener('manifold-provisionButton-invalid', ({ detail }) => console.log(detail));
+// { value: 'MyResourceName', message: 'Must start with a lowercase letter, and use only lowercase, numbers, and hyphens.' }
 ```
 
-You can style or hide these as desired.
-
-_Note: the error message for the input hides/shows on input blur_
+| Name                               |                       Returns                        | Description                                                  |
+| :--------------------------------- | :--------------------------------------------------: | :----------------------------------------------------------- |
+| `manifold-provisionButton-success` | `message`, `resourceName`, `resourceId`, `createdAt` | Successful provision. Returns name, along with a resource ID |
+| `manifold-provisionButton-error`   |              `message`, `resourceName`               | Erred provision, along with information on what went wrong.  |
+| `manifold-provisionButton-invalid` |                  `value`, `message`                  | Fires if the resource name isn’t named properly.             |
 
 ## Styling
 
@@ -80,6 +86,15 @@ choice, or plain ol’ CSS.
 | `productId`    | `product-id`    |                                              | `string`              | `''`                            |
 | `productLabel` | `product-label` | Product to provision (slug)                  | `string`              | `undefined`                     |
 | `regionId`     | `region-id`     |                                              | `string \| undefined` | `globalRegion.id`               |
+
+
+## Events
+
+| Event                              | Description | Type                |
+| ---------------------------------- | ----------- | ------------------- |
+| `manifold-provisionButton-error`   |             | `CustomEvent<void>` |
+| `manifold-provisionButton-invalid` |             | `CustomEvent<void>` |
+| `manifold-provisionButton-success` |             | `CustomEvent<void>` |
 
 
 ----------------------------------------------

--- a/src/components/manifold-data-provision-button/readme.md
+++ b/src/components/manifold-data-provision-button/readme.md
@@ -44,20 +44,26 @@ Set the CTA text by adding anything between the opening and closing tags:
 For validation, error, and success messages, it will emit custom events.
 
 ```js
-document.addEventListener('manifold-provisionButton-success', ({ detail: { resourceName } }) =>
-  alert(`${resourceName} provisioned successfully! 🎉`)
+document.addEventListener('manifold-provisionButton-click', ({ detail: { resourceName } }) =>
+  console.info(`⌛ Provisioning ${resourceName} …`)
+);
+document.addEventListener(
+  'manifold-provisionButton-success',
+  ({ detail: { createdAt, resourceName } }) =>
+    alert(`🚀 ${resourceName} provisioned successfully on ${createdAt}!`)
 );
 document.addEventListener('manifold-provisionButton-error', ({ detail }) => console.log(detail));
 // {message: "bad_request: bad_request: No plan_id provided", resourceName: "auauau"}
 document.addEventListener('manifold-provisionButton-invalid', ({ detail }) => console.log(detail));
-// { value: 'MyResourceName', message: 'Must start with a lowercase letter, and use only lowercase, numbers, and hyphens.' }
+// {resourceName: "MyResourceName", message: "Must start with a lowercase letter, and use only lowercase, numbers, and hyphens."}
 ```
 
-| Name                               |                       Returns                        | Description                                                  |
-| :--------------------------------- | :--------------------------------------------------: | :----------------------------------------------------------- |
-| `manifold-provisionButton-success` | `message`, `resourceName`, `resourceId`, `createdAt` | Successful provision. Returns name, along with a resource ID |
-| `manifold-provisionButton-error`   |              `message`, `resourceName`               | Erred provision, along with information on what went wrong.  |
-| `manifold-provisionButton-invalid` |                  `value`, `message`                  | Fires if the resource name isn’t named properly.             |
+| Name                               |                       Returns                        | Description                                                                                                                 |
+| :--------------------------------- | :--------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------- |
+| `manifold-provisionButton-click`   |                    `resourceName`                    | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
+| `manifold-provisionButton-success` | `message`, `resourceName`, `resourceId`, `createdAt` | Successful provision. Returns name, along with a resource ID                                                                |
+| `manifold-provisionButton-error`   |              `message`, `resourceName`               | Erred provision, along with information on what went wrong.                                                                 |
+| `manifold-provisionButton-invalid` |              `message`, `resourceName`               | Fires if the resource name isn’t named properly.                                                                            |
 
 ## Styling
 
@@ -92,6 +98,7 @@ choice, or plain ol’ CSS.
 
 | Event                              | Description | Type                |
 | ---------------------------------- | ----------- | ------------------- |
+| `manifold-provisionButton-click`   |             | `CustomEvent<void>` |
 | `manifold-provisionButton-error`   |             | `CustomEvent<void>` |
 | `manifold-provisionButton-invalid` |             | `CustomEvent<void>` |
 | `manifold-provisionButton-success` |             | `CustomEvent<void>` |

--- a/src/index.html
+++ b/src/index.html
@@ -1166,15 +1166,53 @@ document.addEventListener('manifold-planSelector-change', updateButton);
                 slots, see
                 <a href="https://stenciljs.com/docs/templating-jsx/">Stencil’s Documentation</a>
               </p>
-              <h2 id="errorsuccessmessages">Error &amp; success messages</h2>
-              <p>
-                An error or status message will display below the component, indicating success:
-              </p>
-              <pre><code class="html language-html">&lt;div role="alert" data-error&gt;This is an error message&lt;/div&gt;
-&lt;div role="alert" data-success&gt;This is success message&lt;/div&gt;
+              <h2 id="events">Events</h2>
+              <p>For validation, error, and success messages, it will emit custom events.</p>
+              <pre><code class="js language-js">document.addEventListener('manifold-provisionButton-success', ({ detail: { resourceName } }) =&gt;
+  alert(`${resourceName} provisioned successfully! 🎉`)
+);
+document.addEventListener('manifold-provisionButton-error', ({ detail }) =&gt; console.log(detail));
+// {message: "bad_request: bad_request: No plan_id provided", resourceName: "auauau"}
+document.addEventListener('manifold-provisionButton-invalid', ({ detail }) =&gt; console.log(detail));
+// { value: 'MyResourceName', message: 'Must start with a lowercase letter, and use only lowercase, numbers, and hyphens.' }
 </code></pre>
-              <p>You can style or hide these as desired.</p>
-              <p><em>Note: the error message for the input hides/shows on input blur</em></p>
+              <table>
+                <thead>
+                  <tr>
+                    <th style="text-align:left;">Name</th>
+                    <th style="text-align:center;">Returns</th>
+                    <th style="text-align:left;">Description</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td style="text-align:left;"><code>manifold-provisionButton-success</code></td>
+                    <td style="text-align:center;">
+                      <code>message</code>, <code>resourceName</code>, <code>resourceId</code>,
+                      <code>createdAt</code>
+                    </td>
+                    <td style="text-align:left;">
+                      Successful provision. Returns name, along with a resource ID
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>manifold-provisionButton-error</code></td>
+                    <td style="text-align:center;">
+                      <code>message</code>, <code>resourceName</code>
+                    </td>
+                    <td style="text-align:left;">
+                      Erred provision, along with information on what went wrong.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="text-align:left;"><code>manifold-provisionButton-invalid</code></td>
+                    <td style="text-align:center;"><code>value</code>, <code>message</code></td>
+                    <td style="text-align:left;">
+                      Fires if the resource name isn’t named properly.
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
               <h2 id="styling">Styling</h2>
               <p>
                 Whereas other components in this system take advantage of
@@ -1260,6 +1298,33 @@ document.addEventListener('manifold-planSelector-change', updateButton);
                     <td></td>
                     <td><code>string | undefined</code></td>
                     <td><code>globalRegion.id</code></td>
+                  </tr>
+                </tbody>
+              </table>
+              <h2 id="events-1">Events</h2>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Event</th>
+                    <th>Description</th>
+                    <th>Type</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td><code>manifold-provisionButton-error</code></td>
+                    <td></td>
+                    <td><code>CustomEvent&lt;void&gt;</code></td>
+                  </tr>
+                  <tr>
+                    <td><code>manifold-provisionButton-invalid</code></td>
+                    <td></td>
+                    <td><code>CustomEvent&lt;void&gt;</code></td>
+                  </tr>
+                  <tr>
+                    <td><code>manifold-provisionButton-success</code></td>
+                    <td></td>
+                    <td><code>CustomEvent&lt;void&gt;</code></td>
                   </tr>
                 </tbody>
               </table>

--- a/src/index.html
+++ b/src/index.html
@@ -1168,8 +1168,13 @@ document.addEventListener('manifold-planSelector-change', updateButton);
               </p>
               <h2 id="events">Events</h2>
               <p>For validation, error, and success messages, it will emit custom events.</p>
-              <pre><code class="js language-js">document.addEventListener('manifold-provisionButton-success', ({ detail: { resourceName } }) =&gt;
-  alert(`${resourceName} provisioned successfully! 🎉`)
+              <pre><code class="js language-js">document.addEventListener('manifold-provisionButton-click', ({ detail: { resourceName } }) =&gt;
+  console.info(`⌛ Provisioning ${resourceName} …`)
+);
+document.addEventListener(
+  'manifold-provisionButton-success',
+  ({ detail: { createdAt, resourceName } }) =&gt;
+    alert(`🚀 ${resourceName} provisioned successfully on ${createdAt}!`)
 );
 document.addEventListener('manifold-provisionButton-error', ({ detail }) =&gt; console.log(detail));
 // {message: "bad_request: bad_request: No plan_id provided", resourceName: "auauau"}
@@ -1185,6 +1190,14 @@ document.addEventListener('manifold-provisionButton-invalid', ({ detail }) =&gt;
                   </tr>
                 </thead>
                 <tbody>
+                  <tr>
+                    <td style="text-align:left;"><code>manifold-provisionButton-click</code></td>
+                    <td style="text-align:center;"><code>resourceName</code></td>
+                    <td style="text-align:left;">
+                      Fires immediately when button is clicked. May be used to trigger a loading
+                      state, until <code>-success</code> or <code>-error</code> is received.
+                    </td>
+                  </tr>
                   <tr>
                     <td style="text-align:left;"><code>manifold-provisionButton-success</code></td>
                     <td style="text-align:center;">
@@ -1206,7 +1219,9 @@ document.addEventListener('manifold-provisionButton-invalid', ({ detail }) =&gt;
                   </tr>
                   <tr>
                     <td style="text-align:left;"><code>manifold-provisionButton-invalid</code></td>
-                    <td style="text-align:center;"><code>value</code>, <code>message</code></td>
+                    <td style="text-align:center;">
+                      <code>message</code>, <code>resourceName</code>
+                    </td>
                     <td style="text-align:left;">
                       Fires if the resource name isn’t named properly.
                     </td>
@@ -1311,6 +1326,11 @@ document.addEventListener('manifold-provisionButton-invalid', ({ detail }) =&gt;
                   </tr>
                 </thead>
                 <tbody>
+                  <tr>
+                    <td><code>manifold-provisionButton-click</code></td>
+                    <td></td>
+                    <td><code>CustomEvent&lt;void&gt;</code></td>
+                  </tr>
                   <tr>
                     <td><code>manifold-provisionButton-error</code></td>
                     <td></td>

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,3 +1,8 @@
+/**
+ * This grabs the manifold_api_token from local storage, and sets the auth header in requests.
+ * You may also pass through any other fetch options you’d like.
+ */
+
 export function withAuth(options?: RequestInit): RequestInit | undefined {
   const token = localStorage.getItem('manifold_api_token');
   if (typeof token !== 'string') return options;


### PR DESCRIPTION
## Reason for change
Like many brilliant softspoken individuals at Manifold, the provision button was too modest about its accomplishments.

I’ve encouraged it to be a little vocal.