### PR TITLE
Fix homepage link highlight

### DIFF
--- a/docs/docs/theming.md
+++ b/docs/docs/theming.md
@@ -14,7 +14,7 @@ However, there are times when it’s advantageous to overwrite some variables.
 In that usecase, CSS variables are recommended.
 
 We recommend setting variables on `body`, which will override
-`@manifoldco/ui/dist/manifold.css` which are scoped to `:host`:
+`@manifoldco/ui/dist/manifold.css` which are scoped to `:root`:
 
 ```css
 body {

--- a/docs/src/components/Sidebar.tsx
+++ b/docs/src/components/Sidebar.tsx
@@ -23,10 +23,18 @@ const WOMBAT = 'wombat';
 
 const themes = [[DEFAULT, 'Default'], [MANIFOLD, 'Manifold'], [SAMMY, 'Sammy'], [WOMBAT, 'Wombat']];
 
+// Handle link styling (needed because this doesn’t work with search params)
 const linkStyling = ({ location, href }: LinkGetProps): any | null => {
   if (typeof window === 'undefined') return null;
-  if (location.href.includes(href)) {
-    return { 'aria-current': true };
+  const pathname = href.replace(/\?.*$/, '');
+  const active = { 'aria-current': true };
+  // If this page is active, highlight this link
+  if (location.pathname.includes(pathname)) {
+    return active;
+  }
+  // Otherwise if this is the homepage, highlight Getting Started
+  if (pathname.includes('/getting-started') && location.pathname === '/') {
+    return active;
   }
   return null;
 };


### PR DESCRIPTION
## Reason for change
When on the homepage, **Getting Started** wasn’t highlighted. But if you clicked on it, it would highlight on the left, even though the page on the right stayed the same. This fixes that bug.

## Testing
Make sure **Getting Started** highlights on `/`. Also make sure the other active links work.
