### PR TITLE
added outline for product logos

### DIFF
--- a/src/components/manifold-product-page/manifold-product-page.css
+++ b/src/components/manifold-product-page/manifold-product-page.css
@@ -156,6 +156,7 @@
   width: 32.5%;
   min-width: 3rem;
   margin-top: calc(var(--overlap) * -1);
+  filter: drop-shadow(0 0 5px rgba(0, 0, 0, 0.2));
 
   & img {
     display: block;
@@ -165,6 +166,7 @@
     min-height: 3rem;
     border-radius: var(--mf-radius-m);
     object-fit: contain;
+    filter: url(#drop-shadow);
   }
 }
 

--- a/src/components/manifold-product-page/manifold-product-page.tsx
+++ b/src/components/manifold-product-page/manifold-product-page.tsx
@@ -40,6 +40,22 @@ export class ManifoldProductPage {
     }
   };
 
+  get imageOutlineFilter() {
+    return (
+      <svg height="0" xmlns="http://www.w3.org/2000/svg">
+        <filter id="drop-shadow">
+          <feMorphology operator="dilate" radius="1" in="SourceAlpha" result="dilated" />
+          <feFlood flood-color="rgba(255,255,255,1)" flood-opacity="1" result="flood" />
+          <feComposite in2="dilated" in="flood" operator="in" />
+          <feMerge>
+            <feMergeNode />
+            <feMergeNode in="SourceGraphic" />
+          </feMerge>
+        </filter>
+      </svg>
+    );
+  }
+
   render() {
     if (this.product) {
       const { documentation_url, support_email, name, label, logo_url, tags } = this.product.body;
@@ -52,6 +68,7 @@ export class ManifoldProductPage {
               <div class="sidebar-inner">
                 <div class="sidebar-card" style={{ '--background-gradient': gradient }}>
                   <div class="product-logo">
+                    {this.imageOutlineFilter}
                     <img src={logo_url} alt={name} itemprop="logo" />
                   </div>
                   <h2 class="product-name" itemprop="name">


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

Some of the logos look good, some look ok, and some look bad. Here's a list of the one's that I think look better, about the same, or worse with this change. This is all personal preference though.

| Product                 | 👍  | 🤷‍♂  | 👎   |
| ----------------- | ---- | ---- | ---- |
| ZeroSix                  |         |         | ✅ |
| OAuth.io (needs higher res logo)    |  ✅    |         |     |
| Elegant CMS         | ✅   |        |     |
| Aiven Cassandra  |          |  ✅  |      |
| Aiven Elasticsearch |       |  ✅  |      |
| Aiven Kafka           |          |  ✅  |      |
| Aiven PostgreSQL  |          |  ✅  |      |
| Aiven Redis .          |          |    |   ✅   |
| Dumper                  |       | ✅    |      |
| JawsDB Maria        |     |    ✅     |      |
| JawsDB MySQL     |     |     ✅    |      |
| JawsDB PostgreSQL  |     |    ✅     |      |
| LogDNA                  | ✅    |         |      |
| Timber                    |       | ✅   |      |
| CloudAMQP           | ✅   |      |     |
| IronCache              | ✅   |      |     |
| IronMQ                   | ✅   |      |     |
| MemCachier          |       | ✅   |      |
| Mailgun                   | ✅   |      |     |
| Posthook                | ✅   |      |     |
| Scaledrone             |       |  ✅    |     |
| Till                           |       | ✅   |      |
| Aiven Grafana        |       | ✅   |      |
| InfluxDB                 | ✅   |      |     |
| Informant               | ✅   |      |     |
| Scout                     |    |   ✅   |     |
| StatusHub             | ✅   |      |     |
| Blitline                    |    |  ✅    |     |
| Custom Image regognition    |    | ✅     |     |
| Generic Image Tagging          |      |  ✅    |     |
| HyPDF                    |    |  ✅    |     |
| Piio                         |    |  ✅    |     |
| Valence                  |       | ✅ |     |
| Ziggeo                   |      |      |  ✅ |
| Bonsai Elasticsearch  |      |      |  ✅ |
| Websolr                   |      | ✅  |      |
| Cloudcube              |      |  ✅    |     |
| Prefab.cloud            |       | ✅  |     |
| IronWorker               | ✅  |     |      |
| PDFShirft                |       | ✅  |     |

## Testing

Open various products in the marketplace component to see how the logos appear with the outline.
