### PR TITLE
UI Tweaks

### DIFF
--- a/src/components/manifold-product-page/manifold-product-page.css
+++ b/src/components/manifold-product-page/manifold-product-page.css
@@ -82,7 +82,7 @@
   grid-template-columns: 1fr;
 
   @media (min-width: 600px) {
-    grid-template-columns: 16rem auto;
+    grid-template-columns: max-content auto;
   }
 }
 
@@ -100,6 +100,12 @@
   & > * {
     display: flex;
   }
+}
+
+.link-text {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .sidebar-inner {

--- a/src/components/manifold-product-page/manifold-product-page.tsx
+++ b/src/components/manifold-product-page/manifold-product-page.tsx
@@ -65,7 +65,7 @@ export class ManifoldProductPage {
                 {this.hideCta !== true && (
                   <div class="sidebar-cta">
                     <manifold-link-button href={this.ctaLink} onClick={this.onClick}>
-                      Get {name}
+                      <span class="link-text">Get {name} Duis mollis, est non commodo luctus</span>
                       <manifold-icon icon={arrow_right} marginLeft />
                     </manifold-link-button>
                   </div>

--- a/src/components/manifold-resource-details/manifold-resource-details.tsx
+++ b/src/components/manifold-resource-details/manifold-resource-details.tsx
@@ -21,6 +21,7 @@ export class ManifoldResourceDetails {
   @Prop() resourceName: string;
   @State() resource?: Gateway.Resource;
   @Watch('resourceName') resourceChange(newName: string) {
+    this.resource = undefined;
     this.fetchResource(newName);
   }
 


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

- loading state when switching resource details
- handle 'get [service]' button overflow for long names.

<img width="953" alt="Screen Shot 2019-04-29 at 9 08 55 PM" src="https://user-images.githubusercontent.com/10498708/56934741-a4596600-6ac3-11e9-94e3-afcbde3d44f5.png">

## Testing
<!-- For someone unfamiliar with the issue, how should this be tested? -->
