### PR TITLE
Add products

### DIFF
--- a/stories/manifold-plan-selector.stories.js
+++ b/stories/manifold-plan-selector.stories.js
@@ -13,5 +13,17 @@ storiesOf('Plan Selector', module)
     'Memcachier',
     () => '<manifold-plan-selector product-label="memcachier-cache"></manifold-plan-selector>'
   )
+  .add(
+    'Prefab.cloud',
+    () => '<manifold-plan-selector product-label="prefab"></manifold-plan-selector>'
+  )
+  .add(
+    'Ximilar Image Recognition',
+    () => '<manifold-plan-selector product-label="custom-recognition"></manifold-plan-selector>'
+  )
+  .add(
+    'Ximilar Tagging',
+    () => '<manifold-plan-selector product-label="generic-tagging"></manifold-plan-selector>'
+  )
   .add('Zerosix', () => '<manifold-plan-selector product-label="zerosix"></manifold-plan-selector>')
   .add('Ziggeo', () => '<manifold-plan-selector product-label="ziggeo"></manifold-plan-selector>');


### PR DESCRIPTION
## Reason for change
This just adds additional plan stories to the sidebar, making it easier to view.

## Testing
Nothing to test; these just show up in the Storybook sidebar now.