### PR TITLE
Allow resource-initialized plan selection

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -26,6 +26,7 @@ export namespace Components {
     'preserveEvent': boolean;
     'product'?: Catalog.ExpandedProduct;
     'regions'?: string[];
+    'selectedResource'?: Gateway.Resource;
   }
   interface ManifoldActivePlanAttributes extends StencilHTMLAttributes {
     'hideCta'?: boolean;
@@ -35,6 +36,7 @@ export namespace Components {
     'preserveEvent'?: boolean;
     'product'?: Catalog.ExpandedProduct;
     'regions'?: string[];
+    'selectedResource'?: Gateway.Resource;
   }
 
   interface ManifoldBadge {}
@@ -174,6 +176,10 @@ export namespace Components {
     * Should the JS event still fire, even if link-format is passed?
     */
     'preserveEvent': boolean;
+    /**
+    * Specify any new string here to trigger a refresh
+    */
+    'tick': string;
   }
   interface ManifoldDataResourceListAttributes extends StencilHTMLAttributes {
     /**
@@ -189,6 +195,10 @@ export namespace Components {
     * Should the JS event still fire, even if link-format is passed?
     */
     'preserveEvent'?: boolean;
+    /**
+    * Specify any new string here to trigger a refresh
+    */
+    'tick'?: string;
   }
 
   interface ManifoldFeaturedService {
@@ -409,6 +419,7 @@ export namespace Components {
     'preserveEvent': boolean;
     'product'?: Catalog.Product;
     'regions'?: string[];
+    'resourceFeatures'?: Gateway.ResolvedFeature[];
   }
   interface ManifoldPlanDetailsAttributes extends StencilHTMLAttributes {
     'hideCta'?: boolean;
@@ -421,6 +432,7 @@ export namespace Components {
     'preserveEvent'?: boolean;
     'product'?: Catalog.Product;
     'regions'?: string[];
+    'resourceFeatures'?: Gateway.ResolvedFeature[];
   }
 
   interface ManifoldPlanMenu {
@@ -460,9 +472,9 @@ export namespace Components {
     */
     'regions'?: string;
     /**
-    * _(optional)_ Is this modifying an existing resource?
+    * Is this tied to an existing resource?
     */
-    'resourceId'?: string;
+    'resourceName'?: string;
   }
   interface ManifoldPlanSelectorAttributes extends StencilHTMLAttributes {
     /**
@@ -490,9 +502,9 @@ export namespace Components {
     */
     'regions'?: string;
     /**
-    * _(optional)_ Is this modifying an existing resource?
+    * Is this tied to an existing resource?
     */
-    'resourceId'?: string;
+    'resourceName'?: string;
   }
 
   interface ManifoldProductDetails {

--- a/src/components/manifold-active-plan/manifold-active-plan.tsx
+++ b/src/components/manifold-active-plan/manifold-active-plan.tsx
@@ -1,4 +1,4 @@
-import { Component, State, Prop } from '@stencil/core';
+import { Component, State, Prop, Watch } from '@stencil/core';
 
 @Component({
   tag: 'manifold-active-plan',
@@ -13,10 +13,18 @@ export class ManifoldActivePlan {
   @Prop() preserveEvent: boolean = false;
   @Prop() product?: Catalog.ExpandedProduct;
   @Prop() regions?: string[];
+  @Prop() selectedResource?: Gateway.Resource;
   @State() selectedPlanId: string;
+  @Watch('selectedResource') resourceChange(newResource: Gateway.Resource) {
+    if (newResource && newResource.plan && newResource.plan.id) {
+      this.selectPlan(newResource.plan.id);
+    }
+  }
 
   componentWillLoad() {
-    if (this.plans.length) {
+    if (this.selectedResource && this.selectedResource.plan && this.selectedResource.plan.id) {
+      this.selectPlan(this.selectedResource.plan.id);
+    } else if (this.plans.length) {
       this.selectPlan(this.plans[0].id);
     }
   }
@@ -41,6 +49,7 @@ export class ManifoldActivePlan {
           preserveEvent={this.preserveEvent}
           product={this.product}
           regions={this.regions}
+          resourceFeatures={this.selectedResource && this.selectedResource.features}
         />
       </div>,
     ];

--- a/src/components/manifold-active-plan/readme.md
+++ b/src/components/manifold-active-plan/readme.md
@@ -16,6 +16,7 @@ Hello
 | `preserveEvent`      | `preserve-event`       |             | `boolean`                      | `false`     |
 | `product`            | --                     |             | `ExpandedProduct \| undefined` | `undefined` |
 | `regions`            | --                     |             | `string[] \| undefined`        | `undefined` |
+| `selectedResource`   | --                     |             | `Resource \| undefined`        | `undefined` |
 
 
 ----------------------------------------------

--- a/src/components/manifold-data-resource-list/manifold-data-resource-list.tsx
+++ b/src/components/manifold-data-resource-list/manifold-data-resource-list.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, State, Event, EventEmitter, Element } from '@stencil/core';
+import { Component, Prop, State, Event, EventEmitter, Element, Watch } from '@stencil/core';
 import Tunnel from '../../data/connection';
 import { withAuth } from '../../utils/auth';
 import { Connection, connections } from '../../utils/connections';
@@ -27,11 +27,19 @@ export class ManifoldDataResourceList {
   @Prop() linkFormat?: string;
   /** Should the JS event still fire, even if link-format is passed?  */
   @Prop() preserveEvent: boolean = false;
+  /** Specify any new string here to trigger a refresh */
+  @Prop() tick: string;
   @State() resources?: Marketplace.Resource[];
   @Event({ eventName: 'manifold-resourceList-click', bubbles: true }) clickEvent: EventEmitter;
+  @Watch('tick') pullResources() {
+    this.fetchResources();
+  }
 
   componentWillLoad() {
-    // Don’t return this promise to invoke the loading state
+    this.fetchResources();
+  }
+
+  fetchResources() {
     fetch(`${this.connection.marketplace}/resources/?me`, withAuth())
       .then(response => response.json())
       .then((resources: Marketplace.Resource[]) => {

--- a/src/components/manifold-data-resource-list/manifold-data-resource-list.tsx
+++ b/src/components/manifold-data-resource-list/manifold-data-resource-list.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, State, Event, EventEmitter, Element, Watch } from '@stencil/core';
+import { Component, Prop, State, Event, EventEmitter, Element } from '@stencil/core';
 import Tunnel from '../../data/connection';
 import { withAuth } from '../../utils/auth';
 import { Connection, connections } from '../../utils/connections';
@@ -29,23 +29,26 @@ export class ManifoldDataResourceList {
   @Prop() preserveEvent: boolean = false;
   /** Specify any new string here to trigger a refresh */
   @Prop() tick: string;
+  @State() interval: number;
   @State() resources?: Marketplace.Resource[];
   @Event({ eventName: 'manifold-resourceList-click', bubbles: true }) clickEvent: EventEmitter;
-  @Watch('tick') pullResources() {
-    this.fetchResources();
-  }
 
   componentWillLoad() {
-    this.fetchResources();
+    this.interval = window.setInterval(() => this.fetchResources(), 3000);
+  }
+
+  componentDidUnload() {
+    window.clearInterval(this.interval);
   }
 
   fetchResources() {
     fetch(`${this.connection.marketplace}/resources/?me`, withAuth())
       .then(response => response.json())
       .then((resources: Marketplace.Resource[]) => {
-        this.resources = this.userResources(
-          [...resources].sort((a, b) => a.body.label.localeCompare(b.body.label))
-        );
+        if (Array.isArray(resources))
+          this.resources = this.userResources(
+            [...resources].sort((a, b) => a.body.label.localeCompare(b.body.label))
+          );
       });
   }
 

--- a/src/components/manifold-data-resource-list/readme.md
+++ b/src/components/manifold-data-resource-list/readme.md
@@ -37,6 +37,7 @@ slot:
 
 <!-- Auto Generated Below -->
 
+
 ## Properties
 
 | Property        | Attribute        | Description                                                    | Type                  | Default            |
@@ -44,6 +45,8 @@ slot:
 | `connection`    | --               | _(hidden)_ Passed by `<manifold-connection>`                   | `Connection`          | `connections.prod` |
 | `linkFormat`    | `link-format`    | Link format structure, with `:resource` placeholder            | `string \| undefined` | `undefined`        |
 | `preserveEvent` | `preserve-event` | Should the JS event still fire, even if link-format is passed? | `boolean`             | `false`            |
+| `tick`          | `tick`           | Specify any new string here to trigger a refresh               | `string`              | `undefined`        |
+
 
 ## Events
 
@@ -51,6 +54,7 @@ slot:
 | ----------------------------- | ----------- | ------------------- |
 | `manifold-resourceList-click` |             | `CustomEvent<void>` |
 
----
 
-_Built with [StencilJS](https://stenciljs.com/)_
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/manifold-plan-details/manifold-plan-details.spec.ts
+++ b/src/components/manifold-plan-details/manifold-plan-details.spec.ts
@@ -24,6 +24,43 @@ describe(`<manifold-plan-details>`, () => {
     });
   });
 
+  it('initializes features if given resource features', () => {
+    const planDetails = new PlanDetails();
+
+    planDetails.resourceFeatures = [
+      {
+        label: 'sandwich',
+        name: 'Choice Sandwich',
+        type: 'string',
+        value: { displayValue: 'Mint Sandwich', value: 'mint' },
+      },
+      {
+        label: 'juice',
+        name: 'Jus Ensache',
+        type: 'number',
+        value: { displayValue: '1410 Litres', suffix: 'Litres', value: 1410 },
+      },
+      {
+        label: 'crackers',
+        name: 'Smashed Crackers',
+        type: 'boolean',
+        value: { displayValue: 'Yes', value: true },
+      },
+      {
+        label: 'cheese',
+        name: 'Cheese',
+        type: 'string',
+        value: { displayValue: 'Premium Surprise Cheese', value: 'nochoice' },
+      },
+    ];
+    expect(planDetails.initialFeatures()).toEqual({
+      sandwich: 'mint',
+      juice: 1410,
+      crackers: true,
+      cheese: 'nochoice',
+    });
+  });
+
   it('filters out non-custom features', () => {
     const planDetails = new PlanDetails();
     planDetails.plan = ExpandedPlanCustom;

--- a/src/components/manifold-plan-details/readme.md
+++ b/src/components/manifold-plan-details/readme.md
@@ -7,15 +7,16 @@
 
 ## Properties
 
-| Property             | Attribute              | Description | Type                        | Default     |
-| -------------------- | ---------------------- | ----------- | --------------------------- | ----------- |
-| `hideCta`            | `hide-cta`             |             | `boolean \| undefined`      | `false`     |
-| `isExistingResource` | `is-existing-resource` |             | `boolean \| undefined`      | `false`     |
-| `linkFormat`         | `link-format`          |             | `string \| undefined`       | `undefined` |
-| `plan`               | --                     |             | `ExpandedPlan \| undefined` | `undefined` |
-| `preserveEvent`      | `preserve-event`       |             | `boolean`                   | `false`     |
-| `product`            | --                     |             | `Product \| undefined`      | `undefined` |
-| `regions`            | --                     |             | `string[] \| undefined`     | `undefined` |
+| Property             | Attribute              | Description | Type                             | Default     |
+| -------------------- | ---------------------- | ----------- | -------------------------------- | ----------- |
+| `hideCta`            | `hide-cta`             |             | `boolean \| undefined`           | `false`     |
+| `isExistingResource` | `is-existing-resource` |             | `boolean \| undefined`           | `false`     |
+| `linkFormat`         | `link-format`          |             | `string \| undefined`            | `undefined` |
+| `plan`               | --                     |             | `ExpandedPlan \| undefined`      | `undefined` |
+| `preserveEvent`      | `preserve-event`       |             | `boolean`                        | `false`     |
+| `product`            | --                     |             | `Product \| undefined`           | `undefined` |
+| `regions`            | --                     |             | `string[] \| undefined`          | `undefined` |
+| `resourceFeatures`   | --                     |             | `ResolvedFeature[] \| undefined` | `undefined` |
 
 
 ## Events

--- a/src/components/manifold-plan-selector/readme.md
+++ b/src/components/manifold-plan-selector/readme.md
@@ -129,7 +129,7 @@ same order).
 | `preserveEvent` | `preserve-event` | Should the JS event still fire, even if link-format is passed?                             | `boolean`              | `false`            |
 | `productLabel`  | `product-label`  | URL-friendly slug (e.g. `"jawsdb-mysql"`)                                                  | `string`               | `undefined`        |
 | `regions`       | `regions`        | Specify region order                                                                       | `string \| undefined`  | `undefined`        |
-| `resourceId`    | `resource-id`    | _(optional)_ Is this modifying an existing resource?                                       | `string \| undefined`  | `undefined`        |
+| `resourceName`  | `resource-name`  | Is this tied to an existing resource?                                                      | `string \| undefined`  | `undefined`        |
 
 
 ----------------------------------------------

--- a/src/index.html
+++ b/src/index.html
@@ -884,9 +884,9 @@ defineCustomElements(window);</code></pre>
                     <td><code>undefined</code></td>
                   </tr>
                   <tr>
-                    <td><code>resourceId</code></td>
-                    <td><code>resource-id</code></td>
-                    <td><em>(optional)</em> Is this modifying an existing resource?</td>
+                    <td><code>resourceName</code></td>
+                    <td><code>resource-name</code></td>
+                    <td>Is this tied to an existing resource?</td>
                     <td><code>string | undefined</code></td>
                     <td><code>undefined</code></td>
                   </tr>
@@ -1470,6 +1470,13 @@ document.addEventListener('manifold-provisionButton-invalid', ({ detail }) =&gt;
                     <td>Should the JS event still fire, even if link-format is passed?</td>
                     <td><code>boolean</code></td>
                     <td><code>false</code></td>
+                  </tr>
+                  <tr>
+                    <td><code>tick</code></td>
+                    <td><code>tick</code></td>
+                    <td>Specify any new string here to trigger a refresh</td>
+                    <td><code>string</code></td>
+                    <td><code>undefined</code></td>
                   </tr>
                 </tbody>
               </table>

--- a/src/types/gateway.ts
+++ b/src/types/gateway.ts
@@ -107,7 +107,7 @@ namespace Gateway {
     value: ResolvedFeatureValue;
   }
   export interface ResolvedFeatureValue {
-    value?: object;
+    value?: boolean | string | number;
     displayValue?: string;
     // Applied to the end of the number for display, for example the ‘GB’ in ‘20 GB’.
     suffix?: string;


### PR DESCRIPTION
## Reason for change
Extends plan selector to be initialized with only a `resource-name` (and auth)

Resource in Dashboard:
<img width="626" alt="Screen Shot 2019-04-25 at 22 34 07" src="https://user-images.githubusercontent.com/1369770/56783739-6ea63b80-67aa-11e9-9f2b-c7ec9fb2f309.png">

Plan selector on page load (same features & cost):

<img width="1076" alt="Screen Shot 2019-04-25 at 22 34 12" src="https://user-images.githubusercontent.com/1369770/56783770-99908f80-67aa-11e9-8c1c-1c1e90919837.png">

## Testing
<!-- For someone unfamiliar with the issue, how should this be tested? -->
