### PR TITLE
Add more screenshot tests

### DIFF
--- a/.happo.js
+++ b/.happo.js
@@ -14,5 +14,6 @@ module.exports = {
   type: 'plain',
   prerender: false,
   setupScript: path.resolve(__dirname, 'happoSetup.js'),
+  stylesheets: [path.join(__dirname, 'dist/manifold/manifold.css')],
   plugins: [happoPluginTypeScript()],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -6625,8 +6625,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6650,15 +6649,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6675,22 +6672,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6821,8 +6815,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6836,7 +6829,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6853,7 +6845,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6862,15 +6853,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6891,7 +6880,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6980,8 +6968,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6995,7 +6982,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7091,8 +7077,7 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7134,7 +7119,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7156,7 +7140,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7205,15 +7188,13 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/components/manifold-active-plan/manifold-active-plan-happo.ts
+++ b/src/components/manifold-active-plan/manifold-active-plan-happo.ts
@@ -1,0 +1,11 @@
+import product from '../../spec/mock/jawsdb/product.json';
+import plans from '../../spec/mock/jawsdb/plans.json';
+import fromJSON from '../../spec/mock/fromJSON';
+
+export const jawsDB = () => {
+  const plan = document.createElement('manifold-active-plan');
+  plan.plans = fromJSON(plans);
+  plan.product = fromJSON(product);
+
+  document.body.appendChild(plan);
+};

--- a/src/components/manifold-marketplace-grid/manifold-marketplace-grid-happo.ts
+++ b/src/components/manifold-marketplace-grid/manifold-marketplace-grid-happo.ts
@@ -1,0 +1,5 @@
+export const skeleton = () => {
+  const grid = document.createElement('manifold-marketplace-grid');
+
+  document.body.appendChild(grid);
+};

--- a/src/components/manifold-marketplace-grid/manifold-marketplace-grid-happo.ts
+++ b/src/components/manifold-marketplace-grid/manifold-marketplace-grid-happo.ts
@@ -1,5 +1,15 @@
+import products from '../../spec/mock/products.json';
+import fromJSON from '../../spec/mock/fromJSON';
+
 export const skeleton = () => {
   const grid = document.createElement('manifold-marketplace-grid');
+
+  document.body.appendChild(grid);
+};
+
+export const allProducts = () => {
+  const grid = document.createElement('manifold-marketplace-grid');
+  grid.services = fromJSON(products);
 
   document.body.appendChild(grid);
 };

--- a/src/components/manifold-marketplace-grid/manifold-marketplace-grid.tsx
+++ b/src/components/manifold-marketplace-grid/manifold-marketplace-grid.tsx
@@ -27,7 +27,7 @@ export class ManifoldMarketplaceGrid {
   @State() activeCategory?: string;
   @State() observer: IntersectionObserver;
   @State() scrollToCategory: string | null;
-  @State() skeleton: boolean = true;
+  @State() skeleton: boolean = false;
   @State() search: string = '';
   @Watch('services') servicesLoaded(services: Catalog.Product[]) {
     if (services.length) this.skeleton = false;
@@ -76,7 +76,10 @@ export class ManifoldMarketplaceGrid {
 
   get filteredServices(): Catalog.Product[] {
     // While services are loading, display skeleton cards
-    if (!this.services || !this.services.length) return skeletonProducts;
+    if (!this.services || !this.services.length) {
+      this.skeleton = true;
+      return skeletonProducts;
+    }
 
     let services: Catalog.Product[] = [];
 

--- a/src/spec/mock/fromJSON.ts
+++ b/src/spec/mock/fromJSON.ts
@@ -1,0 +1,3 @@
+export default function fromJSON(json: object) {
+  return JSON.parse(JSON.stringify(json));
+}

--- a/src/spec/mock/jawsdb/plans.json
+++ b/src/spec/mock/jawsdb/plans.json
@@ -1,0 +1,1332 @@
+[
+  {
+    "body": {
+      "cost": 80000,
+      "features": [
+        { "feature": "static-ram", "value": "ram-generated-21" },
+        { "feature": "static-storage", "value": "storage-generated-22" },
+        { "feature": "static-connections", "value": "connections-generated-23" },
+        { "feature": "static-single-tenant", "value": "true" },
+        { "feature": "static-high-availability", "value": "true" },
+        { "feature": "static-rollback", "value": "rollback-generated-20" }
+      ],
+      "label": "hammerheadalpha",
+      "name": "Hammerhead Alpha",
+      "product_id": "234w1jyaum5j0aqe3g3bmbqjgf20p",
+      "provider_id": "2346mdxcuca9ez2n93f72nb2fpjgu",
+      "regions": ["235mhkk15ky7ha9qpu4gazrqjt2gr", "235m2c51y0625vvtk6ptf55bhpkty"],
+      "resizable_to": ["2353vuh3mpw4ufnqjwnentch3wmkj"],
+      "state": "available",
+      "trial_days": 0,
+      "defaultCost": 80000,
+      "expanded_features": [
+        {
+          "label": "static-ram",
+          "name": "RAM",
+          "type": "string",
+          "values": [
+            { "label": "ram-generated-0", "name": "Shared" },
+            { "label": "ram-generated-10", "name": "1 GB" },
+            { "label": "ram-generated-14", "name": "2 GB" },
+            { "label": "ram-generated-17", "name": "4 GB" },
+            { "label": "ram-generated-21", "name": "8 GB" }
+          ],
+          "value": { "label": "ram-generated-21", "name": "8 GB" },
+          "value_string": "8 GB"
+        },
+        {
+          "label": "static-storage",
+          "name": "Storage",
+          "type": "string",
+          "values": [
+            { "label": "storage-generated-1", "name": "250 MB" },
+            { "label": "storage-generated-6", "name": "1 GB" },
+            { "label": "storage-generated-8", "name": "2.5 GB" },
+            { "label": "storage-generated-11", "name": "5 GB" },
+            { "label": "storage-generated-15", "name": "50 GB" },
+            { "label": "storage-generated-18", "name": "100 GB" },
+            { "label": "storage-generated-22", "name": "250 GB" }
+          ],
+          "value": { "label": "storage-generated-22", "name": "250 GB" },
+          "value_string": "250 GB"
+        },
+        {
+          "label": "static-connections",
+          "name": "Connections",
+          "type": "string",
+          "values": [
+            { "label": "connections-generated-2", "name": "10" },
+            { "label": "connections-generated-7", "name": "15" },
+            { "label": "connections-generated-9", "name": "30" },
+            { "label": "connections-generated-12", "name": "66" },
+            { "label": "connections-generated-16", "name": "150" },
+            { "label": "connections-generated-19", "name": "300" },
+            { "label": "connections-generated-23", "name": "600" }
+          ],
+          "value": { "label": "connections-generated-23", "name": "600" },
+          "value_string": "600"
+        },
+        {
+          "label": "static-single-tenant",
+          "name": "Single Tenant",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }],
+          "value": { "label": "true", "name": "true" },
+          "value_string": "true"
+        },
+        {
+          "label": "static-high-availability",
+          "name": "High Availability",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }],
+          "value": { "label": "true", "name": "true" },
+          "value_string": "true"
+        },
+        {
+          "label": "static-rollback",
+          "name": "Rollback",
+          "type": "string",
+          "values": [
+            { "label": "rollback-generated-4", "name": "0 Days" },
+            { "label": "rollback-generated-13", "name": "1 Day" },
+            { "label": "rollback-generated-20", "name": "2 Days" }
+          ],
+          "value": { "label": "rollback-generated-20", "name": "2 Days" },
+          "value_string": "2 Days"
+        }
+      ],
+      "free": false
+    },
+    "id": "2354cmvu65xccvw974kfjh616b2x0",
+    "type": "plan",
+    "version": 1
+  },
+  {
+    "body": {
+      "cost": 500,
+      "features": [
+        { "feature": "static-ram", "value": "ram-generated-0" },
+        { "feature": "static-storage", "value": "storage-generated-1" },
+        { "feature": "static-connections", "value": "connections-generated-2" },
+        { "feature": "static-single-tenant", "value": "false" },
+        { "feature": "static-rollback", "value": "rollback-generated-4" },
+        { "feature": "static-high-availability", "value": "false" }
+      ],
+      "label": "kitefin",
+      "name": "Kitefin",
+      "product_id": "234w1jyaum5j0aqe3g3bmbqjgf20p",
+      "provider_id": "2346mdxcuca9ez2n93f72nb2fpjgu",
+      "regions": ["235mhkk15ky7ha9qpu4gazrqjt2gr", "235m2c51y0625vvtk6ptf55bhpkty"],
+      "resizable_to": ["23556xtwybe9zv877e6g2c7ygnxpj", "2358u3xj4d8x5qud8x1atgafwchfy"],
+      "state": "available",
+      "trial_days": 0,
+      "defaultCost": 500,
+      "expanded_features": [
+        {
+          "label": "static-ram",
+          "name": "RAM",
+          "type": "string",
+          "values": [
+            { "label": "ram-generated-0", "name": "Shared" },
+            { "label": "ram-generated-10", "name": "1 GB" },
+            { "label": "ram-generated-14", "name": "2 GB" },
+            { "label": "ram-generated-17", "name": "4 GB" },
+            { "label": "ram-generated-21", "name": "8 GB" }
+          ],
+          "value": { "label": "ram-generated-0", "name": "Shared" },
+          "value_string": "Shared"
+        },
+        {
+          "label": "static-storage",
+          "name": "Storage",
+          "type": "string",
+          "values": [
+            { "label": "storage-generated-1", "name": "250 MB" },
+            { "label": "storage-generated-6", "name": "1 GB" },
+            { "label": "storage-generated-8", "name": "2.5 GB" },
+            { "label": "storage-generated-11", "name": "5 GB" },
+            { "label": "storage-generated-15", "name": "50 GB" },
+            { "label": "storage-generated-18", "name": "100 GB" },
+            { "label": "storage-generated-22", "name": "250 GB" }
+          ],
+          "value": { "label": "storage-generated-1", "name": "250 MB" },
+          "value_string": "250 MB"
+        },
+        {
+          "label": "static-connections",
+          "name": "Connections",
+          "type": "string",
+          "values": [
+            { "label": "connections-generated-2", "name": "10" },
+            { "label": "connections-generated-7", "name": "15" },
+            { "label": "connections-generated-9", "name": "30" },
+            { "label": "connections-generated-12", "name": "66" },
+            { "label": "connections-generated-16", "name": "150" },
+            { "label": "connections-generated-19", "name": "300" },
+            { "label": "connections-generated-23", "name": "600" }
+          ],
+          "value": { "label": "connections-generated-2", "name": "10" },
+          "value_string": "10"
+        },
+        {
+          "label": "static-single-tenant",
+          "name": "Single Tenant",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }],
+          "value": { "label": "false", "name": "false" },
+          "value_string": "false"
+        },
+        {
+          "label": "static-high-availability",
+          "name": "High Availability",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }],
+          "value": { "label": "false", "name": "false" },
+          "value_string": "false"
+        },
+        {
+          "label": "static-rollback",
+          "name": "Rollback",
+          "type": "string",
+          "values": [
+            { "label": "rollback-generated-4", "name": "0 Days" },
+            { "label": "rollback-generated-13", "name": "1 Day" },
+            { "label": "rollback-generated-20", "name": "2 Days" }
+          ],
+          "value": { "label": "rollback-generated-4", "name": "0 Days" },
+          "value_string": "0 Days"
+        }
+      ],
+      "free": false
+    },
+    "id": "235abe2ba8b39e941u2h70ayw5m9j",
+    "type": "plan",
+    "version": 1
+  },
+  {
+    "body": {
+      "cost": 11000,
+      "features": [
+        { "feature": "static-ram", "value": "ram-generated-14" },
+        { "feature": "static-storage", "value": "storage-generated-15" },
+        { "feature": "static-connections", "value": "connections-generated-16" },
+        { "feature": "static-single-tenant", "value": "true" },
+        { "feature": "static-rollback", "value": "rollback-generated-13" },
+        { "feature": "static-high-availability", "value": "false" }
+      ],
+      "label": "thresher",
+      "name": "Thresher",
+      "product_id": "234w1jyaum5j0aqe3g3bmbqjgf20p",
+      "provider_id": "2346mdxcuca9ez2n93f72nb2fpjgu",
+      "regions": ["235mhkk15ky7ha9qpu4gazrqjt2gr", "235m2c51y0625vvtk6ptf55bhpkty"],
+      "resizable_to": [
+        "2352ekm35rff86k1w1yfcxhex2waw",
+        "2350hd8b2fe5a5vzj21xzuf558vku",
+        "235e1x01g4hgyf86e4wyp16x4k738",
+        "2353vuh3mpw4ufnqjwnentch3wmkj",
+        "2354cmvu65xccvw974kfjh616b2x0"
+      ],
+      "state": "available",
+      "trial_days": 0,
+      "defaultCost": 11000,
+      "expanded_features": [
+        {
+          "label": "static-ram",
+          "name": "RAM",
+          "type": "string",
+          "values": [
+            { "label": "ram-generated-0", "name": "Shared" },
+            { "label": "ram-generated-10", "name": "1 GB" },
+            { "label": "ram-generated-14", "name": "2 GB" },
+            { "label": "ram-generated-17", "name": "4 GB" },
+            { "label": "ram-generated-21", "name": "8 GB" }
+          ],
+          "value": { "label": "ram-generated-14", "name": "2 GB" },
+          "value_string": "2 GB"
+        },
+        {
+          "label": "static-storage",
+          "name": "Storage",
+          "type": "string",
+          "values": [
+            { "label": "storage-generated-1", "name": "250 MB" },
+            { "label": "storage-generated-6", "name": "1 GB" },
+            { "label": "storage-generated-8", "name": "2.5 GB" },
+            { "label": "storage-generated-11", "name": "5 GB" },
+            { "label": "storage-generated-15", "name": "50 GB" },
+            { "label": "storage-generated-18", "name": "100 GB" },
+            { "label": "storage-generated-22", "name": "250 GB" }
+          ],
+          "value": { "label": "storage-generated-15", "name": "50 GB" },
+          "value_string": "50 GB"
+        },
+        {
+          "label": "static-connections",
+          "name": "Connections",
+          "type": "string",
+          "values": [
+            { "label": "connections-generated-2", "name": "10" },
+            { "label": "connections-generated-7", "name": "15" },
+            { "label": "connections-generated-9", "name": "30" },
+            { "label": "connections-generated-12", "name": "66" },
+            { "label": "connections-generated-16", "name": "150" },
+            { "label": "connections-generated-19", "name": "300" },
+            { "label": "connections-generated-23", "name": "600" }
+          ],
+          "value": { "label": "connections-generated-16", "name": "150" },
+          "value_string": "150"
+        },
+        {
+          "label": "static-single-tenant",
+          "name": "Single Tenant",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }],
+          "value": { "label": "true", "name": "true" },
+          "value_string": "true"
+        },
+        {
+          "label": "static-high-availability",
+          "name": "High Availability",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }],
+          "value": { "label": "false", "name": "false" },
+          "value_string": "false"
+        },
+        {
+          "label": "static-rollback",
+          "name": "Rollback",
+          "type": "string",
+          "values": [
+            { "label": "rollback-generated-4", "name": "0 Days" },
+            { "label": "rollback-generated-13", "name": "1 Day" },
+            { "label": "rollback-generated-20", "name": "2 Days" }
+          ],
+          "value": { "label": "rollback-generated-13", "name": "1 Day" },
+          "value_string": "1 Day"
+        }
+      ],
+      "free": false
+    },
+    "id": "235dutw688y1uqcuqcyvz9twc7yke",
+    "type": "plan",
+    "version": 1
+  },
+  {
+    "body": {
+      "cost": 20000,
+      "features": [
+        { "feature": "static-ram", "value": "ram-generated-14" },
+        { "feature": "static-storage", "value": "storage-generated-15" },
+        { "feature": "static-connections", "value": "connections-generated-16" },
+        { "feature": "static-single-tenant", "value": "true" },
+        { "feature": "static-high-availability", "value": "true" },
+        { "feature": "static-rollback", "value": "rollback-generated-20" }
+      ],
+      "label": "thresheralpha",
+      "name": "Thresher Alpha",
+      "product_id": "234w1jyaum5j0aqe3g3bmbqjgf20p",
+      "provider_id": "2346mdxcuca9ez2n93f72nb2fpjgu",
+      "regions": ["235mhkk15ky7ha9qpu4gazrqjt2gr", "235m2c51y0625vvtk6ptf55bhpkty"],
+      "resizable_to": [
+        "2352ekm35rff86k1w1yfcxhex2waw",
+        "235dutw688y1uqcuqcyvz9twc7yke",
+        "235e1x01g4hgyf86e4wyp16x4k738",
+        "2353vuh3mpw4ufnqjwnentch3wmkj",
+        "2354cmvu65xccvw974kfjh616b2x0"
+      ],
+      "state": "available",
+      "trial_days": 0,
+      "defaultCost": 20000,
+      "expanded_features": [
+        {
+          "label": "static-ram",
+          "name": "RAM",
+          "type": "string",
+          "values": [
+            { "label": "ram-generated-0", "name": "Shared" },
+            { "label": "ram-generated-10", "name": "1 GB" },
+            { "label": "ram-generated-14", "name": "2 GB" },
+            { "label": "ram-generated-17", "name": "4 GB" },
+            { "label": "ram-generated-21", "name": "8 GB" }
+          ],
+          "value": { "label": "ram-generated-14", "name": "2 GB" },
+          "value_string": "2 GB"
+        },
+        {
+          "label": "static-storage",
+          "name": "Storage",
+          "type": "string",
+          "values": [
+            { "label": "storage-generated-1", "name": "250 MB" },
+            { "label": "storage-generated-6", "name": "1 GB" },
+            { "label": "storage-generated-8", "name": "2.5 GB" },
+            { "label": "storage-generated-11", "name": "5 GB" },
+            { "label": "storage-generated-15", "name": "50 GB" },
+            { "label": "storage-generated-18", "name": "100 GB" },
+            { "label": "storage-generated-22", "name": "250 GB" }
+          ],
+          "value": { "label": "storage-generated-15", "name": "50 GB" },
+          "value_string": "50 GB"
+        },
+        {
+          "label": "static-connections",
+          "name": "Connections",
+          "type": "string",
+          "values": [
+            { "label": "connections-generated-2", "name": "10" },
+            { "label": "connections-generated-7", "name": "15" },
+            { "label": "connections-generated-9", "name": "30" },
+            { "label": "connections-generated-12", "name": "66" },
+            { "label": "connections-generated-16", "name": "150" },
+            { "label": "connections-generated-19", "name": "300" },
+            { "label": "connections-generated-23", "name": "600" }
+          ],
+          "value": { "label": "connections-generated-16", "name": "150" },
+          "value_string": "150"
+        },
+        {
+          "label": "static-single-tenant",
+          "name": "Single Tenant",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }],
+          "value": { "label": "true", "name": "true" },
+          "value_string": "true"
+        },
+        {
+          "label": "static-high-availability",
+          "name": "High Availability",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }],
+          "value": { "label": "true", "name": "true" },
+          "value_string": "true"
+        },
+        {
+          "label": "static-rollback",
+          "name": "Rollback",
+          "type": "string",
+          "values": [
+            { "label": "rollback-generated-4", "name": "0 Days" },
+            { "label": "rollback-generated-13", "name": "1 Day" },
+            { "label": "rollback-generated-20", "name": "2 Days" }
+          ],
+          "value": { "label": "rollback-generated-20", "name": "2 Days" },
+          "value_string": "2 Days"
+        }
+      ],
+      "free": false
+    },
+    "id": "2350hd8b2fe5a5vzj21xzuf558vku",
+    "type": "plan",
+    "version": 1
+  },
+  {
+    "body": {
+      "cost": 20000,
+      "features": [
+        { "feature": "static-ram", "value": "ram-generated-17" },
+        { "feature": "static-storage", "value": "storage-generated-18" },
+        { "feature": "static-connections", "value": "connections-generated-19" },
+        { "feature": "static-single-tenant", "value": "true" },
+        { "feature": "static-rollback", "value": "rollback-generated-13" },
+        { "feature": "static-high-availability", "value": "false" }
+      ],
+      "label": "tiger",
+      "name": "Tiger",
+      "product_id": "234w1jyaum5j0aqe3g3bmbqjgf20p",
+      "provider_id": "2346mdxcuca9ez2n93f72nb2fpjgu",
+      "regions": ["235mhkk15ky7ha9qpu4gazrqjt2gr", "235m2c51y0625vvtk6ptf55bhpkty"],
+      "resizable_to": [
+        "235e1x01g4hgyf86e4wyp16x4k738",
+        "2353vuh3mpw4ufnqjwnentch3wmkj",
+        "2354cmvu65xccvw974kfjh616b2x0"
+      ],
+      "state": "available",
+      "trial_days": 0,
+      "defaultCost": 20000,
+      "expanded_features": [
+        {
+          "label": "static-ram",
+          "name": "RAM",
+          "type": "string",
+          "values": [
+            { "label": "ram-generated-0", "name": "Shared" },
+            { "label": "ram-generated-10", "name": "1 GB" },
+            { "label": "ram-generated-14", "name": "2 GB" },
+            { "label": "ram-generated-17", "name": "4 GB" },
+            { "label": "ram-generated-21", "name": "8 GB" }
+          ],
+          "value": { "label": "ram-generated-17", "name": "4 GB" },
+          "value_string": "4 GB"
+        },
+        {
+          "label": "static-storage",
+          "name": "Storage",
+          "type": "string",
+          "values": [
+            { "label": "storage-generated-1", "name": "250 MB" },
+            { "label": "storage-generated-6", "name": "1 GB" },
+            { "label": "storage-generated-8", "name": "2.5 GB" },
+            { "label": "storage-generated-11", "name": "5 GB" },
+            { "label": "storage-generated-15", "name": "50 GB" },
+            { "label": "storage-generated-18", "name": "100 GB" },
+            { "label": "storage-generated-22", "name": "250 GB" }
+          ],
+          "value": { "label": "storage-generated-18", "name": "100 GB" },
+          "value_string": "100 GB"
+        },
+        {
+          "label": "static-connections",
+          "name": "Connections",
+          "type": "string",
+          "values": [
+            { "label": "connections-generated-2", "name": "10" },
+            { "label": "connections-generated-7", "name": "15" },
+            { "label": "connections-generated-9", "name": "30" },
+            { "label": "connections-generated-12", "name": "66" },
+            { "label": "connections-generated-16", "name": "150" },
+            { "label": "connections-generated-19", "name": "300" },
+            { "label": "connections-generated-23", "name": "600" }
+          ],
+          "value": { "label": "connections-generated-19", "name": "300" },
+          "value_string": "300"
+        },
+        {
+          "label": "static-single-tenant",
+          "name": "Single Tenant",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }],
+          "value": { "label": "true", "name": "true" },
+          "value_string": "true"
+        },
+        {
+          "label": "static-high-availability",
+          "name": "High Availability",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }],
+          "value": { "label": "false", "name": "false" },
+          "value_string": "false"
+        },
+        {
+          "label": "static-rollback",
+          "name": "Rollback",
+          "type": "string",
+          "values": [
+            { "label": "rollback-generated-4", "name": "0 Days" },
+            { "label": "rollback-generated-13", "name": "1 Day" },
+            { "label": "rollback-generated-20", "name": "2 Days" }
+          ],
+          "value": { "label": "rollback-generated-13", "name": "1 Day" },
+          "value_string": "1 Day"
+        }
+      ],
+      "free": false
+    },
+    "id": "2352ekm35rff86k1w1yfcxhex2waw",
+    "type": "plan",
+    "version": 1
+  },
+  {
+    "body": {
+      "cost": 1000,
+      "features": [
+        { "feature": "static-ram", "value": "ram-generated-0" },
+        { "feature": "static-storage", "value": "storage-generated-6" },
+        { "feature": "static-connections", "value": "connections-generated-7" },
+        { "feature": "static-single-tenant", "value": "false" },
+        { "feature": "static-rollback", "value": "rollback-generated-4" },
+        { "feature": "static-high-availability", "value": "false" }
+      ],
+      "label": "leopard",
+      "name": "Leopard",
+      "product_id": "234w1jyaum5j0aqe3g3bmbqjgf20p",
+      "provider_id": "2346mdxcuca9ez2n93f72nb2fpjgu",
+      "regions": ["235mhkk15ky7ha9qpu4gazrqjt2gr", "235m2c51y0625vvtk6ptf55bhpkty"],
+      "resizable_to": ["2358u3xj4d8x5qud8x1atgafwchfy"],
+      "state": "available",
+      "trial_days": 0,
+      "defaultCost": 1000,
+      "expanded_features": [
+        {
+          "label": "static-ram",
+          "name": "RAM",
+          "type": "string",
+          "values": [
+            { "label": "ram-generated-0", "name": "Shared" },
+            { "label": "ram-generated-10", "name": "1 GB" },
+            { "label": "ram-generated-14", "name": "2 GB" },
+            { "label": "ram-generated-17", "name": "4 GB" },
+            { "label": "ram-generated-21", "name": "8 GB" }
+          ],
+          "value": { "label": "ram-generated-0", "name": "Shared" },
+          "value_string": "Shared"
+        },
+        {
+          "label": "static-storage",
+          "name": "Storage",
+          "type": "string",
+          "values": [
+            { "label": "storage-generated-1", "name": "250 MB" },
+            { "label": "storage-generated-6", "name": "1 GB" },
+            { "label": "storage-generated-8", "name": "2.5 GB" },
+            { "label": "storage-generated-11", "name": "5 GB" },
+            { "label": "storage-generated-15", "name": "50 GB" },
+            { "label": "storage-generated-18", "name": "100 GB" },
+            { "label": "storage-generated-22", "name": "250 GB" }
+          ],
+          "value": { "label": "storage-generated-6", "name": "1 GB" },
+          "value_string": "1 GB"
+        },
+        {
+          "label": "static-connections",
+          "name": "Connections",
+          "type": "string",
+          "values": [
+            { "label": "connections-generated-2", "name": "10" },
+            { "label": "connections-generated-7", "name": "15" },
+            { "label": "connections-generated-9", "name": "30" },
+            { "label": "connections-generated-12", "name": "66" },
+            { "label": "connections-generated-16", "name": "150" },
+            { "label": "connections-generated-19", "name": "300" },
+            { "label": "connections-generated-23", "name": "600" }
+          ],
+          "value": { "label": "connections-generated-7", "name": "15" },
+          "value_string": "15"
+        },
+        {
+          "label": "static-single-tenant",
+          "name": "Single Tenant",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }],
+          "value": { "label": "false", "name": "false" },
+          "value_string": "false"
+        },
+        {
+          "label": "static-high-availability",
+          "name": "High Availability",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }],
+          "value": { "label": "false", "name": "false" },
+          "value_string": "false"
+        },
+        {
+          "label": "static-rollback",
+          "name": "Rollback",
+          "type": "string",
+          "values": [
+            { "label": "rollback-generated-4", "name": "0 Days" },
+            { "label": "rollback-generated-13", "name": "1 Day" },
+            { "label": "rollback-generated-20", "name": "2 Days" }
+          ],
+          "value": { "label": "rollback-generated-4", "name": "0 Days" },
+          "value_string": "0 Days"
+        }
+      ],
+      "free": false
+    },
+    "id": "23556xtwybe9zv877e6g2c7ygnxpj",
+    "type": "plan",
+    "version": 1
+  },
+  {
+    "body": {
+      "cost": 2000,
+      "features": [
+        { "feature": "static-ram", "value": "ram-generated-0" },
+        { "feature": "static-storage", "value": "storage-generated-8" },
+        { "feature": "static-connections", "value": "connections-generated-9" },
+        { "feature": "static-single-tenant", "value": "false" },
+        { "feature": "static-rollback", "value": "rollback-generated-4" },
+        { "feature": "static-high-availability", "value": "false" }
+      ],
+      "label": "blacktip",
+      "name": "Blacktip",
+      "product_id": "234w1jyaum5j0aqe3g3bmbqjgf20p",
+      "provider_id": "2346mdxcuca9ez2n93f72nb2fpjgu",
+      "regions": ["235mhkk15ky7ha9qpu4gazrqjt2gr", "235m2c51y0625vvtk6ptf55bhpkty"],
+      "resizable_to": [],
+      "state": "available",
+      "trial_days": 0,
+      "defaultCost": 2000,
+      "expanded_features": [
+        {
+          "label": "static-ram",
+          "name": "RAM",
+          "type": "string",
+          "values": [
+            { "label": "ram-generated-0", "name": "Shared" },
+            { "label": "ram-generated-10", "name": "1 GB" },
+            { "label": "ram-generated-14", "name": "2 GB" },
+            { "label": "ram-generated-17", "name": "4 GB" },
+            { "label": "ram-generated-21", "name": "8 GB" }
+          ],
+          "value": { "label": "ram-generated-0", "name": "Shared" },
+          "value_string": "Shared"
+        },
+        {
+          "label": "static-storage",
+          "name": "Storage",
+          "type": "string",
+          "values": [
+            { "label": "storage-generated-1", "name": "250 MB" },
+            { "label": "storage-generated-6", "name": "1 GB" },
+            { "label": "storage-generated-8", "name": "2.5 GB" },
+            { "label": "storage-generated-11", "name": "5 GB" },
+            { "label": "storage-generated-15", "name": "50 GB" },
+            { "label": "storage-generated-18", "name": "100 GB" },
+            { "label": "storage-generated-22", "name": "250 GB" }
+          ],
+          "value": { "label": "storage-generated-8", "name": "2.5 GB" },
+          "value_string": "2.5 GB"
+        },
+        {
+          "label": "static-connections",
+          "name": "Connections",
+          "type": "string",
+          "values": [
+            { "label": "connections-generated-2", "name": "10" },
+            { "label": "connections-generated-7", "name": "15" },
+            { "label": "connections-generated-9", "name": "30" },
+            { "label": "connections-generated-12", "name": "66" },
+            { "label": "connections-generated-16", "name": "150" },
+            { "label": "connections-generated-19", "name": "300" },
+            { "label": "connections-generated-23", "name": "600" }
+          ],
+          "value": { "label": "connections-generated-9", "name": "30" },
+          "value_string": "30"
+        },
+        {
+          "label": "static-single-tenant",
+          "name": "Single Tenant",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }],
+          "value": { "label": "false", "name": "false" },
+          "value_string": "false"
+        },
+        {
+          "label": "static-high-availability",
+          "name": "High Availability",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }],
+          "value": { "label": "false", "name": "false" },
+          "value_string": "false"
+        },
+        {
+          "label": "static-rollback",
+          "name": "Rollback",
+          "type": "string",
+          "values": [
+            { "label": "rollback-generated-4", "name": "0 Days" },
+            { "label": "rollback-generated-13", "name": "1 Day" },
+            { "label": "rollback-generated-20", "name": "2 Days" }
+          ],
+          "value": { "label": "rollback-generated-4", "name": "0 Days" },
+          "value_string": "0 Days"
+        }
+      ],
+      "free": false
+    },
+    "id": "2358u3xj4d8x5qud8x1atgafwchfy",
+    "type": "plan",
+    "version": 1
+  },
+  {
+    "body": {
+      "cost": 3500,
+      "features": [
+        { "feature": "static-ram", "value": "ram-generated-10" },
+        { "feature": "static-storage", "value": "storage-generated-11" },
+        { "feature": "static-connections", "value": "connections-generated-12" },
+        { "feature": "static-single-tenant", "value": "true" },
+        { "feature": "static-rollback", "value": "rollback-generated-13" },
+        { "feature": "static-high-availability", "value": "false" }
+      ],
+      "label": "whitetip",
+      "name": "Whitetip",
+      "product_id": "234w1jyaum5j0aqe3g3bmbqjgf20p",
+      "provider_id": "2346mdxcuca9ez2n93f72nb2fpjgu",
+      "regions": ["235mhkk15ky7ha9qpu4gazrqjt2gr", "235m2c51y0625vvtk6ptf55bhpkty"],
+      "resizable_to": [
+        "235f4zy6ydbpbhmdkn4tx1rgu4pcj",
+        "235dutw688y1uqcuqcyvz9twc7yke",
+        "2352ekm35rff86k1w1yfcxhex2waw",
+        "2350hd8b2fe5a5vzj21xzuf558vku",
+        "235e1x01g4hgyf86e4wyp16x4k738",
+        "2353vuh3mpw4ufnqjwnentch3wmkj",
+        "2354cmvu65xccvw974kfjh616b2x0"
+      ],
+      "state": "available",
+      "trial_days": 0,
+      "defaultCost": 3500,
+      "expanded_features": [
+        {
+          "label": "static-ram",
+          "name": "RAM",
+          "type": "string",
+          "values": [
+            { "label": "ram-generated-0", "name": "Shared" },
+            { "label": "ram-generated-10", "name": "1 GB" },
+            { "label": "ram-generated-14", "name": "2 GB" },
+            { "label": "ram-generated-17", "name": "4 GB" },
+            { "label": "ram-generated-21", "name": "8 GB" }
+          ],
+          "value": { "label": "ram-generated-10", "name": "1 GB" },
+          "value_string": "1 GB"
+        },
+        {
+          "label": "static-storage",
+          "name": "Storage",
+          "type": "string",
+          "values": [
+            { "label": "storage-generated-1", "name": "250 MB" },
+            { "label": "storage-generated-6", "name": "1 GB" },
+            { "label": "storage-generated-8", "name": "2.5 GB" },
+            { "label": "storage-generated-11", "name": "5 GB" },
+            { "label": "storage-generated-15", "name": "50 GB" },
+            { "label": "storage-generated-18", "name": "100 GB" },
+            { "label": "storage-generated-22", "name": "250 GB" }
+          ],
+          "value": { "label": "storage-generated-11", "name": "5 GB" },
+          "value_string": "5 GB"
+        },
+        {
+          "label": "static-connections",
+          "name": "Connections",
+          "type": "string",
+          "values": [
+            { "label": "connections-generated-2", "name": "10" },
+            { "label": "connections-generated-7", "name": "15" },
+            { "label": "connections-generated-9", "name": "30" },
+            { "label": "connections-generated-12", "name": "66" },
+            { "label": "connections-generated-16", "name": "150" },
+            { "label": "connections-generated-19", "name": "300" },
+            { "label": "connections-generated-23", "name": "600" }
+          ],
+          "value": { "label": "connections-generated-12", "name": "66" },
+          "value_string": "66"
+        },
+        {
+          "label": "static-single-tenant",
+          "name": "Single Tenant",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }],
+          "value": { "label": "true", "name": "true" },
+          "value_string": "true"
+        },
+        {
+          "label": "static-high-availability",
+          "name": "High Availability",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }],
+          "value": { "label": "false", "name": "false" },
+          "value_string": "false"
+        },
+        {
+          "label": "static-rollback",
+          "name": "Rollback",
+          "type": "string",
+          "values": [
+            { "label": "rollback-generated-4", "name": "0 Days" },
+            { "label": "rollback-generated-13", "name": "1 Day" },
+            { "label": "rollback-generated-20", "name": "2 Days" }
+          ],
+          "value": { "label": "rollback-generated-13", "name": "1 Day" },
+          "value_string": "1 Day"
+        }
+      ],
+      "free": false
+    },
+    "id": "235fyub2rhaz2aqkj3xvtbzgkc3aw",
+    "type": "plan",
+    "version": 1
+  },
+  {
+    "body": {
+      "cost": 6500,
+      "features": [
+        { "feature": "static-ram", "value": "ram-generated-10" },
+        { "feature": "static-storage", "value": "storage-generated-11" },
+        { "feature": "static-connections", "value": "connections-generated-12" },
+        { "feature": "static-single-tenant", "value": "true" },
+        { "feature": "static-high-availability", "value": "true" },
+        { "feature": "static-rollback", "value": "rollback-generated-20" }
+      ],
+      "label": "whitetipalpha",
+      "name": "Whitetip Alpha",
+      "product_id": "234w1jyaum5j0aqe3g3bmbqjgf20p",
+      "provider_id": "2346mdxcuca9ez2n93f72nb2fpjgu",
+      "regions": ["235mhkk15ky7ha9qpu4gazrqjt2gr", "235m2c51y0625vvtk6ptf55bhpkty"],
+      "resizable_to": [
+        "235fyub2rhaz2aqkj3xvtbzgkc3aw",
+        "235dutw688y1uqcuqcyvz9twc7yke",
+        "2352ekm35rff86k1w1yfcxhex2waw",
+        "2350hd8b2fe5a5vzj21xzuf558vku",
+        "235e1x01g4hgyf86e4wyp16x4k738",
+        "2353vuh3mpw4ufnqjwnentch3wmkj",
+        "2354cmvu65xccvw974kfjh616b2x0"
+      ],
+      "state": "available",
+      "trial_days": 0,
+      "defaultCost": 6500,
+      "expanded_features": [
+        {
+          "label": "static-ram",
+          "name": "RAM",
+          "type": "string",
+          "values": [
+            { "label": "ram-generated-0", "name": "Shared" },
+            { "label": "ram-generated-10", "name": "1 GB" },
+            { "label": "ram-generated-14", "name": "2 GB" },
+            { "label": "ram-generated-17", "name": "4 GB" },
+            { "label": "ram-generated-21", "name": "8 GB" }
+          ],
+          "value": { "label": "ram-generated-10", "name": "1 GB" },
+          "value_string": "1 GB"
+        },
+        {
+          "label": "static-storage",
+          "name": "Storage",
+          "type": "string",
+          "values": [
+            { "label": "storage-generated-1", "name": "250 MB" },
+            { "label": "storage-generated-6", "name": "1 GB" },
+            { "label": "storage-generated-8", "name": "2.5 GB" },
+            { "label": "storage-generated-11", "name": "5 GB" },
+            { "label": "storage-generated-15", "name": "50 GB" },
+            { "label": "storage-generated-18", "name": "100 GB" },
+            { "label": "storage-generated-22", "name": "250 GB" }
+          ],
+          "value": { "label": "storage-generated-11", "name": "5 GB" },
+          "value_string": "5 GB"
+        },
+        {
+          "label": "static-connections",
+          "name": "Connections",
+          "type": "string",
+          "values": [
+            { "label": "connections-generated-2", "name": "10" },
+            { "label": "connections-generated-7", "name": "15" },
+            { "label": "connections-generated-9", "name": "30" },
+            { "label": "connections-generated-12", "name": "66" },
+            { "label": "connections-generated-16", "name": "150" },
+            { "label": "connections-generated-19", "name": "300" },
+            { "label": "connections-generated-23", "name": "600" }
+          ],
+          "value": { "label": "connections-generated-12", "name": "66" },
+          "value_string": "66"
+        },
+        {
+          "label": "static-single-tenant",
+          "name": "Single Tenant",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }],
+          "value": { "label": "true", "name": "true" },
+          "value_string": "true"
+        },
+        {
+          "label": "static-high-availability",
+          "name": "High Availability",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }],
+          "value": { "label": "true", "name": "true" },
+          "value_string": "true"
+        },
+        {
+          "label": "static-rollback",
+          "name": "Rollback",
+          "type": "string",
+          "values": [
+            { "label": "rollback-generated-4", "name": "0 Days" },
+            { "label": "rollback-generated-13", "name": "1 Day" },
+            { "label": "rollback-generated-20", "name": "2 Days" }
+          ],
+          "value": { "label": "rollback-generated-20", "name": "2 Days" },
+          "value_string": "2 Days"
+        }
+      ],
+      "free": false
+    },
+    "id": "235f4zy6ydbpbhmdkn4tx1rgu4pcj",
+    "type": "plan",
+    "version": 1
+  },
+  {
+    "body": {
+      "cost": 3300,
+      "features": [
+        { "feature": "storage", "value": "storage" },
+        { "feature": "backups", "value": "backups" },
+        { "feature": "redundancy", "value": "false" },
+        { "feature": "instance_class", "value": "db.t2.micro" },
+        { "feature": "static-single-tenant", "value": "true" }
+      ],
+      "label": "custom",
+      "name": "Custom",
+      "product_id": "234w1jyaum5j0aqe3g3bmbqjgf20p",
+      "provider_id": "2346mdxcuca9ez2n93f72nb2fpjgu",
+      "regions": ["235mhkk15ky7ha9qpu4gazrqjt2gr", "235m2c51y0625vvtk6ptf55bhpkty"],
+      "resizable_to": ["235exy25wvzpxj52p87bh87gbnj4y"],
+      "state": "available",
+      "customizable": true,
+      "defaultCost": 3500,
+      "expanded_features": [
+        {
+          "label": "static-single-tenant",
+          "name": "Single Tenant",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }],
+          "value": { "label": "true", "name": "true" },
+          "value_string": "true"
+        },
+        {
+          "customizable": true,
+          "downgradable": true,
+          "label": "instance_class",
+          "name": "RAM",
+          "type": "string",
+          "upgradable": true,
+          "values": [
+            { "label": "db.t2.micro", "name": "1 GB", "price": {} },
+            { "cost": 5400, "label": "db.t2.small", "name": "2 GB", "price": { "cost": 5400 } },
+            { "cost": 13400, "label": "db.m3.medium", "name": "4 GB", "price": { "cost": 13400 } },
+            { "cost": 31800, "label": "db.m4.large", "name": "8 GB", "price": { "cost": 31800 } },
+            { "cost": 54400, "label": "db.r4.large", "name": "15 GB", "price": { "cost": 54400 } },
+            { "cost": 89000, "label": "db.r4.xlarge", "name": "31 GB", "price": { "cost": 89000 } },
+            {
+              "cost": 121000,
+              "label": "db.r4.2xlarge",
+              "name": "61 GB",
+              "price": { "cost": 121000 }
+            },
+            {
+              "cost": 239000,
+              "label": "db.r4.4xlarge",
+              "name": "122 GB",
+              "price": { "cost": 239000 }
+            },
+            {
+              "cost": 428000,
+              "label": "db.r4.8xlarge",
+              "name": "244 GB",
+              "price": { "cost": 428000 }
+            },
+            {
+              "cost": 910000,
+              "label": "db.r4.16xlarge",
+              "name": "488 GB",
+              "price": { "cost": 910000 }
+            }
+          ],
+          "value": { "label": "db.t2.micro", "name": "1 GB", "price": {} },
+          "value_string": "1 GB"
+        },
+        {
+          "customizable": true,
+          "label": "storage",
+          "name": "Storage",
+          "type": "number",
+          "upgradable": true,
+          "values": [
+            {
+              "label": "storage",
+              "name": "Storage",
+              "numeric_details": {
+                "cost_ranges": [{ "cost_multiple": 200000000, "limit": 16000 }],
+                "increment": 1,
+                "max": 16000,
+                "min": 5,
+                "suffix": "GB"
+              }
+            }
+          ],
+          "value": {
+            "label": "storage",
+            "name": "Storage",
+            "numeric_details": {
+              "cost_ranges": [{ "cost_multiple": 200000000, "limit": 16000 }],
+              "increment": 1,
+              "max": 16000,
+              "min": 5,
+              "suffix": "GB"
+            }
+          },
+          "value_string": "Storage"
+        },
+        {
+          "customizable": true,
+          "downgradable": true,
+          "label": "backups",
+          "name": "Backups",
+          "type": "number",
+          "upgradable": true,
+          "values": [
+            {
+              "label": "backups",
+              "name": "Backups",
+              "numeric_details": {
+                "cost_ranges": [{ "limit": 35 }],
+                "increment": 1,
+                "max": 35,
+                "min": 1,
+                "suffix": "Days"
+              },
+              "price": {
+                "description": "Backups cost is directly related to storage size",
+                "formula": "(* storage#cost backups#number)"
+              }
+            }
+          ],
+          "value": {
+            "label": "backups",
+            "name": "Backups",
+            "numeric_details": {
+              "cost_ranges": [{ "limit": 35 }],
+              "increment": 1,
+              "max": 35,
+              "min": 1,
+              "suffix": "Days"
+            },
+            "price": {
+              "description": "Backups cost is directly related to storage size",
+              "formula": "(* storage#cost backups#number)"
+            }
+          },
+          "value_string": "Backups"
+        },
+        {
+          "customizable": true,
+          "downgradable": true,
+          "label": "redundancy",
+          "name": "High Availability",
+          "type": "boolean",
+          "upgradable": true,
+          "values": [
+            {
+              "label": "true",
+              "name": "Yes",
+              "price": {
+                "description": "Creates a clone of the DB to rescue from potential outages",
+                "formula": "(* plan#partial_cost redundancy#multiply_factor)",
+                "multiply_factor": 0.8
+              }
+            },
+            { "label": "false", "name": "No" }
+          ],
+          "value": { "label": "false", "name": "No" },
+          "value_string": "No"
+        }
+      ],
+      "free": false
+    },
+    "id": "235exy25wvzpxj52p87bh87gbnj4y",
+    "type": "plan",
+    "version": 1
+  },
+  {
+    "body": {
+      "cost": 38000,
+      "features": [
+        { "feature": "static-ram", "value": "ram-generated-17" },
+        { "feature": "static-storage", "value": "storage-generated-18" },
+        { "feature": "static-connections", "value": "connections-generated-19" },
+        { "feature": "static-single-tenant", "value": "true" },
+        { "feature": "static-high-availability", "value": "true" },
+        { "feature": "static-rollback", "value": "rollback-generated-20" }
+      ],
+      "label": "tigeralpha",
+      "name": "Tiger Alpha",
+      "product_id": "234w1jyaum5j0aqe3g3bmbqjgf20p",
+      "provider_id": "2346mdxcuca9ez2n93f72nb2fpjgu",
+      "regions": ["235mhkk15ky7ha9qpu4gazrqjt2gr", "235m2c51y0625vvtk6ptf55bhpkty"],
+      "resizable_to": [
+        "2352ekm35rff86k1w1yfcxhex2waw",
+        "2353vuh3mpw4ufnqjwnentch3wmkj",
+        "2354cmvu65xccvw974kfjh616b2x0"
+      ],
+      "state": "available",
+      "trial_days": 0,
+      "defaultCost": 38000,
+      "expanded_features": [
+        {
+          "label": "static-ram",
+          "name": "RAM",
+          "type": "string",
+          "values": [
+            { "label": "ram-generated-0", "name": "Shared" },
+            { "label": "ram-generated-10", "name": "1 GB" },
+            { "label": "ram-generated-14", "name": "2 GB" },
+            { "label": "ram-generated-17", "name": "4 GB" },
+            { "label": "ram-generated-21", "name": "8 GB" }
+          ],
+          "value": { "label": "ram-generated-17", "name": "4 GB" },
+          "value_string": "4 GB"
+        },
+        {
+          "label": "static-storage",
+          "name": "Storage",
+          "type": "string",
+          "values": [
+            { "label": "storage-generated-1", "name": "250 MB" },
+            { "label": "storage-generated-6", "name": "1 GB" },
+            { "label": "storage-generated-8", "name": "2.5 GB" },
+            { "label": "storage-generated-11", "name": "5 GB" },
+            { "label": "storage-generated-15", "name": "50 GB" },
+            { "label": "storage-generated-18", "name": "100 GB" },
+            { "label": "storage-generated-22", "name": "250 GB" }
+          ],
+          "value": { "label": "storage-generated-18", "name": "100 GB" },
+          "value_string": "100 GB"
+        },
+        {
+          "label": "static-connections",
+          "name": "Connections",
+          "type": "string",
+          "values": [
+            { "label": "connections-generated-2", "name": "10" },
+            { "label": "connections-generated-7", "name": "15" },
+            { "label": "connections-generated-9", "name": "30" },
+            { "label": "connections-generated-12", "name": "66" },
+            { "label": "connections-generated-16", "name": "150" },
+            { "label": "connections-generated-19", "name": "300" },
+            { "label": "connections-generated-23", "name": "600" }
+          ],
+          "value": { "label": "connections-generated-19", "name": "300" },
+          "value_string": "300"
+        },
+        {
+          "label": "static-single-tenant",
+          "name": "Single Tenant",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }],
+          "value": { "label": "true", "name": "true" },
+          "value_string": "true"
+        },
+        {
+          "label": "static-high-availability",
+          "name": "High Availability",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }],
+          "value": { "label": "true", "name": "true" },
+          "value_string": "true"
+        },
+        {
+          "label": "static-rollback",
+          "name": "Rollback",
+          "type": "string",
+          "values": [
+            { "label": "rollback-generated-4", "name": "0 Days" },
+            { "label": "rollback-generated-13", "name": "1 Day" },
+            { "label": "rollback-generated-20", "name": "2 Days" }
+          ],
+          "value": { "label": "rollback-generated-20", "name": "2 Days" },
+          "value_string": "2 Days"
+        }
+      ],
+      "free": false
+    },
+    "id": "235e1x01g4hgyf86e4wyp16x4k738",
+    "type": "plan",
+    "version": 1
+  },
+  {
+    "body": {
+      "cost": 44000,
+      "features": [
+        { "feature": "static-ram", "value": "ram-generated-21" },
+        { "feature": "static-storage", "value": "storage-generated-22" },
+        { "feature": "static-connections", "value": "connections-generated-23" },
+        { "feature": "static-single-tenant", "value": "true" },
+        { "feature": "static-high-availability", "value": "false" },
+        { "feature": "static-rollback", "value": "rollback-generated-13" }
+      ],
+      "label": "hammerhead",
+      "name": "Hammerhead",
+      "product_id": "234w1jyaum5j0aqe3g3bmbqjgf20p",
+      "provider_id": "2346mdxcuca9ez2n93f72nb2fpjgu",
+      "regions": ["235mhkk15ky7ha9qpu4gazrqjt2gr", "235m2c51y0625vvtk6ptf55bhpkty"],
+      "resizable_to": ["2354cmvu65xccvw974kfjh616b2x0"],
+      "state": "available",
+      "trial_days": 0,
+      "defaultCost": 44000,
+      "expanded_features": [
+        {
+          "label": "static-ram",
+          "name": "RAM",
+          "type": "string",
+          "values": [
+            { "label": "ram-generated-0", "name": "Shared" },
+            { "label": "ram-generated-10", "name": "1 GB" },
+            { "label": "ram-generated-14", "name": "2 GB" },
+            { "label": "ram-generated-17", "name": "4 GB" },
+            { "label": "ram-generated-21", "name": "8 GB" }
+          ],
+          "value": { "label": "ram-generated-21", "name": "8 GB" },
+          "value_string": "8 GB"
+        },
+        {
+          "label": "static-storage",
+          "name": "Storage",
+          "type": "string",
+          "values": [
+            { "label": "storage-generated-1", "name": "250 MB" },
+            { "label": "storage-generated-6", "name": "1 GB" },
+            { "label": "storage-generated-8", "name": "2.5 GB" },
+            { "label": "storage-generated-11", "name": "5 GB" },
+            { "label": "storage-generated-15", "name": "50 GB" },
+            { "label": "storage-generated-18", "name": "100 GB" },
+            { "label": "storage-generated-22", "name": "250 GB" }
+          ],
+          "value": { "label": "storage-generated-22", "name": "250 GB" },
+          "value_string": "250 GB"
+        },
+        {
+          "label": "static-connections",
+          "name": "Connections",
+          "type": "string",
+          "values": [
+            { "label": "connections-generated-2", "name": "10" },
+            { "label": "connections-generated-7", "name": "15" },
+            { "label": "connections-generated-9", "name": "30" },
+            { "label": "connections-generated-12", "name": "66" },
+            { "label": "connections-generated-16", "name": "150" },
+            { "label": "connections-generated-19", "name": "300" },
+            { "label": "connections-generated-23", "name": "600" }
+          ],
+          "value": { "label": "connections-generated-23", "name": "600" },
+          "value_string": "600"
+        },
+        {
+          "label": "static-single-tenant",
+          "name": "Single Tenant",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }],
+          "value": { "label": "true", "name": "true" },
+          "value_string": "true"
+        },
+        {
+          "label": "static-high-availability",
+          "name": "High Availability",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }],
+          "value": { "label": "false", "name": "false" },
+          "value_string": "false"
+        },
+        {
+          "label": "static-rollback",
+          "name": "Rollback",
+          "type": "string",
+          "values": [
+            { "label": "rollback-generated-4", "name": "0 Days" },
+            { "label": "rollback-generated-13", "name": "1 Day" },
+            { "label": "rollback-generated-20", "name": "2 Days" }
+          ],
+          "value": { "label": "rollback-generated-13", "name": "1 Day" },
+          "value_string": "1 Day"
+        }
+      ],
+      "free": false
+    },
+    "id": "2353vuh3mpw4ufnqjwnentch3wmkj",
+    "type": "plan",
+    "version": 1
+  }
+]

--- a/src/spec/mock/jawsdb/product.json
+++ b/src/spec/mock/jawsdb/product.json
@@ -1,0 +1,237 @@
+{
+  "body": {
+    "billing": { "currency": "usd", "type": "monthly-prorated" },
+    "documentation_url": "https://jawsdb.com/docs",
+    "feature_types": [
+      {
+        "label": "static-ram",
+        "name": "RAM",
+        "type": "string",
+        "values": [
+          { "label": "ram-generated-0", "name": "Shared" },
+          { "label": "ram-generated-10", "name": "1 GB" },
+          { "label": "ram-generated-14", "name": "2 GB" },
+          { "label": "ram-generated-17", "name": "4 GB" },
+          { "label": "ram-generated-21", "name": "8 GB" }
+        ]
+      },
+      {
+        "label": "static-storage",
+        "name": "Storage",
+        "type": "string",
+        "values": [
+          { "label": "storage-generated-1", "name": "250 MB" },
+          { "label": "storage-generated-6", "name": "1 GB" },
+          { "label": "storage-generated-8", "name": "2.5 GB" },
+          { "label": "storage-generated-11", "name": "5 GB" },
+          { "label": "storage-generated-15", "name": "50 GB" },
+          { "label": "storage-generated-18", "name": "100 GB" },
+          { "label": "storage-generated-22", "name": "250 GB" }
+        ]
+      },
+      {
+        "label": "static-connections",
+        "name": "Connections",
+        "type": "string",
+        "values": [
+          { "label": "connections-generated-2", "name": "10" },
+          { "label": "connections-generated-7", "name": "15" },
+          { "label": "connections-generated-9", "name": "30" },
+          { "label": "connections-generated-12", "name": "66" },
+          { "label": "connections-generated-16", "name": "150" },
+          { "label": "connections-generated-19", "name": "300" },
+          { "label": "connections-generated-23", "name": "600" }
+        ]
+      },
+      {
+        "label": "static-single-tenant",
+        "name": "Single Tenant",
+        "type": "boolean",
+        "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+      },
+      {
+        "label": "static-high-availability",
+        "name": "High Availability",
+        "type": "boolean",
+        "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+      },
+      {
+        "label": "static-rollback",
+        "name": "Rollback",
+        "type": "string",
+        "values": [
+          { "label": "rollback-generated-4", "name": "0 Days" },
+          { "label": "rollback-generated-13", "name": "1 Day" },
+          { "label": "rollback-generated-20", "name": "2 Days" }
+        ]
+      },
+      {
+        "customizable": true,
+        "downgradable": true,
+        "label": "instance_class",
+        "name": "RAM",
+        "type": "string",
+        "upgradable": true,
+        "values": [
+          { "label": "db.t2.micro", "name": "1 GB", "price": {} },
+          { "cost": 5400, "label": "db.t2.small", "name": "2 GB", "price": { "cost": 5400 } },
+          { "cost": 13400, "label": "db.m3.medium", "name": "4 GB", "price": { "cost": 13400 } },
+          { "cost": 31800, "label": "db.m4.large", "name": "8 GB", "price": { "cost": 31800 } },
+          { "cost": 54400, "label": "db.r4.large", "name": "15 GB", "price": { "cost": 54400 } },
+          { "cost": 89000, "label": "db.r4.xlarge", "name": "31 GB", "price": { "cost": 89000 } },
+          {
+            "cost": 121000,
+            "label": "db.r4.2xlarge",
+            "name": "61 GB",
+            "price": { "cost": 121000 }
+          },
+          {
+            "cost": 239000,
+            "label": "db.r4.4xlarge",
+            "name": "122 GB",
+            "price": { "cost": 239000 }
+          },
+          {
+            "cost": 428000,
+            "label": "db.r4.8xlarge",
+            "name": "244 GB",
+            "price": { "cost": 428000 }
+          },
+          {
+            "cost": 910000,
+            "label": "db.r4.16xlarge",
+            "name": "488 GB",
+            "price": { "cost": 910000 }
+          }
+        ]
+      },
+      {
+        "customizable": true,
+        "label": "storage",
+        "name": "Storage",
+        "type": "number",
+        "upgradable": true,
+        "values": [
+          {
+            "label": "storage",
+            "name": "Storage",
+            "numeric_details": {
+              "cost_ranges": [{ "cost_multiple": 200000000, "limit": 16000 }],
+              "increment": 1,
+              "max": 16000,
+              "min": 5,
+              "suffix": "GB"
+            }
+          }
+        ]
+      },
+      {
+        "customizable": true,
+        "downgradable": true,
+        "label": "backups",
+        "name": "Backups",
+        "type": "number",
+        "upgradable": true,
+        "values": [
+          {
+            "label": "backups",
+            "name": "Backups",
+            "numeric_details": {
+              "cost_ranges": [{ "limit": 35 }],
+              "increment": 1,
+              "max": 35,
+              "min": 1,
+              "suffix": "Days"
+            },
+            "price": {
+              "description": "Backups cost is directly related to storage size",
+              "formula": "(* storage#cost backups#number)"
+            }
+          }
+        ]
+      },
+      {
+        "customizable": true,
+        "downgradable": true,
+        "label": "redundancy",
+        "name": "High Availability",
+        "type": "boolean",
+        "upgradable": true,
+        "values": [
+          {
+            "label": "true",
+            "name": "Yes",
+            "price": {
+              "description": "Creates a clone of the DB to rescue from potential outages",
+              "formula": "(* plan#partial_cost redundancy#multiply_factor)",
+              "multiply_factor": 0.8
+            }
+          },
+          { "label": "false", "name": "No" }
+        ]
+      }
+    ],
+    "images": [
+      "https://cdn.manifold.co/providers/jawsdb/screenshots/ss1.PNG",
+      "https://cdn.manifold.co/providers/jawsdb/screenshots/ss2.PNG",
+      "https://cdn.manifold.co/providers/jawsdb/screenshots/ss3.PNG",
+      "https://cdn.manifold.co/providers/jawsdb/screenshots/ss4.PNG"
+    ],
+    "integration": {
+      "base_url": "https://api.jawsdb.com/mysql",
+      "features": {
+        "access_code": false,
+        "plan_change": true,
+        "region": "user-specified",
+        "sso": true,
+        "credential": "unknown"
+      },
+      "provisioning": "public",
+      "sso_url": "https://api.jawsdb.com/mysql",
+      "version": "v1"
+    },
+    "label": "jawsdb-mysql",
+    "listing": {
+      "listed": true,
+      "marketing": { "beta": false, "featured": false, "new": false },
+      "public": true
+    },
+    "logo_url": "https://cdn.manifold.co/providers/jawsdb/logos/80ca8b9113cf76fd.png",
+    "name": "JawsDB MySQL",
+    "provider_id": "2346mdxcuca9ez2n93f72nb2fpjgu",
+    "state": "available",
+    "support_email": "support@jawsdb.com",
+    "tagline": "Fast, reliable, no-bullshark MySQL as a Service",
+    "tags": ["database"],
+    "terms": { "provided": false },
+    "value_props": [
+      {
+        "body": "Get access to the same database trusted by sites such as Google, Facebook, Twitter, Youtube, and more.",
+        "header": "Trust in Jaws"
+      },
+      {
+        "body": "In addition to any backups you personally create, we automatically take nightly snapshots for single tenant databases. This means that our team can help you restore to a previous point in time.",
+        "header": "Backups"
+      },
+      {
+        "body": "Create, edit, and save reusable queries against your provisioned server. Databites are a custom, zero-hassle reporting solution for your database right out of the box!",
+        "header": "Databites"
+      },
+      {
+        "body": "Regardless of how big of a wave you're riding, JawsDB makes it easy to scale your database performance.",
+        "header": "Scale"
+      },
+      {
+        "body": "For single tenant plans, we provide you and only you with root credentials — so you have complete control of your server.",
+        "header": "Stay in Control"
+      },
+      {
+        "body": "The world doesn't need to be a scary place, choose a plan that supports failover and your data is replicated to servers in different regions of the world, reducing unexpected downtime.",
+        "header": "Data Replication"
+      }
+    ]
+  },
+  "id": "234w1jyaum5j0aqe3g3bmbqjgf20p",
+  "type": "product",
+  "version": 1
+}

--- a/src/spec/mock/products.json
+++ b/src/spec/mock/products.json
@@ -1,0 +1,4945 @@
+[
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://www.scaledrone.com/docs",
+      "feature_types": [
+        {
+          "label": "concurrent-users",
+          "name": "Concurrent Users",
+          "type": "string",
+          "values": [
+            { "label": "020", "name": "20", "price": {} },
+            { "label": "100", "name": "100", "price": {} },
+            { "label": "500", "name": "500", "price": {} },
+            { "label": "5-000", "name": "5 000", "price": {} },
+            { "label": "10-000", "name": "10 000", "price": {} }
+          ]
+        },
+        {
+          "label": "daily-events",
+          "name": "Daily Events",
+          "type": "string",
+          "values": [
+            { "label": "100-000", "name": "100 000", "price": {} },
+            { "label": "200-000", "name": "200 000", "price": {} },
+            { "label": "1-000-000", "name": "1 000 000", "price": {} },
+            { "label": "10-000-000", "name": "10 000 000", "price": {} },
+            { "label": "20-000-000", "name": "20 000 000", "price": {} }
+          ]
+        },
+        {
+          "label": "ssl-encryption",
+          "name": "SSL Encryption",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "Yes" }, { "label": "false", "name": "No" }]
+        },
+        {
+          "label": "priority-support",
+          "name": "Priority Support",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "Yes" }, { "label": "false", "name": "No" }]
+        },
+        {
+          "label": "personal-onboarding",
+          "name": "Personal Onboarding",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "Yes" }, { "label": "false", "name": "No" }]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/23498wxg3tc421xbepp34xyfg555y/screenshots/5f63274a-d546-4270-bacd-cd03c6d5d78f.png",
+        "https://cdn.manifold.co/providers/23498wxg3tc421xbepp34xyfg555y/screenshots/89d637fb-94d6-48ab-aab8-919b30f9b3dc.png"
+      ],
+      "integration": {
+        "base_url": "https://dashboard.scaledrone.com/manifold",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "unspecified",
+          "sso": true,
+          "credential": "single"
+        },
+        "provisioning": "public",
+        "sso_url": "https://dashboard.scaledrone.com/manifold",
+        "version": "v1"
+      },
+      "label": "scaledrone",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": true },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/23498wxg3tc421xbepp34xyfg555y/logos/2c36aa72-a7a6-4bdc-9581-5b68a9b1981d.png",
+      "name": "Scaledrone",
+      "provider_id": "23498wxg3tc421xbepp34xyfg555y",
+      "state": "new",
+      "support_email": "info@scaledrone.com",
+      "tagline": "Send realtime data to your users",
+      "tags": ["messaging"],
+      "terms": { "provided": true, "url": "https://www.scaledrone.com/terms" },
+      "value_props": [
+        {
+          "body": "Scaledrone provides features like realtime messaging, message history and user presence so you can focus on the business logic.",
+          "header": "Build apps, not infrastructure"
+        },
+        {
+          "body": "Scaledrone makes sure you never have to feel pain when growing, whether you have a hundred or a million users.",
+          "header": "Scaling realtime infrastructure is complex"
+        },
+        {
+          "body": "Let us take care of your realtime data, so you don’t have to waste endless developer hours managing infrastructure — so your developers can stay focused on building great apps.",
+          "header": "Save time and money"
+        }
+      ]
+    },
+    "id": "234my0gk2vuh2jhtynk2ekpzpvtfm",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://jawsdb.com/docs",
+      "feature_types": [
+        {
+          "label": "ram",
+          "name": "RAM",
+          "type": "string",
+          "values": [
+            { "label": "ram-generated-0", "name": "Shared" },
+            { "label": "ram-generated-9", "name": "1 GB" },
+            { "label": "ram-generated-13", "name": "2 GB" },
+            { "label": "ram-generated-16", "name": "4 GB" }
+          ]
+        },
+        {
+          "label": "storage",
+          "name": "Storage",
+          "type": "string",
+          "values": [
+            { "label": "storage-generated-1", "name": "250 MB" },
+            { "label": "storage-generated-5", "name": "1 GB" },
+            { "label": "storage-generated-7", "name": "2.5 GB" },
+            { "label": "storage-generated-10", "name": "5 GB" },
+            { "label": "storage-generated-14", "name": "50 GB" },
+            { "label": "storage-generated-17", "name": "100 GB" }
+          ]
+        },
+        {
+          "label": "connections",
+          "name": "Connections",
+          "type": "string",
+          "values": [
+            { "label": "connections-generated-2", "name": "10" },
+            { "label": "connections-generated-6", "name": "15" },
+            { "label": "connections-generated-8", "name": "30" },
+            { "label": "connections-generated-11", "name": "66" },
+            { "label": "connections-generated-15", "name": "150" },
+            { "label": "connections-generated-18", "name": "300" }
+          ]
+        },
+        {
+          "label": "single-tenant",
+          "name": "Single Tenant",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "rollback",
+          "name": "Rollback",
+          "type": "string",
+          "values": [
+            { "label": "rollback-generated-4", "name": "0 Days" },
+            { "label": "rollback-generated-12", "name": "1 Day" }
+          ]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/jawsdb/screenshots/ss1.PNG",
+        "https://cdn.manifold.co/providers/jawsdb/screenshots/ss2.PNG",
+        "https://cdn.manifold.co/providers/jawsdb/screenshots/ss3.PNG",
+        "https://cdn.manifold.co/providers/jawsdb/screenshots/ss4.PNG"
+      ],
+      "integration": {
+        "base_url": "https://api.jawsdb.com/postgres",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "user-specified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://api.jawsdb.com/postgres",
+        "version": "v1"
+      },
+      "label": "jawsdb-postgres",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": false },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/jawsdb/logos/rm2ru508t4b2wtzy33y21xm870.png",
+      "name": "JawsDB PostgreSQL",
+      "provider_id": "2346mdxcuca9ez2n93f72nb2fpjgu",
+      "state": "available",
+      "support_email": "support@jawsdb.com",
+      "tagline": "Fast, reliable, no-bullshark Postgres as a Service",
+      "tags": ["database"],
+      "terms": { "provided": false },
+      "value_props": [
+        {
+          "body": "Postgres is a highly advanced open source database that boasts a robust set of extensions allowing it to map geographic data (PostGIS), query remote tables as if they were local (postgres_fdw), closely monitor execution statistics (pg_stat_statements), and many more.",
+          "header": "A Perfect Match for the Web"
+        },
+        {
+          "body": "In addition to any backups you personally create, we automatically take nightly snapshots for single tenant databases. This means that our team can help you restore to a previous point in time.",
+          "header": "Backups"
+        },
+        {
+          "body": "Create, edit, and save reusable queries against your provisioned server. Databites are a custom, zero-hassle reporting solution for your database right out of the box!",
+          "header": "Databites"
+        },
+        {
+          "body": "Regardless of how big of a wave you're riding, JawsDB makes it easy to scale your database performance.",
+          "header": "Scale"
+        },
+        {
+          "body": "For single tenant plans, we provide you and only you with root credentials — so you have complete control of your server.",
+          "header": "Stay in Control"
+        },
+        {
+          "body": "The world doesn't need to be a scary place, choose a plan that supports failover and your data is replicated to servers in different regions of the world, reducing unexpected downtime.",
+          "header": "Data Replication"
+        }
+      ]
+    },
+    "id": "234udujapvu1yg2fq019qt02ynf1m",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://jawsdb.com/docs",
+      "feature_types": [
+        {
+          "label": "ram",
+          "name": "RAM",
+          "type": "string",
+          "values": [
+            { "label": "ram-generated-0", "name": "Shared" },
+            { "label": "ram-generated-9", "name": "1 GB" },
+            { "label": "ram-generated-13", "name": "2 GB" },
+            { "label": "ram-generated-16", "name": "4 GB" }
+          ]
+        },
+        {
+          "label": "storage",
+          "name": "Storage",
+          "type": "string",
+          "values": [
+            { "label": "storage-generated-1", "name": "250 MB" },
+            { "label": "storage-generated-5", "name": "1 GB" },
+            { "label": "storage-generated-7", "name": "2.5 GB" },
+            { "label": "storage-generated-10", "name": "5 GB" },
+            { "label": "storage-generated-14", "name": "50 GB" },
+            { "label": "storage-generated-17", "name": "100 GB" }
+          ]
+        },
+        {
+          "label": "connections",
+          "name": "Connections",
+          "type": "string",
+          "values": [
+            { "label": "connections-generated-2", "name": "10" },
+            { "label": "connections-generated-6", "name": "15" },
+            { "label": "connections-generated-8", "name": "30" },
+            { "label": "connections-generated-11", "name": "66" },
+            { "label": "connections-generated-15", "name": "150" },
+            { "label": "connections-generated-18", "name": "300" }
+          ]
+        },
+        {
+          "label": "single-tenant",
+          "name": "Single Tenant",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "rollback",
+          "name": "Rollback",
+          "type": "string",
+          "values": [
+            { "label": "rollback-generated-4", "name": "0 Days" },
+            { "label": "rollback-generated-12", "name": "1 Day" }
+          ]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/jawsdb/screenshots/ss1.PNG",
+        "https://cdn.manifold.co/providers/jawsdb/screenshots/ss2.PNG",
+        "https://cdn.manifold.co/providers/jawsdb/screenshots/ss3.PNG",
+        "https://cdn.manifold.co/providers/jawsdb/screenshots/ss4.PNG"
+      ],
+      "integration": {
+        "base_url": "https://api.jawsdb.com/maria",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "user-specified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://api.jawsdb.com/maria",
+        "version": "v1"
+      },
+      "label": "jawsdb-maria",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": false },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/jawsdb/logos/vd83rdtn50m0zb0yk9qzdqgz7m.png",
+      "name": "JawsDB Maria",
+      "provider_id": "2346mdxcuca9ez2n93f72nb2fpjgu",
+      "state": "available",
+      "support_email": "support@jawsdb.com",
+      "tagline": "Fast, reliable, no-bullshark MariaDB as a Service",
+      "tags": ["database"],
+      "terms": { "provided": false },
+      "value_props": [
+        {
+          "body": "MariaDB is a completely open source drop-in replacement for MySQL from one of the original developers of MySQL. Not only does MySQL code run ‘swimmingly’ on MariaDB, but Maria also adds several enhancements and features to the database you already know and love.",
+          "header": "Improving on the Best"
+        },
+        {
+          "body": "In addition to any backups you personally create, we automatically take nightly snapshots for single tenant databases. This means that our team can help you restore to a previous point in time.",
+          "header": "Backups"
+        },
+        {
+          "body": "Create, edit, and save reusable queries against your provisioned server. Databites are a custom, zero-hassle reporting solution for your database right out of the box!",
+          "header": "Databites"
+        },
+        {
+          "body": "Regardless of how big of a wave you're riding, JawsDB makes it easy to scale your database performance.",
+          "header": "Scale"
+        },
+        {
+          "body": "For single tenant plans, we provide you and only you with root credentials — so you have complete control of your server.",
+          "header": "Stay in Control"
+        },
+        {
+          "body": "The world doesn't need to be a scary place, choose a plan that supports failover and your data is replicated to servers in different regions of the world, reducing unexpected downtime.",
+          "header": "Data Replication"
+        }
+      ]
+    },
+    "id": "234wx0gvvxnqxyukyn6r7xgy9qm6u",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://documentation.mailgun.com/",
+      "feature_types": [
+        {
+          "label": "emails",
+          "name": "Emails",
+          "type": "string",
+          "values": [
+            { "label": "emails-generated-0", "name": "1000000" },
+            { "label": "emails-generated-2", "name": "30000" },
+            { "label": "emails-generated-4", "name": "100000" },
+            { "label": "emails-generated-5", "name": "500000" }
+          ]
+        },
+        {
+          "label": "ips",
+          "name": "IPs",
+          "type": "string",
+          "values": [
+            { "label": "ips-generated-1", "name": "1" },
+            { "label": "ips-generated-3", "name": "0" }
+          ]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/mailgun/mailgun/images/zkj2ruj3wtbnbyjy6ynrhcc85r.png",
+        "https://cdn.manifold.co/providers/mailgun/mailgun/images/qdjte3ux3q4jvvx3a7ze6f078g.png",
+        "https://cdn.manifold.co/providers/mailgun/mailgun/images/5bf55h4dxkvqge5ujyj5mj9260.png"
+      ],
+      "integration": {
+        "base_url": "https://platform.mailgun.com/manifold",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "unspecified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://platform.mailgun.com/manifold",
+        "version": "v1"
+      },
+      "label": "mailgun",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": false },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/mailgun/logos/q922nwncyuw263chbg86e0rw1m.png",
+      "name": "Mailgun",
+      "provider_id": "234ae8fx4ud4wqj7q0vy7vhjxvjb6",
+      "state": "available",
+      "support_email": "help@mailgun.com",
+      "tagline": "The Email Service For Developers",
+      "tags": ["messaging"],
+      "terms": { "provided": true, "url": "https://www.mailgun.com/terms" },
+      "value_props": [
+        {
+          "body": "Everything is built API first with a focus on simplicity and compliance to standards. We're serious about uptime and we have the track record to prove it.",
+          "header": "Engineered for developers for reliability"
+        },
+        {
+          "body": "Have a question? Our support team is available 24/7/365.",
+          "header": "Help when you need it"
+        },
+        {
+          "body": "Easy SMTP integration and a simple, RESTful API abstracts away the messy details of sending transactional or bulk email. Scale quickly, whether you need to send 10 or 10 million emails.",
+          "header": "Powerful sending infrastructure"
+        },
+        {
+          "body": "Route and forward email directly into your app or inbox. Email parsing turns your emails into easy-to-digest structured data and spam filtering keeps out unwanted emails.",
+          "header": "Intelligent inbound routing \u0026 storage"
+        },
+        {
+          "body": "Searchable logs mean you always know what is happening to your email while tags make it easy to A/B test and report on your data, and all via our webhooks.",
+          "header": "Tracking and analytics"
+        },
+        {
+          "body": "Advanced email validation increases your conversions. Our jQuery plugin enables you to integrate it into your web forms fast.",
+          "header": "Email validation"
+        }
+      ]
+    },
+    "id": "234mauvfd213a0a87q42eb0mmq5ye",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://www.ximilar.com/services/generic-tagging/",
+      "feature_types": [
+        {
+          "label": "requests-month",
+          "name": "Requests per month",
+          "type": "string",
+          "values": [
+            { "label": "5000", "name": "5000", "price": {} },
+            { "label": "100000", "name": "100000", "price": {} },
+            { "label": "1000000", "name": "1000000", "price": {} }
+          ]
+        },
+        {
+          "label": "recognition-tasks",
+          "name": "Recognition tasks",
+          "type": "string",
+          "values": [
+            { "label": "03", "name": "3", "price": {} },
+            { "label": "10", "name": "10", "price": {} },
+            { "label": "20", "name": "20", "price": {} }
+          ]
+        },
+        {
+          "label": "parallel-processing-requests",
+          "name": "Parallel processing of requests",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "Yes" }, { "label": "false", "name": "No" }]
+        },
+        {
+          "label": "support",
+          "name": "Support",
+          "type": "string",
+          "values": [
+            { "label": "limited", "name": "Limited Email", "price": {} },
+            { "label": "standard", "name": "Standard", "price": {} },
+            { "label": "priority", "name": "Priority", "price": {} }
+          ]
+        },
+        {
+          "label": "request",
+          "measurable": true,
+          "name": "Requests",
+          "type": "number",
+          "values": [
+            {
+              "label": "image-requests",
+              "name": "Image Requests",
+              "numeric_details": {
+                "cost_ranges": [{ "cost_multiple": 950000, "limit": -1 }],
+                "increment": 1,
+                "suffix": "request"
+              }
+            }
+          ]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/ximilar/screenshots/39d5a682-8532-405d-952b-c9b58f787fa2.png"
+      ],
+      "integration": {
+        "base_url": "https://api.ximilar.com/manifold/",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "unspecified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://api.ximilar.com/manifold/",
+        "version": "v1"
+      },
+      "label": "generic-tagging",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": true },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/ximilar/logos/9ef978f9-309e-4e0b-a9d8-ee99b78a4ac3.png",
+      "name": "Generic Image Tagging",
+      "provider_id": "2342x6jwx1xrqcnfe6nn2n89c2fc8",
+      "state": "new",
+      "support_email": "tech@ximilar.com",
+      "tagline": "Automatic tagging of everyday photos. Powerful computer vision \u0026 machine learning with blazing speed.",
+      "tags": ["optimization"],
+      "terms": { "provided": true, "url": "https://www.ximilar.com/terms-of-use-privacy/" },
+      "value_props": [
+        {
+          "body": "The service can recognises 1,000 concepts in your everyday photos.",
+          "header": "We Spot Everything"
+        },
+        {
+          "body": "You do not have to train anything, the service is ready for you.",
+          "header": "Ready To Use"
+        },
+        {
+          "body": "Performance is a key - image analysis is quick and can be processed in batches.",
+          "header": "Swift \u0026 Scalable"
+        }
+      ]
+    },
+    "id": "234hyjj2qbkpyw4z0g0bwgjgtydnj",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://docs.websolr.com",
+      "feature_types": [
+        {
+          "label": "documents",
+          "name": "Documents",
+          "type": "string",
+          "values": [
+            { "label": "documents-generated-0", "name": "10000" },
+            { "label": "documents-generated-3", "name": "1000000" },
+            { "label": "documents-generated-5", "name": "5000000" },
+            { "label": "documents-generated-8", "name": "10000000" },
+            { "label": "documents-generated-11", "name": "unlimited" }
+          ]
+        },
+        {
+          "label": "data",
+          "name": "Data",
+          "type": "string",
+          "values": [
+            { "label": "data-generated-1", "name": "1 GB" },
+            { "label": "data-generated-6", "name": "5 GB" },
+            { "label": "data-generated-9", "name": "10 GB" },
+            { "label": "data-generated-12", "name": "20 GB" },
+            { "label": "data-generated-14", "name": "50 GB" },
+            { "label": "data-generated-16", "name": "100 GB" }
+          ]
+        },
+        {
+          "label": "requests",
+          "name": "Requests/day",
+          "type": "string",
+          "values": [
+            { "label": "requests-generated-2", "name": "20000" },
+            { "label": "requests-generated-4", "name": "40000" },
+            { "label": "requests-generated-7", "name": "150000" },
+            { "label": "requests-generated-10", "name": "250000" },
+            { "label": "requests-generated-13", "name": "500000" },
+            { "label": "requests-generated-15", "name": "1000000" },
+            { "label": "requests-generated-17", "name": "2000000" }
+          ]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/onemorecloud/websolr/images/77ceu24yz3ea9wu4hyvgwjjxg8.png",
+        "https://cdn.manifold.co/providers/onemorecloud/websolr/images/cc7phdry12h58p54v452q2w1h4.png",
+        "https://cdn.manifold.co/providers/onemorecloud/websolr/images/zz7qugpmm4jcea4em0vjpe8kwr.png"
+      ],
+      "integration": {
+        "base_url": "https://www.websolr.com/manifold",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "user-specified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://www.websolr.com/manifold",
+        "version": "v1"
+      },
+      "label": "websolr",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": false },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/onemorecloud/logos/3mep371t3tgax3e8x5h5112wv4.png",
+      "name": "Websolr",
+      "provider_id": "23411mqbvgx5eqzb1qfhqfvmn27b8",
+      "state": "available",
+      "support_email": "support@websolr.com",
+      "tagline": "Solr, fully managed by the experts in hosted search at One More Cloud.",
+      "tags": ["search"],
+      "terms": { "provided": true, "url": "https://onemorecloud.com/info/terms" },
+      "value_props": [
+        {
+          "body": "Leverage Lucene’s search features to create immediate value for your users instead of spinning your wheels keeping Solr up and optimized.",
+          "header": "Build meaningful search experiences"
+        },
+        {
+          "body": "Our support team members are engineers. We take pride in our quick, thorough, and knowledgeable responses. There’s no one in our field that does Solr support better, or who have been doing it longer.",
+          "header": "Get support from real people who know search"
+        },
+        {
+          "body": "We’ve put in the years and solved the hard problems so you don’t have to. We’re on call 24/7, with hourly offsite backups and architected for 99.99% uptime.",
+          "header": "Never worry about availability"
+        },
+        {
+          "body": "With features like Secure TLS Encryption and Advanced API Credentials, never worry about keeping your data secure.",
+          "header": "Rest easy with battle-tested security"
+        },
+        {
+          "body": "When it’s time to add or remove resources, easily scale your index with no downtime.",
+          "header": "Scale with Ease"
+        },
+        {
+          "body": "We don’t compromise on quality or resiliency at any level. Our unique architecture gives you the best value for your resources, without skimping on operational best practices.",
+          "header": "The gold standard in hosted search"
+        }
+      ]
+    },
+    "id": "234kw73u6y3vdgdpxqhxbr39vxdmj",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://dumper.io/help/how",
+      "feature_types": [
+        {
+          "label": "storage",
+          "name": "Storage",
+          "type": "string",
+          "values": [
+            { "label": "storage-generated-0", "name": "1 GB" },
+            { "label": "storage-generated-2", "name": "10 GB" },
+            { "label": "storage-generated-4", "name": "100 GB" },
+            { "label": "storage-generated-6", "name": "300 GB" }
+          ]
+        },
+        {
+          "label": "backup-retention",
+          "name": "Retained Backups",
+          "type": "string",
+          "values": [
+            { "label": "backup-retention-generated-1", "name": "7 Days" },
+            { "label": "backup-retention-generated-3", "name": "14 Days" },
+            { "label": "backup-retention-generated-5", "name": "30 Days" },
+            { "label": "backup-retention-generated-7", "name": "60 Days" }
+          ]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/dumper/screenshots/7.png",
+        "https://cdn.manifold.co/providers/dumper/screenshots/1.png",
+        "https://cdn.manifold.co/providers/dumper/screenshots/2.png",
+        "https://cdn.manifold.co/providers/dumper/screenshots/3.png",
+        "https://cdn.manifold.co/providers/dumper/screenshots/4.png",
+        "https://cdn.manifold.co/providers/dumper/screenshots/5.png",
+        "https://cdn.manifold.co/providers/dumper/screenshots/6.png"
+      ],
+      "integration": {
+        "base_url": "https://dumper.io/manifold/",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "unspecified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://dumper.io/manifold/",
+        "version": "v1"
+      },
+      "label": "dumper",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": false },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/dumper/logos/512x512_2.png",
+      "name": "Dumper",
+      "provider_id": "2348fce0u9qahqwyn3a5edqkqz1wa",
+      "state": "available",
+      "support_email": "support@dumper.io",
+      "tagline": "Off-site backup-as-a-service for MySQL, PostgreSQL, MongoDB and Redis.",
+      "tags": ["database"],
+      "terms": { "provided": true, "url": "\u003chttps://dumper.io/help/terms\u003e" },
+      "value_props": [
+        {
+          "body": "VM snapshots won’t save you when your data-center catches on fire. Dumper offers the off-site backup which is the only way to protect your data from disastrous events.",
+          "header": "Disaster recovery"
+        },
+        {
+          "body": "All too often, cron jobs start to fail silently and go unnoticed for months. Dumper reports errors immediately, as well as a status summary weekly or monthly.",
+          "header": "No more silent failures"
+        },
+        {
+          "body": "We store everything on Amazon S3. It’s a highly reliable storage with an astronomical 99.999999999% durability.",
+          "header": "Security and safety"
+        },
+        {
+          "body": "Our dashboard gives you insights to understand how well backup jobs are running or how fast your datasets are growing.",
+          "header": "Insightful Dashboard"
+        },
+        {
+          "body": "In the age of polyglot persistence, Dumper offers a central location to manage all backups of all databases from all projects.",
+          "header": "Multiple databases"
+        },
+        {
+          "body": "We've been in production since 2012 and achieved 99.97% uptime per year. Our database expertise comes from scaling multiple projects with millions of users.",
+          "header": "Proven and reliable"
+        }
+      ]
+    },
+    "id": "234gy5mug2rpqcfjq109z6dcqmrgc",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://www.cloudamqp.com/docs/",
+      "feature_types": [
+        {
+          "label": "connections",
+          "name": "Connections",
+          "type": "string",
+          "values": [
+            { "label": "connections-generated-0", "name": "4000" },
+            { "label": "connections-generated-7", "name": "20" },
+            { "label": "connections-generated-12", "name": "100" },
+            { "label": "connections-generated-15", "name": "1000" },
+            { "label": "connections-generated-18", "name": "10000" },
+            { "label": "connections-generated-20", "name": "20000" },
+            { "label": "connections-generated-22", "name": "40000" },
+            { "label": "connections-generated-24", "name": "80000" }
+          ]
+        },
+        {
+          "label": "messages",
+          "name": "Messages",
+          "type": "string",
+          "values": [
+            { "label": "messages-generated-1", "name": "10k/second" },
+            { "label": "messages-generated-8", "name": "1M/month" },
+            { "label": "messages-generated-13", "name": "10M/month" },
+            { "label": "messages-generated-16", "name": "1k/second" },
+            { "label": "messages-generated-19", "name": "20k/second" },
+            { "label": "messages-generated-21", "name": "50k/second" },
+            { "label": "messages-generated-23", "name": "100k/second" },
+            { "label": "messages-generated-25", "name": "200k/second" }
+          ]
+        },
+        {
+          "label": "queued-messages",
+          "name": "Queued Messages",
+          "type": "string",
+          "values": [
+            { "label": "queued-messages-generated-2", "name": "Unlimited" },
+            { "label": "queued-messages-generated-9", "name": "10,000" },
+            { "label": "queued-messages-generated-14", "name": "100,000" }
+          ]
+        },
+        {
+          "label": "nodes",
+          "name": "Nodes",
+          "type": "string",
+          "values": [
+            { "label": "nodes-generated-3", "name": "Two Mirrored" },
+            { "label": "nodes-generated-10", "name": "Shared" },
+            { "label": "nodes-generated-17", "name": "Single" }
+          ]
+        },
+        {
+          "label": "multi-az",
+          "name": "Multi AZ Mirroring",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "autoheal",
+          "name": "Autoheal",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "idle-time",
+          "name": "Idle Queue Time",
+          "type": "string",
+          "values": [
+            { "label": "idle-time-generated-6", "name": "Unlimited" },
+            { "label": "idle-time-generated-11", "name": "Max 28 Days" }
+          ]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/84codes/cloudamqp/images/zkj2ruj3wtbnbyjy6ynrhcc85r.jpg",
+        "https://cdn.manifold.co/providers/84codes/cloudamqp/images/qdjte3ux3q4jvvx3a7ze6f078g.jpg",
+        "https://cdn.manifold.co/providers/84codes/cloudamqp/images/5bf55h4dxkvqge5ujyj5mj9260.jpg",
+        "https://cdn.manifold.co/providers/84codes/cloudamqp/images/qhn2j8mek2hn8ek88r92heyv64.jpg",
+        "https://cdn.manifold.co/providers/84codes/cloudamqp/images/mdnkd18vk3hbwpf7ymt3uqq828.jpg"
+      ],
+      "integration": {
+        "base_url": "https://api.cloudamqp.com/api/manifold",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "user-specified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://api.cloudamqp.com/api/manifold",
+        "version": "v1"
+      },
+      "label": "cloudamqp",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": false },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/84codes/logos/ctg5nbw5zp51u5begurzxry2tm.png",
+      "name": "CloudAMQP",
+      "provider_id": "23495cy7q7kpcnbp4gkk8zaejtbvj",
+      "state": "available",
+      "support_email": "support@cloudamqp.com",
+      "tagline": "Perfectly configured and optimized RabbitMQ clusters ready in 2 minutes.",
+      "tags": ["memory-store", "messaging"],
+      "terms": { "provided": true, "url": "https://www.cloudamqp.com/terms_of_service.html" },
+      "value_props": [
+        {
+          "body": "Queue job messages for your workers. CloudAMQP gives you in-order, no-duplicates guarantees and high availability as the messages can be replicated between multiple RabbitMQ nodes.",
+          "header": "Message queueing"
+        },
+        {
+          "body": "Instead of building a massive application many teams find it beneficial to decouple different concerns in your application and only communicate between them asynchronously with messages. That way different parts of your application can evolve independently, be written in different languages and/or maintained by complete separated teams.",
+          "header": "Application decoupling"
+        },
+        {
+          "body": "Instead of polling your data store, publish a message when new data is inserted. Interested parties will be notified immediately and your data store will be ready to answer qualified queries instead.",
+          "header": "Offload your data store"
+        },
+        {
+          "body": "CloudAMQP is an excellent backend for realtime applications. Notifications and message streaming is handled very effectively by RabbitMQ, you’ll be able to push thousands of messages per second.",
+          "header": "Realtime applications"
+        },
+        {
+          "body": "All our servers are clustered and all queues are by default mirrored over all nodes. The load-balancer will automatically detect and temporarily remove unhealthy nodes. We provide RabbitMQ clusters you can rely on.",
+          "header": "High Availability"
+        },
+        {
+          "body": "Unlike most other hosted message queue services you’re not risking vendor lock-in with CloudAMQP. Have RabbitMQ installed locally when you develop, for fast, free and offline available usage.",
+          "header": "RabbitMQ is open source"
+        }
+      ]
+    },
+    "id": "234u3fyxq4pa2kzcu23w77cd9tq4g",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://www.ximilar.com/services/image-recognition/",
+      "feature_types": [
+        {
+          "label": "requests-month",
+          "name": "Requests per month",
+          "type": "string",
+          "values": [
+            { "label": "5000", "name": "5000", "price": {} },
+            { "label": "100000", "name": "100000", "price": {} },
+            { "label": "1000000", "name": "1000000", "price": {} }
+          ]
+        },
+        {
+          "label": "recognition-tasks",
+          "name": "Recognition tasks",
+          "type": "string",
+          "values": [
+            { "label": "03", "name": "3", "price": {} },
+            { "label": "10", "name": "10", "price": {} },
+            { "label": "20", "name": "20", "price": {} }
+          ]
+        },
+        {
+          "label": "parallel-processing-requests",
+          "name": "Parallel processing of requests",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "Yes" }, { "label": "false", "name": "No" }]
+        },
+        {
+          "label": "support",
+          "name": "Support",
+          "type": "string",
+          "values": [
+            { "label": "limited", "name": "Limited Email", "price": {} },
+            { "label": "standard", "name": "Standard", "price": {} },
+            { "label": "priority", "name": "Priority", "price": {} }
+          ]
+        },
+        {
+          "label": "request",
+          "measurable": true,
+          "name": "Requests",
+          "type": "number",
+          "values": [
+            {
+              "label": "image-requests",
+              "name": "Image Requests",
+              "numeric_details": {
+                "cost_ranges": [{ "cost_multiple": 950000, "limit": -1 }],
+                "increment": 1,
+                "suffix": "requests"
+              }
+            }
+          ]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/ximilar/screenshots/30aa29b2-8a55-4277-b755-53fe375bbf51.png"
+      ],
+      "integration": {
+        "base_url": "https://api.ximilar.com/manifold/",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "unspecified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://api.ximilar.com/manifold/",
+        "version": "v1"
+      },
+      "label": "custom-recognition",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": true },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/ximilar/logos/c469ba54-687c-4412-9672-75fdc91d35ab.png",
+      "name": "Custom Image Recognition",
+      "provider_id": "2342x6jwx1xrqcnfe6nn2n89c2fc8",
+      "state": "new",
+      "support_email": "tech@ximilar.com",
+      "tagline": "Image classification \u0026 tagging by your labels. Powerful computer vision \u0026 machine learning with blazing speed.",
+      "tags": ["optimization"],
+      "terms": { "provided": true, "url": "https://www.ximilar.com/terms-of-use-privacy/" },
+      "value_props": [
+        {
+          "body": "Use deep learning algorithms with the highest accuracy on the market.",
+          "header": "High Accuracy"
+        },
+        {
+          "body": "Implement cutting-edge vision automation faster with no development costs.",
+          "header": "Simple Setup \u0026 Use"
+        },
+        {
+          "body": "Train custom neural network to recognize your specific images.",
+          "header": "Recognize Anything"
+        },
+        {
+          "body": "Create powerful and custom image recognizers in intuitive web interface.",
+          "header": "Training Interface"
+        },
+        { "body": "Scale up easily with no infrastructure costs.", "header": "Scalable" },
+        {
+          "body": "Ongoing improvements of the underlying machine learning algorithms. You are up-to-date",
+          "header": "Improving Constantly"
+        }
+      ]
+    },
+    "id": "234q7ufpnwffnw63ktp1bzeqzxzdy",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://piio.co/docs",
+      "feature_types": [
+        {
+          "label": "users",
+          "name": "Users",
+          "type": "string",
+          "values": [
+            { "label": "users-generated-0", "name": "100" },
+            { "label": "users-generated-8", "name": "5000" },
+            { "label": "users-generated-9", "name": "20000" },
+            { "label": "users-generated-10", "name": "100000" }
+          ]
+        },
+        {
+          "label": "image-compression",
+          "name": "Image Compression",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "pixel-perfect",
+          "name": "Pixel Perfect",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "global-cdn",
+          "name": "Global CDN",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "automatic-updates",
+          "name": "Automatic Updates",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "email-support",
+          "name": "Email Support",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "slack-support",
+          "name": "Slack Support",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "phone-support",
+          "name": "Phone Support",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/piio/screenshots/1.png",
+        "https://cdn.manifold.co/providers/piio/screenshots/2.png",
+        "https://cdn.manifold.co/providers/piio/screenshots/3.png"
+      ],
+      "integration": {
+        "base_url": "https://app.piio.co/api/",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "unspecified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://app.piio.co/",
+        "version": "v1"
+      },
+      "label": "piio",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": true },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/piio/logos/512x512.png",
+      "name": "Piio",
+      "provider_id": "23411q5cm1tycd507awqnqzdeenvc",
+      "state": "new",
+      "support_email": "support@piio.co",
+      "tagline": "Never optimize an image again, automatic image optimization for your website.",
+      "tags": ["optimization"],
+      "terms": { "provided": true, "url": "\u003chttps://app.piio.co/terms\u003e" },
+      "value_props": [
+        {
+          "body": "Don’t worry about multiple resolutions or mobile devices, Piio automatically loads the best image for each device. Including Hi-DPR (Retina) support and Super Fast Device Detection.",
+          "header": "Cross device experience"
+        },
+        {
+          "body": "We learn from your html and deliver pixel perfect images, they don't only load faster but they'll look better.",
+          "header": "Automatic Responsive Images"
+        },
+        {
+          "body": "With worldwide reach, our CDN provides low latency and faster download times. We also provide 160 edges and regional caches worldwide.",
+          "header": "CDN Delivered"
+        },
+        {
+          "body": "Copy and paste one code in the html and you're done! You don't need to change anything on your backend or how you store your images.",
+          "header": "Super easy to integrate!"
+        },
+        {
+          "body": "Piio is cloud based and scales with your needs.",
+          "header": "Scales to your needs"
+        },
+        {
+          "body": "We help your website load faster by optimizing your images in real time and deliver them to your visitors at maximum speed. Expect better image quality, faster load times and more conversions.",
+          "header": "Real-time Image Optimization"
+        },
+        {
+          "body": "Piio can deliver images in WebP or MozJPEG format every time browser supports it.",
+          "header": "WebP support, MozJPEG support"
+        },
+        {
+          "body": "For those with more needs, Piio provides custom advanced parameters like: Piio mode (to choose how to use Piio), Lazy loading (to improve the site load and user experience), Dev mode (it’s a great feature if in your development environment you need to serve your images from your machine), Disable Webp (for those that do not need WebP format at all), Crop (in case you also need to crop an image).",
+          "header": "Advanced configuration"
+        }
+      ]
+    },
+    "id": "234vvhkmmpg2mtvr7vqpf1b439y9y",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://apps.elegantcms.io/documentation",
+      "feature_types": [
+        {
+          "label": "users",
+          "name": "Users",
+          "type": "string",
+          "values": [
+            { "label": "users-generated-0", "name": "1" },
+            { "label": "users-generated-6", "name": "4" },
+            { "label": "users-generated-11", "name": "18" },
+            { "label": "users-generated-17", "name": "50" },
+            { "label": "users-generated-23", "name": "125" }
+          ]
+        },
+        {
+          "label": "apps",
+          "name": "Apps",
+          "type": "string",
+          "values": [
+            { "label": "apps-generated-1", "name": "1" },
+            { "label": "apps-generated-12", "name": "5" },
+            { "label": "apps-generated-18", "name": "15" },
+            { "label": "apps-generated-24", "name": "40" }
+          ]
+        },
+        {
+          "label": "cms-items",
+          "name": "CMS Items",
+          "type": "string",
+          "values": [
+            { "label": "cms-items-generated-2", "name": "1000" },
+            { "label": "cms-items-generated-7", "name": "2500" },
+            { "label": "cms-items-generated-13", "name": "10000" },
+            { "label": "cms-items-generated-19", "name": "25000" },
+            { "label": "cms-items-generated-25", "name": "75000" }
+          ]
+        },
+        {
+          "label": "gb-storage",
+          "name": "GB Storage",
+          "type": "string",
+          "values": [
+            { "label": "gb-storage-generated-3", "name": "10" },
+            { "label": "gb-storage-generated-8", "name": "30" },
+            { "label": "gb-storage-generated-14", "name": "125" },
+            { "label": "gb-storage-generated-20", "name": "250" },
+            { "label": "gb-storage-generated-26", "name": "500" }
+          ]
+        },
+        {
+          "label": "api-requests",
+          "name": "API Requests",
+          "type": "string",
+          "values": [
+            { "label": "api-requests-generated-4", "name": "50000" },
+            { "label": "api-requests-generated-9", "name": "100000" },
+            { "label": "api-requests-generated-15", "name": "350000" },
+            { "label": "api-requests-generated-21", "name": "1000000" },
+            { "label": "api-requests-generated-27", "name": "25000000" }
+          ]
+        },
+        {
+          "label": "gb-transfer",
+          "name": "GB Transfer",
+          "type": "string",
+          "values": [
+            { "label": "gb-transfer-generated-5", "name": "25" },
+            { "label": "gb-transfer-generated-10", "name": "50" },
+            { "label": "gb-transfer-generated-16", "name": "200" },
+            { "label": "gb-transfer-generated-22", "name": "600" },
+            { "label": "gb-transfer-generated-28", "name": "1500" }
+          ]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/elegant-cms/screenshots/ss1.png",
+        "https://cdn.manifold.co/providers/elegant-cms/screenshots/ss2.png",
+        "https://cdn.manifold.co/providers/elegant-cms/screenshots/ss3.png",
+        "https://cdn.manifold.co/providers/elegant-cms/screenshots/ss4.png",
+        "https://cdn.manifold.co/providers/elegant-cms/screenshots/ss5.png"
+      ],
+      "integration": {
+        "base_url": "https://apps.elegantcms.io/manifold/",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "unspecified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://apps.elegantcms.io/manifold/",
+        "version": "v1"
+      },
+      "label": "elegant-cms",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": false },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/elegant-cms/logos/280x280.png",
+      "name": "Elegant CMS",
+      "provider_id": "234bpdr48mzd8npnztefjevwmzmnu",
+      "state": "available",
+      "support_email": "support@elegantcms.io",
+      "tagline": "Headless CMS with JSON-API interface. The essential power features to manage all content within your application.",
+      "tags": ["cms"],
+      "terms": { "provided": true, "url": "https://www.elegantcms.io/terms-of-service" },
+      "value_props": [
+        {
+          "body": "Make a CMS part of your application using our RESTFUL JSON - API, so business users can self - manage all content with the application and not need to turn to developers for updates.",
+          "header": "Never get asked to update content again"
+        },
+        {
+          "body": "Eliminate the content management challenge, one of the greatest sources of end-user dissatisfaction. Focus development on building \u0026amp; maintaining the valuable features of your applications.",
+          "header": "Develop better applications without the distraction of coding a CMS"
+        },
+        {
+          "body": "Design your own content models with powerful GUI Content Manager \u0026amp; content type relationships -- authors can work more quickly while maintaining content integrity through re-use.",
+          "header": "Customizable content model"
+        },
+        {
+          "body": "Enable authors to self-manage content with an easy to use interface accessed from any device. Quickly build and publish content with the help of field constraints, contextual help and a scheduler.",
+          "header": "Authors enjoy easy to use interface"
+        },
+        {
+          "body": "Provide role specific access control to authors, developers and admins to effectively and securely manage applications you own or built.",
+          "header": "Total control over the user experience and application "
+        },
+        {
+          "body": "Separate read/ write API ensures your users enjoy the type of performance expected.",
+          "header": "Blazing fast performance"
+        }
+      ]
+    },
+    "id": "234qqzb2wm6gavkvaqr9e6b54j9dg",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://till.readme.io/docs",
+      "feature_types": [
+        {
+          "label": "renders",
+          "name": "Renders",
+          "type": "string",
+          "values": [
+            { "label": "renders-generated-0", "name": "100" },
+            { "label": "renders-generated-7", "name": "500" },
+            { "label": "renders-generated-8", "name": "200" },
+            { "label": "renders-generated-9", "name": "1000" },
+            { "label": "renders-generated-10", "name": "2000" },
+            { "label": "renders-generated-11", "name": "5000" },
+            { "label": "renders-generated-12", "name": "30000" },
+            { "label": "renders-generated-13", "name": "15000" }
+          ]
+        },
+        {
+          "label": "inbound_sms",
+          "name": "Inbound SMS",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "webhooks",
+          "name": "Webhooks",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "results_api",
+          "name": "Results API",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "stats_api",
+          "name": "Stats API",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "outbound_sms",
+          "name": "Outbound SMS",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "dedicated_number",
+          "name": "Dedicated Number",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/till/screenshots/image3.png",
+        "https://cdn.manifold.co/providers/till/screenshots/image2.png",
+        "https://cdn.manifold.co/providers/till/screenshots/image1.png"
+      ],
+      "integration": {
+        "base_url": "https://platform.tillmobile.com/addon/manifold/",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "unspecified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://platform.tillmobile.com/addon/manifold/v1/sso/",
+        "version": "v1"
+      },
+      "label": "till",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": true, "new": false },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/till-mobile/logos/5854b4df-8e3d-42ad-bbc7-1b2f89877ce5.png",
+      "name": "Till",
+      "provider_id": "234fvnnbq48pxabznkaxk2upyef2y",
+      "state": "available",
+      "support_email": "support@tillmobile.com",
+      "tagline": "Your two-way SMS \u0026 Voice Microservice",
+      "tags": ["messaging"],
+      "terms": { "provided": true, "url": "https://tillmobile.com/terms-of-service/" },
+      "value_props": [
+        {
+          "body": "SMS is the leading asynchronous communication medium. Available on 4.5B phones worldwide, SMS messages generate a 45% response rate and a ~98% open rate compared to 6% and 20% for email.",
+          "header": "SMS \u0026 Voice Communication"
+        },
+        {
+          "body": "You get to focus on building out the core competencies and features of your app and let Till manage the complexity of stateful SMS conversations between your application and your users.",
+          "header": "Reduced Development Effort"
+        },
+        { "body": "Be ready when your app takes off.", "header": "Scalable Infrastucture" },
+        {
+          "body": "Not just alerts. Enable interactive SMS \u0026 Voice in your app.",
+          "header": "Two-Way Communication"
+        },
+        {
+          "body": "Use our HTTP API to ask create interactions via SMS \u0026 Voice, collect real-time responses via webhook.",
+          "header": "Easily Send and Receive SMS Messages \u0026 Voice Calls"
+        }
+      ]
+    },
+    "id": "234jqxdqzjmcr5vu8uhc8dacx3xww",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "http://dev.iron.io/",
+      "feature_types": [
+        {
+          "label": "concurent-workers",
+          "name": "Concurrent Workers",
+          "type": "string",
+          "values": [
+            { "label": "concurent-workers-generated-0", "name": "30" },
+            { "label": "concurent-workers-generated-8", "name": "5" },
+            { "label": "concurent-workers-generated-10", "name": "60" },
+            { "label": "concurent-workers-generated-12", "name": "1" },
+            { "label": "concurent-workers-generated-14", "name": "100" }
+          ]
+        },
+        {
+          "label": "hours-mo",
+          "name": "Hours per Month",
+          "type": "string",
+          "values": [
+            { "label": "hours-mo-generated-1", "name": "25000" },
+            { "label": "hours-mo-generated-9", "name": "5000" },
+            { "label": "hours-mo-generated-11", "name": "45000" },
+            { "label": "hours-mo-generated-13", "name": "800" },
+            { "label": "hours-mo-generated-15", "name": "unlimited" }
+          ]
+        },
+        {
+          "label": "ram",
+          "name": "RAM in MiB",
+          "type": "string",
+          "values": [{ "label": "ram-generated-2", "name": "512" }]
+        },
+        {
+          "label": "runtime",
+          "name": "Runtime in Minutes",
+          "type": "string",
+          "values": [{ "label": "runtime-generated-3", "name": "60" }]
+        },
+        {
+          "label": "auto-retry",
+          "name": "Auto Retry",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "autoscaling",
+          "name": "Autoscaling",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "webhooks",
+          "name": "Webhooks",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "logging-integration",
+          "name": "Logging Integration",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        }
+      ],
+      "images": ["https://cdn.manifold.co/providers/iron-io/screenshots/worker-lowres.png"],
+      "integration": {
+        "base_url": "https://billy.iron.io/manifold/",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "user-specified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://billy.iron.io/manifold/",
+        "version": "v1"
+      },
+      "label": "iron_worker",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": true },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/iron-io/logos/worker-200x200.png",
+      "name": "IronWorker",
+      "provider_id": "23423wffqvcmbdyyktzjy9wu6d120",
+      "state": "new",
+      "support_email": "support@iron.io",
+      "tagline": "Highly available and scalable task queue / worker service. Starting at $26/mo.",
+      "tags": ["worker"],
+      "terms": { "provided": true, "url": "\u003chttps://www.iron.io/terms\u003e" },
+      "value_props": [
+        {
+          "body": "Run tens, hundreds, or thousands of tasks – chunks of functionality in your application – at once. No need to stand up servers or manage queues.",
+          "header": "Workers at Scale"
+        },
+        {
+          "body": "Workers are not platform-specific. Write code like you would for your own machine. There's no lock-in, nothing to change in your code.",
+          "header": "Painless Setup"
+        },
+        {
+          "body": "Tasks queues provide a simple solution to distribute workloads across a system, processing them asynchronously. This allows your application to elastically scale and provides strong reliability.",
+          "header": "Distributed, Asynchronous Processing"
+        },
+        {
+          "body": "Distribute your work horizontally across thousands of cores. Workers run across our entire cloud, making it possible to reduce jobs that took ten hours to jobs that take ten minutes.",
+          "header": "Highly Concurrent Processing"
+        },
+        {
+          "body": "Stop worrying about servers and maintenance. Our elastic infrastructure is a secure, managed environment that scales with your application. Focus on your code, not your servers.",
+          "header": "Hosted Environment"
+        }
+      ]
+    },
+    "id": "234we3e052j7aywctt4ut62yxkddj",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://timber.io/docs/",
+      "feature_types": [
+        {
+          "label": "volume",
+          "name": "Volume - per month",
+          "type": "string",
+          "values": [
+            { "label": "volume-generated-0", "name": "8 GB" },
+            { "label": "volume-generated-3", "name": "1 TB" },
+            { "label": "volume-generated-4", "name": "1.5 TB" },
+            { "label": "volume-generated-5", "name": "10 TB" },
+            { "label": "volume-generated-6", "name": "750 GB" },
+            { "label": "volume-generated-7", "name": "2 GB" },
+            { "label": "volume-generated-9", "name": "2 TB" },
+            { "label": "volume-generated-10", "name": "5 TB" },
+            { "label": "volume-generated-11", "name": "250 MB" },
+            { "label": "volume-generated-13", "name": "500 GB" },
+            { "label": "volume-generated-14", "name": "128 GB" },
+            { "label": "volume-generated-15", "name": "64 GB" },
+            { "label": "volume-generated-16", "name": "250 GB" },
+            { "label": "volume-generated-17", "name": "96 GB" },
+            { "label": "volume-generated-18", "name": "32 GB" },
+            { "label": "volume-generated-19", "name": "16 GB" },
+            { "label": "volume-generated-20", "name": "4 GB" }
+          ]
+        },
+        {
+          "label": "retention",
+          "name": "Retention",
+          "type": "string",
+          "values": [
+            { "label": "retention-generated-1", "name": "30 days" },
+            { "label": "retention-generated-8", "name": "7 days" },
+            { "label": "retention-generated-12", "name": "1 days" }
+          ]
+        },
+        {
+          "label": "users",
+          "name": "Users",
+          "type": "string",
+          "values": [{ "label": "users-generated-2", "name": "unlimited" }]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/timber/screenshots/1.png",
+        "https://cdn.manifold.co/providers/timber/screenshots/2.png",
+        "https://cdn.manifold.co/providers/timber/screenshots/3.png",
+        "https://cdn.manifold.co/providers/timber/screenshots/4.png"
+      ],
+      "integration": {
+        "base_url": "https://api.timber.io/provisioning/manifold",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "user-specified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://api.timber.io/sso/manifold_resource",
+        "version": "v1"
+      },
+      "label": "timber-logging",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": false },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/timber/logos/timber.png",
+      "name": "Timber.io Logging",
+      "provider_id": "2349ev2ypwh8tecjdf21m8ky7yfhy",
+      "state": "available",
+      "support_email": "support@timber.io",
+      "tagline": "Log better. Solve problems faster.",
+      "tags": ["logging"],
+      "terms": { "provided": true, "url": "\u0026lt;https://timber.io/terms\u0026gt;" },
+      "value_props": [
+        {
+          "body": "Simple, fast, low memory footprint, easy to use. The best logging interface in the industry.",
+          "header": "Modern Interface"
+        },
+        {
+          "body": "Invite your whole team. Unrestricted access to your data.",
+          "header": "Unlimited Users"
+        },
+        {
+          "body": "Get up and running in minutes. Simple, copy-and-paste setup instructions.",
+          "header": "Simple setup"
+        },
+        {
+          "body": "From 1gb to 1tb, blazing fast regardless of the amount of data.",
+          "header": "🔥 Blazing 🔥 fast search"
+        },
+        {
+          "body": "Conveniently switch between apps directly within Timber, search across all of them with ease.",
+          "header": "Multi-app support"
+        },
+        {
+          "body": "No games, fully-featured free plans, retention and all, making it perfect for your staging and development apps.",
+          "header": "Fully-featured free plans"
+        }
+      ]
+    },
+    "id": "234yxhkjk8y0c3zjhcxg8brykrnuu",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "http://dev.iron.io/",
+      "feature_types": [
+        {
+          "label": "data-size",
+          "name": "Data Size",
+          "type": "string",
+          "values": [
+            { "label": "data-size-generated-0", "name": "100" },
+            { "label": "data-size-generated-6", "name": "5000" },
+            { "label": "data-size-generated-8", "name": "1000" },
+            { "label": "data-size-generated-10", "name": "20000" }
+          ]
+        },
+        {
+          "label": "requests-month",
+          "name": "Requests Per Month",
+          "type": "string",
+          "values": [
+            { "label": "requests-month-generated-1", "name": "10000000" },
+            { "label": "requests-month-generated-7", "name": "150000000" },
+            { "label": "requests-month-generated-9", "name": "50000000" },
+            { "label": "requests-month-generated-11", "name": "500000000" }
+          ]
+        },
+        {
+          "label": "unlimited-caches",
+          "name": "Unlimited Caches",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "ssl",
+          "name": "SSL",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "high-availability",
+          "name": "High Availability",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "phone-support",
+          "name": "Phone Support",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        }
+      ],
+      "images": ["https://cdn.manifold.co/providers/iron-io/screenshots/cache-lowres.png"],
+      "integration": {
+        "base_url": "https://billy.iron.io/manifold/",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "user-specified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://billy.iron.io/manifold/",
+        "version": "v1"
+      },
+      "label": "iron_cache",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": true },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/iron-io/logos/cache-200x200.png",
+      "name": "IronCache",
+      "provider_id": "23423wffqvcmbdyyktzjy9wu6d120",
+      "state": "new",
+      "support_email": "support@iron.io",
+      "tagline": "Elastic, scalable, highly available, secure cloud-based key/value store. Starting at $0/mo.",
+      "tags": ["memory-store"],
+      "terms": { "provided": true, "url": "\u003chttps://www.iron.io/terms\u003e" },
+      "value_props": [
+        {
+          "body": "Built with open standards in mind, which means no lock-in and maximum flexibility. Change endpoints from a local cache and move to a cache in the cloud.",
+          "header": "Built On Open Standards"
+        },
+        {
+          "body": "Make use of a large set of IronCache language libraries including Ruby, PHP, Python, Go, and more. Or choose from a long list of memcached interfaces.",
+          "header": "Speak Your Own Language"
+        },
+        {
+          "body": "Written with elasticity and scale at its core, IronCache is built using high-performance languages designed for concurrency.",
+          "header": "Data Storage At Scale"
+        },
+        {
+          "body": "The people building IronCache every day staff a public chat room, ready to answer questions and help you.",
+          "header": "23/7 Chat Support"
+        }
+      ]
+    },
+    "id": "234pder46cj32zuj6eh5uhyc8tjxe",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://docs.posthook.io/",
+      "feature_types": [
+        {
+          "label": "requests-scheduled-per-month",
+          "name": "Scheduled Requests",
+          "type": "string",
+          "values": [
+            { "label": "500", "name": "500" },
+            { "label": "5000", "name": "50 000" },
+            { "label": "20000", "name": "200 000" },
+            { "label": "100000", "name": "1 000 000" }
+          ]
+        },
+        {
+          "label": "projects",
+          "name": "Projects",
+          "type": "string",
+          "values": [
+            { "label": "01", "name": "1" },
+            { "label": "02", "name": "2" },
+            { "label": "03", "name": "3" },
+            { "label": "10", "name": "10" }
+          ]
+        },
+        {
+          "label": "email-notifications",
+          "name": "Email Notifications",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "Yes" }, { "label": "false", "name": "No" }]
+        },
+        {
+          "label": "configurable-retries",
+          "name": "Configurable Retries",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "Yes" }, { "label": "false", "name": "No" }]
+        },
+        {
+          "label": "priority-support",
+          "name": "Priority Support",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "Yes" }, { "label": "false", "name": "No" }]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/posthook/screenshots/32bb056e-9c74-4229-b393-99597fcd9833.png",
+        "https://cdn.manifold.co/providers/posthook/screenshots/f3210722-60eb-4320-8228-3283323d3e5d.png",
+        "https://cdn.manifold.co/providers/posthook/screenshots/0b743185-49e7-4d6a-bca1-3eaee7aa67a5.png",
+        "https://cdn.manifold.co/providers/posthook/screenshots/1b7ed459-4e9d-4994-9c40-598b6664bdd0.png",
+        "https://cdn.manifold.co/providers/posthook/screenshots/e94f9e64-c4d8-4104-81f1-a60847f47881.png"
+      ],
+      "integration": {
+        "base_url": "https://api.posthook.io/manifold",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "unspecified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://posthook.io/app/msso",
+        "version": "v1"
+      },
+      "label": "posthook",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": true },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/posthook/logos/0479c2e7-5bae-42b3-b8ca-5f2b2640386e.png",
+      "name": "Posthook",
+      "provider_id": "23480zdan3x3ydz25dy1mr8pug50p",
+      "state": "new",
+      "support_email": "support@posthook.io",
+      "tagline": "Simple, Robust Job Scheduling For Your Application",
+      "tags": ["worker", "messaging"],
+      "terms": { "provided": true, "url": "https://posthook.io/terms" },
+      "value_props": [
+        {
+          "body": "No need to set up and manage additional infrastructure. Works with any HTTP-based backends, including serverless ones.",
+          "header": "Use your Existing Infrastructure"
+        },
+        {
+          "body": "Posthook is hosted on multiple Google Cloud Platform availability zones and leverages highly available systems.",
+          "header": "Architected for Reliability"
+        },
+        {
+          "body": "Requests to your servers are made over HTTPS and cryptographically signed so they can be verified to be legitimate.",
+          "header": "Secure"
+        },
+        {
+          "body": "Manage your projects and see the status of your scheduled requests at a glance.",
+          "header": "Rich Dashboard"
+        },
+        {
+          "body": "Get instantly notified when we are not able to complete a scheduled request to your application.",
+          "header": "Failure Notifications"
+        },
+        {
+          "body": "Configure the number of times Posthook retries scheduled requests and the delay between each retry.",
+          "header": "Custom Retries"
+        }
+      ]
+    },
+    "id": "234unyrqtdvmyk71qf3cgapdrn9wj",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://docs.oauth.io/",
+      "feature_types": [
+        {
+          "label": "api-calls-per-month",
+          "name": "API Calls per Month",
+          "type": "string",
+          "values": [
+            { "label": "20000-per-month", "name": "20,000 / month", "price": {} },
+            { "label": "400000-per-month", "name": "400,000 / month", "price": {} },
+            { "label": "8000000-per-month", "name": "8,000,000 / month", "price": {} }
+          ]
+        },
+        {
+          "label": "support-type",
+          "name": "Support Type",
+          "type": "string",
+          "values": [
+            { "label": "email", "name": "Email", "price": {} },
+            {
+              "label": "priority-email-and-chat",
+              "name": "Priority live chat and emails",
+              "price": {}
+            },
+            {
+              "label": "direct-line",
+              "name": "Priority live chat and email, CEO's direct line",
+              "price": {}
+            }
+          ]
+        },
+        {
+          "label": "user-management-api",
+          "name": "User Management API",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "Yes" }, { "label": "false", "name": "No" }]
+        },
+        {
+          "label": "request-api",
+          "name": "Request API",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "Yes" }, { "label": "false", "name": "No" }]
+        },
+        {
+          "label": "oauth-server-solution",
+          "name": "OAuth Server Solution",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "Yes" }, { "label": "false", "name": "No" }]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/oauth-io/screenshots/1-homepage.png",
+        "https://cdn.manifold.co/providers/oauth-io/screenshots/2-providers.png",
+        "https://cdn.manifold.co/providers/oauth-io/screenshots/3-100providers.png",
+        "https://cdn.manifold.co/providers/oauth-io/screenshots/4-analytics.png",
+        "https://cdn.manifold.co/providers/oauth-io/screenshots/5-user-management.png",
+        "https://cdn.manifold.co/providers/oauth-io/screenshots/7-oauth-server.png"
+      ],
+      "integration": {
+        "base_url": "https://oauth.io/",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "unspecified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://oauth.io/",
+        "version": "v1"
+      },
+      "label": "oauth-io",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": true },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/oauth-io/60x60.png",
+      "name": "OAuth.io",
+      "provider_id": "23466043urzgmmhkarudemqv28t8g",
+      "state": "new",
+      "support_email": "support@oauth.io",
+      "tagline": "OAuth that just works. Choose from 100+ OAuth providers and integrate with them in minutes",
+      "tags": ["authentication"],
+      "terms": { "provided": true, "url": "https://oauth.io/terms" },
+      "value_props": []
+    },
+    "id": "234mbngepc31ebkb0dp7j12b7ukjy",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://jawsdb.com/docs",
+      "feature_types": [
+        {
+          "label": "static-ram",
+          "name": "RAM",
+          "type": "string",
+          "values": [
+            { "label": "ram-generated-0", "name": "Shared" },
+            { "label": "ram-generated-10", "name": "1 GB" },
+            { "label": "ram-generated-14", "name": "2 GB" },
+            { "label": "ram-generated-17", "name": "4 GB" },
+            { "label": "ram-generated-21", "name": "8 GB" }
+          ]
+        },
+        {
+          "label": "static-storage",
+          "name": "Storage",
+          "type": "string",
+          "values": [
+            { "label": "storage-generated-1", "name": "250 MB" },
+            { "label": "storage-generated-6", "name": "1 GB" },
+            { "label": "storage-generated-8", "name": "2.5 GB" },
+            { "label": "storage-generated-11", "name": "5 GB" },
+            { "label": "storage-generated-15", "name": "50 GB" },
+            { "label": "storage-generated-18", "name": "100 GB" },
+            { "label": "storage-generated-22", "name": "250 GB" }
+          ]
+        },
+        {
+          "label": "static-connections",
+          "name": "Connections",
+          "type": "string",
+          "values": [
+            { "label": "connections-generated-2", "name": "10" },
+            { "label": "connections-generated-7", "name": "15" },
+            { "label": "connections-generated-9", "name": "30" },
+            { "label": "connections-generated-12", "name": "66" },
+            { "label": "connections-generated-16", "name": "150" },
+            { "label": "connections-generated-19", "name": "300" },
+            { "label": "connections-generated-23", "name": "600" }
+          ]
+        },
+        {
+          "label": "static-single-tenant",
+          "name": "Single Tenant",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "static-high-availability",
+          "name": "High Availability",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "static-rollback",
+          "name": "Rollback",
+          "type": "string",
+          "values": [
+            { "label": "rollback-generated-4", "name": "0 Days" },
+            { "label": "rollback-generated-13", "name": "1 Day" },
+            { "label": "rollback-generated-20", "name": "2 Days" }
+          ]
+        },
+        {
+          "customizable": true,
+          "downgradable": true,
+          "label": "instance_class",
+          "name": "RAM",
+          "type": "string",
+          "upgradable": true,
+          "values": [
+            { "label": "db.t2.micro", "name": "1 GB", "price": {} },
+            { "cost": 5400, "label": "db.t2.small", "name": "2 GB", "price": { "cost": 5400 } },
+            { "cost": 13400, "label": "db.m3.medium", "name": "4 GB", "price": { "cost": 13400 } },
+            { "cost": 31800, "label": "db.m4.large", "name": "8 GB", "price": { "cost": 31800 } },
+            { "cost": 54400, "label": "db.r4.large", "name": "15 GB", "price": { "cost": 54400 } },
+            { "cost": 89000, "label": "db.r4.xlarge", "name": "31 GB", "price": { "cost": 89000 } },
+            {
+              "cost": 121000,
+              "label": "db.r4.2xlarge",
+              "name": "61 GB",
+              "price": { "cost": 121000 }
+            },
+            {
+              "cost": 239000,
+              "label": "db.r4.4xlarge",
+              "name": "122 GB",
+              "price": { "cost": 239000 }
+            },
+            {
+              "cost": 428000,
+              "label": "db.r4.8xlarge",
+              "name": "244 GB",
+              "price": { "cost": 428000 }
+            },
+            {
+              "cost": 910000,
+              "label": "db.r4.16xlarge",
+              "name": "488 GB",
+              "price": { "cost": 910000 }
+            }
+          ]
+        },
+        {
+          "customizable": true,
+          "label": "storage",
+          "name": "Storage",
+          "type": "number",
+          "upgradable": true,
+          "values": [
+            {
+              "label": "storage",
+              "name": "Storage",
+              "numeric_details": {
+                "cost_ranges": [{ "cost_multiple": 200000000, "limit": 16000 }],
+                "increment": 1,
+                "max": 16000,
+                "min": 5,
+                "suffix": "GB"
+              }
+            }
+          ]
+        },
+        {
+          "customizable": true,
+          "downgradable": true,
+          "label": "backups",
+          "name": "Backups",
+          "type": "number",
+          "upgradable": true,
+          "values": [
+            {
+              "label": "backups",
+              "name": "Backups",
+              "numeric_details": {
+                "cost_ranges": [{ "limit": 35 }],
+                "increment": 1,
+                "max": 35,
+                "min": 1,
+                "suffix": "Days"
+              },
+              "price": {
+                "description": "Backups cost is directly related to storage size",
+                "formula": "(* storage#cost backups#number)"
+              }
+            }
+          ]
+        },
+        {
+          "customizable": true,
+          "downgradable": true,
+          "label": "redundancy",
+          "name": "High Availability",
+          "type": "boolean",
+          "upgradable": true,
+          "values": [
+            {
+              "label": "true",
+              "name": "Yes",
+              "price": {
+                "description": "Creates a clone of the DB to rescue from potential outages",
+                "formula": "(* plan#partial_cost redundancy#multiply_factor)",
+                "multiply_factor": 0.8
+              }
+            },
+            { "label": "false", "name": "No" }
+          ]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/jawsdb/screenshots/ss1.PNG",
+        "https://cdn.manifold.co/providers/jawsdb/screenshots/ss2.PNG",
+        "https://cdn.manifold.co/providers/jawsdb/screenshots/ss3.PNG",
+        "https://cdn.manifold.co/providers/jawsdb/screenshots/ss4.PNG"
+      ],
+      "integration": {
+        "base_url": "https://api.jawsdb.com/mysql",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "user-specified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://api.jawsdb.com/mysql",
+        "version": "v1"
+      },
+      "label": "jawsdb-mysql",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": false },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/jawsdb/logos/80ca8b9113cf76fd.png",
+      "name": "JawsDB MySQL",
+      "provider_id": "2346mdxcuca9ez2n93f72nb2fpjgu",
+      "state": "available",
+      "support_email": "support@jawsdb.com",
+      "tagline": "Fast, reliable, no-bullshark MySQL as a Service",
+      "tags": ["database"],
+      "terms": { "provided": false },
+      "value_props": [
+        {
+          "body": "Get access to the same database trusted by sites such as Google, Facebook, Twitter, Youtube, and more.",
+          "header": "Trust in Jaws"
+        },
+        {
+          "body": "In addition to any backups you personally create, we automatically take nightly snapshots for single tenant databases. This means that our team can help you restore to a previous point in time.",
+          "header": "Backups"
+        },
+        {
+          "body": "Create, edit, and save reusable queries against your provisioned server. Databites are a custom, zero-hassle reporting solution for your database right out of the box!",
+          "header": "Databites"
+        },
+        {
+          "body": "Regardless of how big of a wave you're riding, JawsDB makes it easy to scale your database performance.",
+          "header": "Scale"
+        },
+        {
+          "body": "For single tenant plans, we provide you and only you with root credentials — so you have complete control of your server.",
+          "header": "Stay in Control"
+        },
+        {
+          "body": "The world doesn't need to be a scary place, choose a plan that supports failover and your data is replicated to servers in different regions of the world, reducing unexpected downtime.",
+          "header": "Data Replication"
+        }
+      ]
+    },
+    "id": "234w1jyaum5j0aqe3g3bmbqjgf20p",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://www.prefab.cloud/documentation/getting_started",
+      "feature_types": [
+        {
+          "label": "feature-flags",
+          "name": "Feature flags",
+          "type": "string",
+          "values": [{ "label": "free", "name": "Free", "price": {} }]
+        },
+        {
+          "label": "instant-updates",
+          "name": "Instant Updates",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "Yes" }, { "label": "false", "name": "No" }]
+        },
+        {
+          "label": "redundant-backends",
+          "name": "Redundant Backends",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "Yes" }, { "label": "false", "name": "No" }]
+        },
+        {
+          "label": "audit-logs",
+          "name": "Audit Logs",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "Yes" }, { "label": "false", "name": "No" }]
+        },
+        {
+          "label": "email-support",
+          "name": "Email Support",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "Yes" }, { "label": "false", "name": "No" }]
+        },
+        {
+          "label": "limitcheck",
+          "measurable": true,
+          "name": "Limitcheck",
+          "type": "number",
+          "values": [
+            {
+              "label": "unavailable",
+              "name": "Unavailable",
+              "numeric_details": {
+                "cost_ranges": [],
+                "increment": 1,
+                "max": 1000,
+                "suffix": "check"
+              }
+            },
+            {
+              "label": "basic",
+              "name": "Basic",
+              "numeric_details": {
+                "cost_ranges": [{ "cost_multiple": 5000, "limit": -1 }],
+                "increment": 1,
+                "suffix": "check"
+              }
+            },
+            {
+              "label": "upgrade",
+              "name": "Upgrade",
+              "numeric_details": {
+                "cost_ranges": [{ "cost_multiple": 2000, "limit": -1 }],
+                "increment": 1,
+                "suffix": "check"
+              }
+            }
+          ]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/prefab/screenshots/f7c125bc-6049-4b76-8f50-db594797f4fb.png",
+        "https://cdn.manifold.co/providers/prefab/screenshots/36fde154-2e26-4447-9f08-72eae58d4f2b.png",
+        "https://cdn.manifold.co/providers/prefab/screenshots/f31a0889-e1dc-4eca-a1a5-08e23abc2d86.png"
+      ],
+      "integration": {
+        "base_url": "https://www.prefab.cloud",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "unspecified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://www.prefab.cloud",
+        "version": "v1"
+      },
+      "label": "prefab",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": true, "new": true },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/prefab/logos/b0f0b014-4063-4588-bc65-1da31f3fc187.png",
+      "name": "Prefab.cloud",
+      "provider_id": "2340cfzebyhmuhemk5qubj0w3zvz4",
+      "state": "new",
+      "support_email": "hello@prefab.cloud",
+      "tagline": "Feature Flags, RateLimits \u0026 RemoteConfig. Microservices as a Service.",
+      "tags": ["utility"],
+      "terms": { "provided": true, "url": "https://www.prefab.cloud/terms_of_service" },
+      "value_props": [
+        {
+          "body": "Fast, efficient, bombproof and cost-effective rate limiting libraries that don't require any Redis/Memcached on your end.",
+          "header": "Rate Limits"
+        },
+        {
+          "body": "Don't leave home without them. Feature flags enable Moving Fast and Breaking Less. Our flags can be: on, off, on for a percentage of your traffic and on for specific users or users that match specific criteria.",
+          "header": "Feature Flags"
+        },
+        {
+          "body": "Want a reliable distributed config like Consul / Zookeeper that works out of the box and is cost-effective?",
+          "header": "Distributed/Remote Config"
+        },
+        {
+          "body": "Only want to send the 'Welcome Email' once per person, but have some nasty race conditions that could lead to doing it twice? Put an eternal semaphore for 'welcome-email:bob@example.com' and let us store that forever. Easy idempotency as a service.",
+          "header": "Deduplication"
+        },
+        {
+          "body": "Paying your usage tracking service by the event? Do you really need to send an event for Bob _every_ time he clicks? How about only sending bob's unique events every 5 minutes? Let's decimate that bill.",
+          "header": "Scales to millions of individual limits"
+        },
+        {
+          "body": "Open source libraries included for Node, Ruby, Java \u0026 C#. gRPC provides robust extensible support for other languages.",
+          "header": "Batteries Included"
+        }
+      ]
+    },
+    "id": "234j199gnaggg2qj6fvey2m3gw1nc",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://help.aiven.io/elasticsearch",
+      "feature_types": [
+        {
+          "label": "cpus-per-vm",
+          "name": "CPUs per VM",
+          "type": "string",
+          "values": [
+            { "label": "1-cpu", "name": "1 CPU", "price": {} },
+            { "label": "2-cpu", "name": "2 CPU", "price": {} },
+            { "label": "4-cpu", "name": "4 CPU", "price": {} },
+            { "label": "8-cpu", "name": "8 CPU", "price": {} }
+          ]
+        },
+        {
+          "label": "ram-per-vm",
+          "name": "RAM per VM",
+          "type": "string",
+          "values": [
+            { "label": "4-gb", "name": "4 GB", "price": {} },
+            { "label": "8-gb", "name": "8 GB", "price": {} },
+            { "label": "15-gb", "name": "15 GB", "price": {} },
+            { "label": "30-gb", "name": "30 GB", "price": {} }
+          ]
+        },
+        {
+          "label": "disk-space",
+          "name": "Disk space",
+          "type": "string",
+          "values": [
+            { "label": "80-gb", "name": "80 GB", "price": {} },
+            { "label": "175-gb", "name": "175 GB", "price": {} },
+            { "label": "240-gb", "name": "240 GB", "price": {} },
+            { "label": "350-gb", "name": "350 GB", "price": {} },
+            { "label": "525-gb", "name": "525 GB", "price": {} },
+            { "label": "700-gb", "name": "700 GB", "price": {} }
+          ]
+        }
+      ],
+      "images": [],
+      "integration": {
+        "base_url": "https://console.aiven.io/v1/marketplace/manifold/",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "user-specified",
+          "sso": false,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://aiven-rest-aiven-public-smulis-test.avns.net/v1/marketplace/manifold/",
+        "version": "v1"
+      },
+      "label": "aiven-elasticsearch",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": true },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/aiven/logos/c1aaf5d6-63f6-47e4-a0f0-79b5e5d4388d.png",
+      "name": "Aiven Elasticsearch",
+      "provider_id": "2341k8ga6p3d9qv3t42vmcjkb6kqe",
+      "state": "new",
+      "support_email": "support-manifold@aiven.io",
+      "tagline": "The most complete cloud Elasticsearch on the market",
+      "tags": ["database", "search"],
+      "terms": { "provided": true, "url": "https://aiven.io/terms" },
+      "value_props": [
+        {
+          "body": "Aiven Elasticsearch allows you to use popular plugins like analysis-icu, analysis-phonetic, and kuromoji to enhance your service's language analysis capabilities, as well as ingest-geoip, ingest-user-agent, and mapper-size.",
+          "header": "Use popular Elasticsearch plug-ins"
+        },
+        {
+          "body": "A great data system is worthless if it isn't secure. All Aiven services run on dedicated VMs instead of multi-tenant ones most providers use. Your data is encrypted in transit and at rest, and our automation handles all security updates.",
+          "header": "Enjoy end-to-end security"
+        },
+        {
+          "body": "Aiven Elasticsearch comes equipped with Kibana, making your searches easier and adding more to your data story with visualization with Kibana. Even better, Kibana also possesses advanced analytics capabilities—a  perfect match.",
+          "header": "Get more with Kibana"
+        }
+      ]
+    },
+    "id": "234j2mtuym05gh8far9000mjnt2yw",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://docs.logdna.com/docs/",
+      "feature_types": [
+        {
+          "label": "users",
+          "name": "Users",
+          "type": "string",
+          "values": [
+            { "label": "users-generated-0", "name": "1" },
+            { "label": "users-generated-3", "name": "5" },
+            { "label": "users-generated-8", "name": "10" },
+            { "label": "users-generated-15", "name": "25" }
+          ]
+        },
+        {
+          "label": "search-retention",
+          "name": "Search Retention",
+          "type": "string",
+          "values": [
+            { "label": "search-retention-generated-1", "name": "0 Days" },
+            { "label": "search-retention-generated-4", "name": "7 Days" },
+            { "label": "search-retention-generated-9", "name": "14 Days" },
+            { "label": "search-retention-generated-16", "name": "30 Days" }
+          ]
+        },
+        {
+          "label": "storage-volume",
+          "name": "Storage Volume Per Day",
+          "type": "string",
+          "values": [
+            { "label": "storage-volume-generated-2", "name": "0 MB" },
+            { "label": "storage-volume-generated-5", "name": "90 MB" },
+            { "label": "storage-volume-generated-6", "name": "175 MB" },
+            { "label": "storage-volume-generated-7", "name": "350 MB" },
+            { "label": "storage-volume-generated-10", "name": "700 MB" },
+            { "label": "storage-volume-generated-11", "name": "1.5 GB" },
+            { "label": "storage-volume-generated-12", "name": "3 GB" },
+            { "label": "storage-volume-generated-13", "name": "5.5 GB" },
+            { "label": "storage-volume-generated-14", "name": "10 GB" },
+            { "label": "storage-volume-generated-17", "name": "20 GB" }
+          ]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/logdna/logdna/images/1ew2g2d9bahjjdvrcyd7k71nwr.png",
+        "https://cdn.manifold.co/providers/logdna/logdna/images/4uy1kt8we9nzbnehyzev94117m.png",
+        "https://cdn.manifold.co/providers/logdna/logdna/images/nawd3ffc9nwpkw6347b8y8whgw.png"
+      ],
+      "integration": {
+        "base_url": "https://api.logdna.com/manifold",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "unspecified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://api.logdna.com/manifold",
+        "version": "v1"
+      },
+      "label": "logdna",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": false },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png",
+      "name": "LogDNA",
+      "provider_id": "23409yv8yfy06gt8553wzz5x8k164",
+      "state": "available",
+      "support_email": "support@logdna.com",
+      "tagline": "The best logging service you will ever use",
+      "tags": ["logging", "monitoring"],
+      "terms": { "provided": true, "url": "https://logdna.com/terms.html" },
+      "value_props": [
+        {
+          "body": "Centralize your logs in one place instead of tailing one file at a time. Aggregate, search \u0026 filter from all your hosts and apps. See related events across your infrastructure on one screen.",
+          "header": "Aggregate Logs \u0026 Analyze Events"
+        },
+        {
+          "body": "With our blazing fast speeds, search like a pro and set up alerts with just a few clicks. Easily send important event notifications through email, Slack, or even a custom webhook.",
+          "header": "Powerful Search \u0026 Alerts"
+        },
+        {
+          "body": "Get up and running in mere minutes! Spend that saved time building your awesome product instead.",
+          "header": "Easy Setup"
+        },
+        {
+          "body": "Search for specific fields and values automatically picked up from common log formats, such as JSON, Redis, HTTP access logs, and a whole host of others.",
+          "header": "Automatic Field Parsing"
+        },
+        {
+          "body": "Diagnose issues, chase down server errors and look up customer activity, fast! Use live streaming tail to instantly surface hard-to-find bugs.",
+          "header": "Debug \u0026 Troubleshoot Faster"
+        },
+        {
+          "body": "Filter, search, live tail, jump back in time, create views and alerts, all from one interface without leaving the page.",
+          "header": "Modern User Interface"
+        }
+      ]
+    },
+    "id": "234qkjvrptpy3thna4qttwt7m2nf6",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "http://help.apm.scoutapp.com/",
+      "feature_types": [
+        {
+          "label": "transactions",
+          "name": "Transactions",
+          "type": "string",
+          "values": [
+            { "label": "transactions-generated-0", "name": "10000" },
+            { "label": "transactions-generated-4", "name": "65000" },
+            { "label": "transactions-generated-6", "name": "100000" },
+            { "label": "transactions-generated-9", "name": "130000" },
+            { "label": "transactions-generated-10", "name": "165000" },
+            { "label": "transactions-generated-11", "name": "198000" },
+            { "label": "transactions-generated-12", "name": "230000" },
+            { "label": "transactions-generated-13", "name": "260000" },
+            { "label": "transactions-generated-14", "name": "300000" },
+            { "label": "transactions-generated-15", "name": "3000000" }
+          ]
+        },
+        {
+          "label": "metric_retention",
+          "name": "Metric Retention",
+          "type": "string",
+          "values": [
+            { "label": "metric_retention-generated-1", "name": "1 Day" },
+            { "label": "metric_retention-generated-7", "name": "30 Days" }
+          ]
+        },
+        {
+          "label": "trace_retention",
+          "name": "Trace Retention",
+          "type": "string",
+          "values": [
+            { "label": "trace_retention-generated-2", "name": "1 Hour" },
+            { "label": "trace_retention-generated-5", "name": "1 Day" },
+            { "label": "trace_retention-generated-8", "name": "7 Days" }
+          ]
+        },
+        {
+          "label": "deploy_tracking",
+          "name": "Deploy Tracking",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/scout/scout/images/c8v703rfqvzdabqen9cyze43h0.png",
+        "https://cdn.manifold.co/providers/scout/scout/images/phd8dbw48eme2dxnvj0hynxhm4.png",
+        "https://cdn.manifold.co/providers/scout/scout/images/phdafv8qgybpyewqtmckar310c.png"
+      ],
+      "integration": {
+        "base_url": "https://apm.scoutapp.com/manifold",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "unspecified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://apm.scoutapp.com/manifold",
+        "version": "v1"
+      },
+      "label": "scoutapp",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": false },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/scout/logos/h3z4mxt33k3ufm7rzmth0xa4r8.png",
+      "name": "Scout",
+      "provider_id": "2347kwfkggmrhazkweut9vrugc0dp",
+      "state": "available",
+      "support_email": "support@scoutapp.com",
+      "tagline": "Track down memory leaks, N+1s, slow code and more. For Ruby, Python, and Elixir apps",
+      "tags": ["monitoring"],
+      "terms": { "provided": true, "url": "https://scoutapp.com/info/terms" },
+      "value_props": [
+        {
+          "body": "Track response times by tier (ActiveRecord, Redis, MongoDB, etc), throughput, queue time, error rates, and more with zero configuration.",
+          "header": "Monitor App Health"
+        },
+        {
+          "body": "Scout hunts down expensive N+1 queries, tracks the number of ActiveRecord rows returned, and compares slow queries against their performance in faster requests.",
+          "header": "Database Query Analysis"
+        },
+        {
+          "body": "Scout continually monitors your app for requests that trigger large memory increases and pinpoints memory hotspots in your code.",
+          "header": "Memory Leak Detection"
+        },
+        {
+          "body": "Go beyond backtraces - with Scout’s GitHub integration, view relevant slow lines of code, authors, and commit dates inline with your slow transaction traces.",
+          "header": "GitHub CodeView"
+        },
+        {
+          "body": "Scout analyzes your app for performance trends and outliers and emails you a summary every week.",
+          "header": "Weekly Performance Digest"
+        }
+      ]
+    },
+    "id": "234mh3t2j3gk00veubpxbxmzkzgtp",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://hostedmetrics.com/documentation/",
+      "feature_types": [
+        {
+          "label": "data-points",
+          "name": "Data Points",
+          "type": "string",
+          "values": [
+            { "label": "1-million", "name": "1 million", "price": {} },
+            { "label": "25-million", "name": "25 million", "price": {} },
+            { "label": "500-million", "name": "500 million", "price": {} },
+            { "label": "4-billion", "name": "4 billion", "price": {} }
+          ]
+        },
+        {
+          "label": "alerts",
+          "name": "Alerts",
+          "type": "string",
+          "values": [
+            { "label": "two-alerts", "name": "2 alerts", "price": {} },
+            { "label": "ten-alerts", "name": "10 alerts", "price": {} },
+            { "label": "fifty-alerts", "name": "50 alerts", "price": {} },
+            { "label": "two-hundred-alerts", "name": "200 alerts", "price": {} },
+            { "label": "unlimited", "name": "Unlimited", "price": {} }
+          ]
+        },
+        {
+          "label": "team-members",
+          "name": "Team Members",
+          "type": "string",
+          "values": [
+            { "label": "one-member", "name": "1 member", "price": {} },
+            { "label": "two-members", "name": "2 members", "price": {} },
+            { "label": "five-members", "name": "5 members", "price": {} },
+            { "label": "twenty-members", "name": "20 members", "price": {} },
+            { "label": "unlimited", "name": "Unlimited", "price": {} }
+          ]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/hostedmetrics/screenshots/d946571b-2445-47d5-9c80-ae5aa064e2b0.png",
+        "https://cdn.manifold.co/providers/hostedmetrics/screenshots/551144ef-0b38-4ca7-93c2-6b7774514fa1.png",
+        "https://cdn.manifold.co/providers/hostedmetrics/screenshots/9c2f6103-a46f-4ea4-bef1-4c2f840e4314.png",
+        "https://cdn.manifold.co/providers/hostedmetrics/screenshots/bea5bf15-3546-4d40-a900-217750bedd03.png"
+      ],
+      "integration": {
+        "base_url": "https://hostedmetrics.com/integrations/manifold",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "unspecified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://hostedmetrics.com/integrations/manifold",
+        "version": "v1"
+      },
+      "label": "hostedmetrics-influxdb",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": true },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/hosted-metrics/logos/cf170c9c-6dc1-4fcf-9c91-9ab1b3515d71.png",
+      "name": "InfluxDB",
+      "provider_id": "234102an6n5u3dac04nkenx1mchj8",
+      "state": "new",
+      "support_email": "support@hostedmetrics.com",
+      "tagline": "Monitor your applications with InfluxDB, Grafana, and StatsD",
+      "tags": ["monitoring"],
+      "terms": { "provided": true, "url": "https://hostedmetrics.com/terms-of-use/" },
+      "value_props": [
+        {
+          "body": "Start recording and charting your first metrics within minutes. Get up and running as hassle-free as possible by using our hosted and fully managed InfluxDB and Grafana environment.",
+          "header": "Instant Start"
+        },
+        {
+          "body": "Skip the guesswork, configuration, and deployment with our complete and turnkey solution. Send your metrics with StatsD or InfluxDB's line protocol. Use Grafana for dashboards. Configure alerts to instantly be notified when problems arise.",
+          "header": "Complete Turnkey Toolset"
+        },
+        {
+          "body": "Collect and make use of metrics without the hassle of running, scaling, and maintaining a metrics platform. Stop worrying about server specs, uptime, maintenance, and configuration. We take care of all the details so that you can get back to your product because you have better things to do than to babysit all the ancillary tools needed to run your business.",
+          "header": "Zero Maintenance"
+        },
+        {
+          "body": "Drastically reduce your costs by using our hosted and managed tools to collect and visualize the metrics needed to understand your systems, processes, and code. We aid you in monitoring, error handling, and debugging. Also, with alerts, you'll know right away when your attention is needed.",
+          "header": "Drastically Lower Costs"
+        },
+        {
+          "body": "We take pride in treating you right. We address issues quickly and with care, so don't be surprised when you'll receive thoughtful messages instead of canned replies.",
+          "header": "Exceptional Support"
+        }
+      ]
+    },
+    "id": "234ku86rd8fmea5peabd7fgzxztxw",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://github.com/valencenet/valence-manifests",
+      "feature_types": [
+        {
+          "label": "deployments",
+          "measurable": true,
+          "name": "Deployments",
+          "type": "number",
+          "values": [
+            {
+              "label": "deployments",
+              "name": "deployments",
+              "numeric_details": {
+                "cost_ranges": [{ "cost_multiple": 30000000000, "limit": 100 }],
+                "max": 100,
+                "suffix": "deployments"
+              }
+            }
+          ]
+        },
+        {
+          "label": "number-of-deployments",
+          "name": "Number of Deployments",
+          "type": "string",
+          "values": [
+            {
+              "label": "free-up-to-5-deployments",
+              "name": "Free up to 5 Deployments",
+              "price": {}
+            },
+            {
+              "label": "metered-up-to-100-deployments",
+              "name": "Metered up to 100 Deployments",
+              "price": {}
+            }
+          ]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/23411qpzbkv6ajn17860rvzpzcmr4/screenshots/2ac4cf0b-27d2-4de4-8578-575d4e5fa50d.png"
+      ],
+      "integration": {
+        "base_url": "https://api.valence.ai/provider",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "unspecified",
+          "sso": false,
+          "credential": "single"
+        },
+        "provisioning": "public",
+        "version": "v1"
+      },
+      "label": "valence",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": true },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/23411qpzbkv6ajn17860rvzpzcmr4/logos/a0442c01-e629-4693-9197-fcf9aa3b29f3.png",
+      "name": "Valence",
+      "provider_id": "23411qpzbkv6ajn17860rvzpzcmr4",
+      "state": "new",
+      "support_email": "dom@valence.net",
+      "tagline": "Deployment Scaling, Performance Compliance, and Cost Optimization for Kubernetes",
+      "tags": ["optimization"],
+      "terms": { "provided": true, "url": "https://github.com/valencenet/valence-manifests" },
+      "value_props": [
+        {
+          "body": "Scaling applications on Kubernetes is hard. What should my limits and requests be? What should my replicas be? Valence determines your limits, requests, and replicas based on your applications total behaviour in response to its workload. Valence can be used as a right-sizer, an autoscaler, or a resourcing recommender. So you can set your resources correctly from the beginning.",
+          "header": "Easy Scaling Applications and Resource Management on Kubernetes"
+        },
+        {
+          "body": "Valence is built around the concept of declarative performance. Gaurentee performance compliance for your applications by declaring Service Level Objectives and have Valence resource and scale your applications to meet those.",
+          "header": "SLA Performance Compliance for Applications"
+        },
+        {
+          "body": "Valence learns to operate your application in the most cost effective way. By maximizing utilization, cluster density, and node usage such that performance is never degraded.",
+          "header": "Kubernetes Cost Optimization and Improved Resource Utility"
+        }
+      ]
+    },
+    "id": "234kcr16xcekdjjvk0mun98rypeg0",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://help.aiven.io/redis",
+      "feature_types": [
+        {
+          "label": "cpus-per-vm",
+          "name": "CPUs per VM",
+          "type": "string",
+          "values": [
+            { "label": "1-cpu", "name": "1 CPU", "price": {} },
+            { "label": "2-cpu", "name": "2 CPU", "price": {} }
+          ]
+        },
+        {
+          "label": "ram-per-vm",
+          "name": "RAM per VM",
+          "type": "string",
+          "values": [
+            { "label": "4-gb", "name": "4 GB", "price": {} },
+            { "label": "8-gb", "name": "8 GB", "price": {} }
+          ]
+        },
+        {
+          "label": "highly-available",
+          "name": "Highly available",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "Yes" }, { "label": "false", "name": "No" }]
+        }
+      ],
+      "images": [],
+      "integration": {
+        "base_url": "https://console.aiven.io/v1/marketplace/manifold/",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "user-specified",
+          "sso": false,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://aiven-rest-aiven-public-smulis-test.avns.net/v1/marketplace/manifold/",
+        "version": "v1"
+      },
+      "label": "aiven-redis",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": true },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/aiven/logos/2d4f9f98-3520-4238-9320-bb4570adc2c0.png",
+      "name": "Aiven Redis",
+      "provider_id": "2341k8ga6p3d9qv3t42vmcjkb6kqe",
+      "state": "new",
+      "support_email": "support-manifold@aiven.io",
+      "tagline": "The most complete cloud Redis on the market",
+      "tags": ["database", "memory-store"],
+      "terms": { "provided": true, "url": "https://aiven.io/terms" },
+      "value_props": [
+        {
+          "body": "It doesn't matter how fast, stable, and advanced a Kafka offering is if it isn't secure. All Aiven services are run on dedicated virtual machines instead of multi-tenant ones most providers use. Your data is encrypted in transit and at rest, and our automation takes care of all security updates.",
+          "header": "Enjoy end-to-end security"
+        }
+      ]
+    },
+    "id": "234x63nf03qxfrvkexxfk79hrczmp",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://help.aiven.io/kafka",
+      "feature_types": [
+        {
+          "label": "cpus-per-vm",
+          "name": "CPUs per VM",
+          "type": "string",
+          "values": [
+            { "label": "1-cpu", "name": "1 CPU", "price": {} },
+            { "label": "2-cpu", "name": "2 CPU", "price": {} }
+          ]
+        },
+        {
+          "label": "ram-per-vm",
+          "name": "RAM per VM",
+          "type": "string",
+          "values": [
+            { "label": "2-gb", "name": "2 GB", "price": {} },
+            { "label": "4-gb", "name": "4 GB", "price": {} },
+            { "label": "8-gb", "name": "8 GB", "price": {} }
+          ]
+        },
+        {
+          "label": "disk-space",
+          "name": "Disk space",
+          "type": "string",
+          "values": [
+            { "label": "90-gb", "name": "90 GB", "price": {} },
+            { "label": "600-gb", "name": "600 GB", "price": {} },
+            { "label": "1200-gb", "name": "1200 GB", "price": {} }
+          ]
+        }
+      ],
+      "images": [],
+      "integration": {
+        "base_url": "https://console.aiven.io/v1/marketplace/manifold/",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "user-specified",
+          "sso": false,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://aiven-rest-aiven-public-smulis-test.avns.net/v1/marketplace/manifold/",
+        "version": "v1"
+      },
+      "label": "aiven-kafka",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": true },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/aiven/logos/6164a03f-545c-4e77-b467-174a8764ec4a.png",
+      "name": "Aiven Kafka",
+      "provider_id": "2341k8ga6p3d9qv3t42vmcjkb6kqe",
+      "state": "new",
+      "support_email": "support-manifold@aiven.io",
+      "tagline": "The benefits of Kafka without the headaches",
+      "tags": ["database", "messaging"],
+      "terms": { "provided": true, "url": "https://aiven.io/terms" },
+      "value_props": [
+        {
+          "body": "Running a single node Kafka cluster is a recipe for disaster, which is why all Aiven Kafka plans purchased through Manifold come with three-node clusters. So, when a node fails, the other two can take over uninterrupted while it gets rebuilt.",
+          "header": "Resilient multi-node clusters"
+        },
+        {
+          "body": "BUT, even if your have a multi-node cluster, you're still playing with fire if it's not spread across availability zones. With Aiven Kafka, your cluster is split across zones so that if one drops offline, your cluster will remain operational.",
+          "header": "Smart availability zone placement"
+        },
+        {
+          "body": "If your data isn't secure, nothing else matters. All Aiven services are run on dedicated virtual machines instead of multi-tenant ones most providers use. Your data is encrypted in transit and at rest, and our automation takes care of all security updates.",
+          "header": "Full-spectrum security"
+        }
+      ]
+    },
+    "id": "234j1veb58h231cf99mqjmambj37c",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://hostedmetrics.com/documentation/",
+      "feature_types": [
+        {
+          "label": "data-points",
+          "name": "Data Points",
+          "type": "string",
+          "values": [
+            { "label": "1-million", "name": "1 million", "price": {} },
+            { "label": "25-million", "name": "25 million", "price": {} },
+            { "label": "500-million", "name": "500 million", "price": {} },
+            { "label": "4-billion", "name": "4 billion", "price": {} }
+          ]
+        },
+        {
+          "label": "alerts",
+          "name": "Alerts",
+          "type": "string",
+          "values": [{ "label": "unlimited", "name": "Unlimited", "price": {} }]
+        },
+        {
+          "label": "team-members",
+          "name": "Team Members",
+          "type": "string",
+          "values": [{ "label": "unlimited", "name": "Unlimited", "price": {} }]
+        }
+      ],
+      "images": [],
+      "integration": {
+        "base_url": "https://hostedmetrics.com/integrations/manifold",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "unspecified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://hostedmetrics.com/integrations/manifold",
+        "version": "v1"
+      },
+      "label": "hostedmetrics-prometheus",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": true },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/hostedmetrics/logos/f64dc325-e826-4b06-ba0f-6e1c4550a8d8.png",
+      "name": "Prometheus",
+      "provider_id": "234102an6n5u3dac04nkenx1mchj8",
+      "state": "new",
+      "support_email": "support@hostedmetrics.com",
+      "tagline": "Monitor your applications and infrastructure with Prometheus, Grafana, and StatsD",
+      "tags": ["monitoring"],
+      "terms": { "provided": true, "url": "https://hostedmetrics.com/terms-of-use/" },
+      "value_props": [
+        {
+          "body": "Start recording and charting your first metrics within minutes. Get up and running as hassle-free as possible by using our hosted and fully managed Prometheus and Grafana environment.",
+          "header": "Instant Start"
+        },
+        {
+          "body": "Skip the guesswork, configuration, and deployment with our complete and turnkey solution. Scrape your metrics with Prometheus' pull mechanism, remote write, or PushGateway, or simply use StatsD. Use Grafana for dashboards. Configure alerts to instantly be notified when problems arise.",
+          "header": "Complete Turnkey Toolset"
+        },
+        {
+          "body": "Collect and make use of metrics without the hassle of running, scaling, and maintaining a metrics platform. Stop worrying about server specs, uptime, maintenance, and configuration. We take care of all the details so that you can get back to your product because you have better things to do than to babysit all the ancillary tools needed to run your business.",
+          "header": "Zero Maintenance"
+        },
+        {
+          "body": "Drastically reduce your costs by using our hosted and managed tools to collect and visualize the metrics needed to understand your systems, processes, and code. We aid you in monitoring, error handling, and debugging. Also, with alerts, you'll know right away when your attention is needed.",
+          "header": "Drastically Lower Costs"
+        },
+        {
+          "body": "We take pride in treating you right. We address issues quickly and with care, so don't be surprised when you'll receive thoughtful messages instead of canned replies.",
+          "header": "Exceptional Support"
+        }
+      ]
+    },
+    "id": "234pbjjvexny04ft9fn78hf2r9pnj",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://cloudcube.cloudforged.com/docs",
+      "feature_types": [
+        {
+          "label": "storage",
+          "name": "Storage",
+          "type": "string",
+          "values": [
+            { "label": "1-mb", "name": "1 mb", "price": {} },
+            { "label": "5-gb", "name": "5 gb", "price": {} },
+            { "label": "10-gb", "name": "10 gb", "price": {} },
+            { "label": "50-gb", "name": "50 gb", "price": {} },
+            { "label": "500-gb", "name": "500 gb", "price": {} },
+            { "label": "5-tb", "name": "5 tb", "price": {} },
+            { "label": "50-tb", "name": "50 tb", "price": {} },
+            { "label": "500-tb", "name": "500 tb", "price": {} }
+          ]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/cloudforged/screenshots/3648f0c2-77c4-47c9-9af7-9251babfb054.png",
+        "https://cdn.manifold.co/providers/cloudforged/screenshots/bcd5ce08-6c5a-4f0a-ba9f-2bad268886ec.png"
+      ],
+      "integration": {
+        "base_url": "https://cloudcube.cloudforged.com/manifold",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "user-specified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://cloudcube.cloudforged.com/manifold",
+        "version": "v1"
+      },
+      "label": "cloudcube",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": true },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/cloudforged/logos/b2d4d01c-dee4-4a87-95da-45f72fdc3202.png",
+      "name": "Cloudcube",
+      "provider_id": "2348m4rz1wm33z9tcwb23jxfan62a",
+      "state": "new",
+      "support_email": "support@cloudforged.com",
+      "tagline": "Flexible AWS S3 file storage without the hassle.",
+      "tags": ["utility"],
+      "terms": { "provided": true, "url": "https://cloudcube.cloudforged.com/terms" },
+      "value_props": [
+        {
+          "body": "Cubes can contain both private files and public files. Public files are given a URL which can be shared with others or used inside your application.",
+          "header": "Private and Public Storage"
+        },
+        {
+          "body": "Upload, Rename, Move, and Delete your files from the Dashboard’s intuitive graphical interface.",
+          "header": "GUI Interface"
+        },
+        {
+          "body": "Your cube comes with a set of IAM credentials for manipulating your Cube files via Amazon’s REST API or one of its many free-to-user SDKs.",
+          "header": "AWS Credentials"
+        },
+        {
+          "body": "S3 storage offers 99.99% availability for object storage so you can rest easy knowing your files will be there when you need them.",
+          "header": "Always Available"
+        },
+        {
+          "body": "In-house filesystems experience the inevitable degradation of hard-disks. Corrupt drives can result in loss of data that can be quite costly as well as annoying. With Cloudcube, your data will enjoy S3‘s 99.999999999% durability record. No more lost files, no more disk corruption.",
+          "header": "Epic Durability"
+        }
+      ]
+    },
+    "id": "234vpcvg8k7dty17j7wmazfpdbrag",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://docs.bonsai.io/",
+      "feature_types": [
+        {
+          "label": "capacity",
+          "name": "Capacity",
+          "type": "string",
+          "values": [
+            { "label": "capacity-generated-0", "name": "128MB" },
+            { "label": "capacity-generated-5", "name": "2GB" },
+            { "label": "capacity-generated-10", "name": "10GB" },
+            { "label": "capacity-generated-15", "name": "30GB" },
+            { "label": "capacity-generated-20", "name": "60GB" },
+            { "label": "capacity-generated-25", "name": "90GB" },
+            { "label": "capacity-generated-30", "name": "120GB" }
+          ]
+        },
+        {
+          "label": "memory",
+          "name": "Memory",
+          "type": "string",
+          "values": [
+            { "label": "memory-generated-1", "name": "128MB" },
+            { "label": "memory-generated-6", "name": "512MB" },
+            { "label": "memory-generated-11", "name": "1GB" },
+            { "label": "memory-generated-16", "name": "3GB" },
+            { "label": "memory-generated-21", "name": "6GB" },
+            { "label": "memory-generated-26", "name": "9GB" },
+            { "label": "memory-generated-31", "name": "12GB" }
+          ]
+        },
+        {
+          "label": "shards",
+          "name": "Shards",
+          "type": "string",
+          "values": [
+            { "label": "shards-generated-2", "name": "2" },
+            { "label": "shards-generated-7", "name": "10" },
+            { "label": "shards-generated-12", "name": "20" },
+            { "label": "shards-generated-17", "name": "40" },
+            { "label": "shards-generated-22", "name": "70" },
+            { "label": "shards-generated-27", "name": "100" },
+            { "label": "shards-generated-32", "name": "130" }
+          ]
+        },
+        {
+          "label": "documents",
+          "name": "Documents",
+          "type": "string",
+          "values": [
+            { "label": "documents-generated-3", "name": "10000" },
+            { "label": "documents-generated-8", "name": "500000" },
+            { "label": "documents-generated-13", "name": "1000000" },
+            { "label": "documents-generated-18", "name": "15000000" },
+            { "label": "documents-generated-23", "name": "30000000" },
+            { "label": "documents-generated-28", "name": "45000000" },
+            { "label": "documents-generated-33", "name": "60000000" }
+          ]
+        },
+        {
+          "label": "connections",
+          "name": "Connections (Search x Updates x Bulk)",
+          "type": "string",
+          "values": [
+            { "label": "connections-generated-4", "name": "1x1x1" },
+            { "label": "connections-generated-9", "name": "2x1x1" },
+            { "label": "connections-generated-14", "name": "5x1x1" },
+            { "label": "connections-generated-19", "name": "7x2x2" },
+            { "label": "connections-generated-24", "name": "30x4x4" },
+            { "label": "connections-generated-29", "name": "45x5x5" },
+            { "label": "connections-generated-34", "name": "60x7x7" }
+          ]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/onemorecloud/bonsai-elasticsearch/images/uwdfwkyuvmzp0kx26047tpu1kr.png",
+        "https://cdn.manifold.co/providers/onemorecloud/bonsai-elasticsearch/images/65vpduq7zeuhgmbz2z2v4mbagm.png",
+        "https://cdn.manifold.co/providers/onemorecloud/bonsai-elasticsearch/images/9ccatjykfvbwevwn3cgpc33khw.png"
+      ],
+      "integration": {
+        "base_url": "https://app.bonsai.io/manifold",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "user-specified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://app.bonsai.io/manifold",
+        "version": "v1"
+      },
+      "label": "bonsai-elasticsearch",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": false },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/onemorecloud/logos/rt5nvd4yxuy0467bak0jqxz41m.png",
+      "name": "Bonsai Elasticsearch",
+      "provider_id": "23411mqbvgx5eqzb1qfhqfvmn27b8",
+      "state": "available",
+      "support_email": "support@onemorecloud.com",
+      "tagline": "Elasticsearch, fully managed by the experts in hosted search.",
+      "tags": ["search"],
+      "terms": { "provided": true, "url": "https://onemorecloud.com/info/terms" },
+      "value_props": [
+        {
+          "body": "Leverage Lucene’s search features to create immediate value for your users instead of spinning your wheels keeping Elasticsearch up and optimized.",
+          "header": "Build meaningful search experiences"
+        },
+        {
+          "body": "Our support team members are engineers. We take pride in our quick, thorough, and knowledgeable responses. There’s no one in our field that does Elasticsearch support better, or who's been doing it longer.",
+          "header": "Get support from real people who know search"
+        },
+        {
+          "body": "We’ve put in the years and solved the hard problems so you don’t have to. We’re on call 24/7, with hourly offsite backups and architected for 99.99% uptime.",
+          "header": "Never worry about availability"
+        },
+        {
+          "body": "With features like Secure TLS Encryption and Advanced API Credentials, never worry about keeping your data secure.",
+          "header": "Rest easy with battle-tested security"
+        },
+        {
+          "body": "Partition and replicate your data throughout our shared cluster with ElasticSearch shards and replicas.",
+          "header": "Scale with Ease"
+        },
+        {
+          "body": "Our unique architecture gives you the best value for your resources.",
+          "header": "The best value in hosted search"
+        }
+      ]
+    },
+    "id": "234rrwjuvq3t66r1r0p797p9jvrn2",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://ziggeo.com/docs",
+      "feature_types": [
+        {
+          "label": "recording_sd",
+          "measurable": true,
+          "name": "Video Recorder - SD",
+          "type": "number",
+          "values": [
+            {
+              "label": "standard-seconds",
+              "name": "Standard Seconds",
+              "numeric_details": {
+                "cost_ranges": [{ "limit": 202680 }, { "cost_multiple": 300000, "limit": -1 }],
+                "increment": 1,
+                "suffix": "Seconds"
+              }
+            },
+            {
+              "label": "pro-seconds",
+              "name": "Pro Seconds",
+              "numeric_details": {
+                "cost_ranges": [{ "limit": 210000 }, { "cost_multiple": 200000, "limit": -1 }],
+                "increment": 1,
+                "suffix": "Seconds"
+              }
+            },
+            {
+              "label": "enterprise-seconds",
+              "name": "Enterprise Seconds",
+              "numeric_details": {
+                "cost_ranges": [{ "limit": 666660 }, { "cost_multiple": 150000, "limit": -1 }],
+                "increment": 1,
+                "suffix": "Seconds"
+              }
+            }
+          ]
+        },
+        {
+          "label": "recording_hd",
+          "measurable": true,
+          "name": "Video Recorder - HD",
+          "type": "number",
+          "values": [
+            {
+              "label": "standard-no-recording",
+              "name": "No Recording",
+              "numeric_details": { "cost_ranges": [], "suffix": "Seconds" }
+            },
+            {
+              "label": "pro-seconds",
+              "name": "Pro Seconds",
+              "numeric_details": {
+                "cost_ranges": [{ "limit": 125640 }, { "cost_multiple": 400000, "limit": -1 }],
+                "increment": 1,
+                "suffix": "Seconds"
+              }
+            },
+            {
+              "label": "enterprise-seconds",
+              "name": "Enterprise Seconds",
+              "numeric_details": {
+                "cost_ranges": [{ "limit": 422520 }, { "cost_multiple": 300000, "limit": -1 }],
+                "increment": 1,
+                "suffix": "Seconds"
+              }
+            }
+          ]
+        },
+        {
+          "label": "playing_sd",
+          "measurable": true,
+          "name": "Video Player - SD",
+          "type": "number",
+          "values": [
+            {
+              "label": "standard-seconds",
+              "name": "Standard Seconds",
+              "numeric_details": {
+                "cost_ranges": [{ "limit": 1014000 }, { "cost_multiple": 11667, "limit": -1 }],
+                "increment": 1,
+                "suffix": "Seconds"
+              }
+            },
+            {
+              "label": "pro-seconds",
+              "name": "Pro Seconds",
+              "numeric_details": {
+                "cost_ranges": [{ "limit": 807000 }, { "cost_multiple": 6667, "limit": -1 }],
+                "increment": 1,
+                "suffix": "Seconds"
+              }
+            },
+            {
+              "label": "enterprise-seconds",
+              "name": "Enterprise Seconds",
+              "numeric_details": {
+                "cost_ranges": [{ "limit": 3000000 }, { "cost_multiple": 6667, "limit": -1 }],
+                "increment": 1,
+                "suffix": "Seconds"
+              }
+            }
+          ]
+        },
+        {
+          "label": "playing_hd",
+          "measurable": true,
+          "name": "Video Player - HD",
+          "type": "number",
+          "values": [
+            {
+              "label": "standard-no-playing",
+              "name": "No Playing",
+              "numeric_details": { "cost_ranges": [], "suffix": "Seconds" }
+            },
+            {
+              "label": "pro-seconds",
+              "name": "Pro Seconds",
+              "numeric_details": {
+                "cost_ranges": [{ "limit": 750000 }, { "cost_multiple": 13334, "limit": -1 }],
+                "increment": 1,
+                "suffix": "Seconds"
+              }
+            },
+            {
+              "label": "enterprise-seconds",
+              "name": "Enterprise Seconds",
+              "numeric_details": {
+                "cost_ranges": [{ "limit": 2064840 }, { "cost_multiple": 11667, "limit": -1 }],
+                "increment": 1,
+                "suffix": "Seconds"
+              }
+            }
+          ]
+        },
+        {
+          "label": "storage_sd",
+          "measurable": true,
+          "name": "Video Storage - SD",
+          "type": "number",
+          "values": [
+            {
+              "label": "standard-seconds",
+              "name": "Standard Seconds",
+              "numeric_details": {
+                "cost_ranges": [{ "limit": 1216560 }, { "cost_multiple": 21667, "limit": -1 }],
+                "increment": 1,
+                "suffix": "Seconds"
+              }
+            },
+            {
+              "label": "pro-seconds",
+              "name": "Pro Seconds",
+              "numeric_details": {
+                "cost_ranges": [{ "limit": 1333320 }, { "cost_multiple": 15000, "limit": -1 }],
+                "increment": 1,
+                "suffix": "Seconds"
+              }
+            },
+            {
+              "label": "enterprise-seconds",
+              "name": "Enterprise Seconds",
+              "numeric_details": {
+                "cost_ranges": [{ "limit": 3000000 }, { "cost_multiple": 10000, "limit": -1 }],
+                "increment": 1,
+                "suffix": "Seconds"
+              }
+            }
+          ]
+        },
+        {
+          "label": "storage_hd",
+          "measurable": true,
+          "name": "Video Storage - HD",
+          "type": "number",
+          "values": [
+            {
+              "label": "standard-no-storage",
+              "name": "No Storage",
+              "numeric_details": { "cost_ranges": [], "suffix": "Seconds" }
+            },
+            {
+              "label": "pro-seconds",
+              "name": "Pro Seconds",
+              "numeric_details": {
+                "cost_ranges": [{ "limit": 717300 }, { "cost_multiple": 30000, "limit": -1 }],
+                "increment": 1,
+                "suffix": "Seconds"
+              }
+            },
+            {
+              "label": "enterprise-seconds",
+              "name": "Enterprise Seconds",
+              "numeric_details": {
+                "cost_ranges": [{ "limit": 3150420 }, { "cost_multiple": 21667, "limit": -1 }],
+                "increment": 1,
+                "suffix": "Seconds"
+              }
+            }
+          ]
+        },
+        {
+          "label": "effects_sd",
+          "measurable": true,
+          "name": "Video Effects - SD",
+          "type": "number",
+          "values": [
+            {
+              "label": "standard-no-effects",
+              "name": "No Effects",
+              "numeric_details": { "cost_ranges": [], "suffix": "Seconds" }
+            },
+            {
+              "label": "pro-seconds",
+              "name": "Pro Seconds",
+              "numeric_details": {
+                "cost_ranges": [{ "limit": 191280 }, { "cost_multiple": 333334, "limit": -1 }],
+                "increment": 1,
+                "suffix": "Seconds"
+              }
+            },
+            {
+              "label": "enterprise-seconds",
+              "name": "Enterprise Seconds",
+              "numeric_details": {
+                "cost_ranges": [{ "limit": 511740 }, { "cost_multiple": 250000, "limit": -1 }],
+                "increment": 1,
+                "suffix": "Seconds"
+              }
+            }
+          ]
+        },
+        {
+          "label": "effects_hd",
+          "measurable": true,
+          "name": "Video Effects - HD",
+          "type": "number",
+          "values": [
+            {
+              "label": "standard-no-effects",
+              "name": "No Effects",
+              "numeric_details": { "cost_ranges": [], "suffix": "Seconds" }
+            },
+            {
+              "label": "pro-seconds",
+              "name": "Pro Seconds",
+              "numeric_details": {
+                "cost_ranges": [{ "limit": 135000 }, { "cost_multiple": 666667, "limit": -1 }],
+                "increment": 1,
+                "suffix": "Seconds"
+              }
+            },
+            {
+              "label": "enterprise-seconds",
+              "name": "Enterprise Seconds",
+              "numeric_details": {
+                "cost_ranges": [{ "limit": 499980 }, { "cost_multiple": 500000, "limit": -1 }],
+                "increment": 1,
+                "suffix": "Seconds"
+              }
+            }
+          ]
+        },
+        {
+          "label": "analysis",
+          "measurable": true,
+          "name": "A.I. Video Analysis",
+          "type": "number",
+          "values": [
+            {
+              "label": "standard-no-analysis",
+              "name": "No Analysis",
+              "numeric_details": { "cost_ranges": [], "suffix": "Seconds" }
+            },
+            {
+              "label": "pro-seconds",
+              "name": "Pro Seconds",
+              "numeric_details": {
+                "cost_ranges": [{ "limit": 230640 }, { "cost_multiple": 416667, "limit": -1 }],
+                "increment": 1,
+                "suffix": "Seconds"
+              }
+            },
+            {
+              "label": "enterprise-seconds",
+              "name": "Enterprise Seconds",
+              "numeric_details": {
+                "cost_ranges": [{ "limit": 755880 }, { "cost_multiple": 333334, "limit": -1 }],
+                "increment": 1,
+                "suffix": "Seconds"
+              }
+            }
+          ]
+        },
+        {
+          "label": "secure-video-access",
+          "name": "Secure Video Access",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "screen-capture",
+          "name": "Screen Capture",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "video-profiles",
+          "name": "Video Profiles",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "nsfw-detection",
+          "name": "Not - Safe for Work Detection",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "sub-accounts",
+          "name": "Sub Accounts",
+          "type": "string",
+          "values": [
+            { "label": "none", "name": "None" },
+            { "label": "five-shared-apps", "name": "Up to 5 shared apps only" },
+            { "label": "unlimited", "name": "Unlimited" }
+          ]
+        },
+        {
+          "label": "on-the-fly-transcoding",
+          "name": "On Fly Transcoding",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "webhooks",
+          "name": "Webhooks",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "3rd-party-integrations",
+          "name": "3rd Party Integrations",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "easy-share",
+          "name": "Easy Share",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/ziggeo/screenshots/1-instagram-like-effects.png",
+        "https://cdn.manifold.co/providers/ziggeo/screenshots/3-video-analysis.jpg",
+        "https://cdn.manifold.co/providers/ziggeo/screenshots/4-video-player-themes.png",
+        "https://cdn.manifold.co/providers/ziggeo/screenshots/5-video-profiles.png",
+        "https://cdn.manifold.co/providers/ziggeo/screenshots/6-video-recorder-themes.png"
+      ],
+      "integration": {
+        "base_url": "https://srvapi.ziggeo.com/v1/manifold/",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "unspecified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://ziggeo.com/manifold/sso/",
+        "version": "v1"
+      },
+      "label": "ziggeo",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": false },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/ziggeo/logos/ziggeo.png",
+      "name": "Ziggeo",
+      "provider_id": "234a33rd2pxfzq9qfk0v5qdrykhcp",
+      "state": "available",
+      "support_email": "support@ziggeo.com",
+      "tagline": "Ziggeo is an award-winning cloud-based service for in-browser/in-app video recording, playback, transcoding, storage \u0026 video management.",
+      "tags": ["optimization"],
+      "terms": { "provided": true, "url": "https://ziggeo.com/terms" },
+      "value_props": [
+        {
+          "body": "Records + uploads videos from any device/browser. Supports HTML-5 / WebRTC. Mobile-friendly, responsive, and fully customizable.",
+          "header": "Video Recorder"
+        },
+        {
+          "body": "Automatically transcodes to all desired resolutions. No complicated settings. Highly customizable. Includes video uploader.",
+          "header": "Video Transcoder"
+        },
+        {
+          "body": "Plays videos across all devices/browsers. Is responsive, embeddable, and fully customizable. Comes with several predefined themes.",
+          "header": "Video Player"
+        },
+        {
+          "body": "Native mobile SDKs for iOS and Android. Supports seamless video recording and video playback across all apps, browsers and devices.",
+          "header": "Video SDKs"
+        },
+        {
+          "body": "Ziggeo has launched the ability to record computer desktop screens right from the browser.",
+          "header": "Screen Recorder"
+        },
+        {
+          "body": "All your video hosting needs, including content delivery. Permanent or temporary hosting with moderation and workflows.",
+          "header": "Video Hosting"
+        },
+        {
+          "body": "Plethora of different integrations to tie into your workflow and with our automated services they easily get auto pushed to any integration you need..",
+          "header": "Integrations \u0026 Automated Services"
+        },
+        {
+          "body": "All of our SDKs utilize our API and next to our server side SDKs and mobile SDKs you can easily and quickly make your own steps by utilizing our APIs directly.",
+          "header": "Video APIs"
+        }
+      ]
+    },
+    "id": "234yycr3mf5f2hrw045vuxeatnd50",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://www.hypdf.com/info/documentation",
+      "feature_types": [
+        {
+          "label": "documents-per-day",
+          "name": "Documents per day",
+          "type": "string",
+          "values": [
+            { "label": "five", "name": "5 documents", "price": {} },
+            { "label": "fifteen", "name": "15 documents", "price": {} },
+            { "label": "forty-five", "name": "45 documents", "price": {} },
+            { "label": "one-hundred-thirty-five", "name": "135 documents", "price": {} },
+            { "label": "one-thousand", "name": "1000 documents", "price": {} },
+            { "label": "ten-thousand", "name": "10 000 documents", "price": {} },
+            { "label": "fifty-thousand", "name": "50 000 documents", "price": {} }
+          ]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/hypdf/screenshots/ec7933fb-2236-420e-bf94-c2d0c98768a1.png",
+        "https://cdn.manifold.co/providers/hypdf/screenshots/5dd3d577-2cce-4feb-9139-a6e8b0dd1f94.png",
+        "https://cdn.manifold.co/providers/hypdf/screenshots/5bf869c4-d181-4350-9a1f-684180e0af3f.png"
+      ],
+      "integration": {
+        "base_url": "https://hypdf.com/manifold",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "unspecified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://hypdf.com/manifold",
+        "version": "v1"
+      },
+      "label": "hypdf",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": true },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/hypdf/logos/15cbd713-15e1-41fc-9894-b73049dce40d.png",
+      "name": "HyPDF",
+      "provider_id": "234542w8d45emjcwgwj9zu2653baj",
+      "state": "new",
+      "support_email": "support@hypdf.com",
+      "tagline": "Your Swiss Army knife for working with PDF",
+      "tags": ["optimization"],
+      "terms": { "provided": true, "url": "https://www.hypdf.com/info/terms_of_service" },
+      "value_props": [
+        {
+          "body": "Create beautiful and complex PDF documents using familiar HTML, CSS and JavaScript.",
+          "header": "Create"
+        },
+        { "body": "Read and fill forms in your PDF files.", "header": "Edit" },
+        { "body": "Extract certain pages from the whole PDF file.", "header": "Extract" },
+        { "body": "Merge multiple PDF files into one.", "header": "Unite" },
+        {
+          "body": "Read and edit meta-information for any PDF file, such as author, title and so on.",
+          "header": "Inspect"
+        },
+        { "body": "Convert PDF files to the plain text.", "header": "Transform" },
+        {
+          "body": "HyPDF can upload created PDFs to your own AWS S3 bucket.",
+          "header": "Integrate"
+        },
+        {
+          "body": "You don’t need to pay for licenses and royalties, you only pay for the convenience.",
+          "header": "Save money"
+        }
+      ]
+    },
+    "id": "234n81q2693cee1680fxjkcutw476",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://pdfshift.io/documentation",
+      "feature_types": [
+        {
+          "label": "conversions",
+          "name": "Conversions",
+          "type": "string",
+          "values": [
+            { "label": "250", "name": "250", "price": {} },
+            { "label": "1000", "name": "1 000", "price": {} },
+            { "label": "10000", "name": "10 000", "price": {} },
+            { "label": "50000", "name": "50 000", "price": {} }
+          ]
+        },
+        {
+          "label": "document-size",
+          "name": "Documents Size",
+          "type": "string",
+          "values": [
+            { "label": "1mb", "name": "1 MB", "price": {} },
+            { "label": "5mb", "name": "5 MB", "price": {} },
+            { "label": "10mb", "name": "10 MB", "price": {} },
+            { "label": "25mb", "name": "25 MB", "price": {} }
+          ]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/pdfshift/screenshots/d98ba380-7927-411e-a255-40a7ffa7bf33.png",
+        "https://cdn.manifold.co/providers/pdfshift/screenshots/ef2badc1-5167-467d-b679-fbe9011edaae.png",
+        "https://cdn.manifold.co/providers/pdfshift/screenshots/b99effba-284d-4928-b9b9-2953b27e7bf5.png"
+      ],
+      "integration": {
+        "base_url": "https://api.pdfshift.io/v2/manifold/",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "unspecified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://api.pdfshift.io/v2/manifold/",
+        "version": "v1"
+      },
+      "label": "pdfshift",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": true },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/pdfshift/logos/2cfcefe3-ba37-4530-881a-0e1257a3c91f.png",
+      "name": "PDFShift",
+      "provider_id": "2349hyewy8azqf8e1m1e7728m2v12",
+      "state": "new",
+      "support_email": "support@pdfshift.io",
+      "tagline": "Convert HTML documents to PDF in one simple POST request!",
+      "tags": ["worker"],
+      "terms": { "provided": true, "url": "https://pdfshift.io/terms" },
+      "value_props": [
+        {
+          "body": "Generate a fully structured, high-quality PDF document, in a few seconds only.",
+          "header": "High-Quality PDF"
+        },
+        {
+          "body": "Convert up to 250 documents per month for free. Start to pay after.",
+          "header": "Free to start"
+        },
+        {
+          "body": "Our cluster of servers can handle many simultaneous requests, and with large files.",
+          "header": "Reliable"
+        },
+        {
+          "body": "Our API has been built for developer specifically, resulting in a quick learning curve. Simple, complete, elegant.",
+          "header": "Easy to implement"
+        },
+        {
+          "body": "Requests are made over SSL and the documents generated are never stored.",
+          "header": "Secure"
+        }
+      ]
+    },
+    "id": "234k06n0t66x48t5x1gbb0z3v3d4c",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://www.memcachier.com/documentation",
+      "feature_types": [
+        {
+          "label": "bucket-size",
+          "name": "Bucket Size",
+          "type": "string",
+          "values": [
+            { "label": "bucket-size-generated-0", "name": "250 MB" },
+            { "label": "bucket-size-generated-9", "name": "500 MB" },
+            { "label": "bucket-size-generated-10", "name": "50 GB" },
+            { "label": "bucket-size-generated-14", "name": "75 GB" },
+            { "label": "bucket-size-generated-15", "name": "100 GB" },
+            { "label": "bucket-size-generated-16", "name": "25 MB" },
+            { "label": "bucket-size-generated-20", "name": "100 MB" },
+            { "label": "bucket-size-generated-21", "name": "1 GB" },
+            { "label": "bucket-size-generated-23", "name": "2.5 GB" },
+            { "label": "bucket-size-generated-24", "name": "5 GB" },
+            { "label": "bucket-size-generated-26", "name": "10 GB" },
+            { "label": "bucket-size-generated-28", "name": "7.5 GB" },
+            { "label": "bucket-size-generated-29", "name": "25 GB" }
+          ]
+        },
+        {
+          "label": "proxies",
+          "name": "Proxy Servers",
+          "type": "string",
+          "values": [
+            { "label": "proxies-generated-1", "name": "1" },
+            { "label": "proxies-generated-11", "name": "6" },
+            { "label": "proxies-generated-22", "name": "2" },
+            { "label": "proxies-generated-25", "name": "3" },
+            { "label": "proxies-generated-27", "name": "4" }
+          ]
+        },
+        {
+          "label": "high-availability",
+          "name": "High Availability Cluster",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "connection-limit",
+          "name": "Connection Limit",
+          "type": "string",
+          "values": [
+            { "label": "connection-limit-generated-3", "name": "unlimited" },
+            { "label": "connection-limit-generated-17", "name": "10" }
+          ]
+        },
+        {
+          "label": "advanced-analytics-dashboard",
+          "name": "Analytics",
+          "type": "string",
+          "values": [
+            { "label": "advanced-analytics-dashboard-generated-4", "name": "Historical" },
+            { "label": "advanced-analytics-dashboard-generated-12", "name": "Advanced" },
+            { "label": "advanced-analytics-dashboard-generated-18", "name": "Basic" }
+          ]
+        },
+        {
+          "label": "credential-management",
+          "name": "Credential Management",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "access-control",
+          "name": "Access Control",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "new-relic",
+          "name": "New Relic Integration",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "support",
+          "name": "Support",
+          "type": "string",
+          "values": [
+            { "label": "support-generated-8", "name": "Best Effort" },
+            { "label": "support-generated-13", "name": "24/7" },
+            { "label": "support-generated-19", "name": "" }
+          ]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/memcachier/cache/images/2bwrkmxyp0tg60pbnmctfcnqmw.png",
+        "https://cdn.manifold.co/providers/memcachier/cache/images/8q3dkv453pv2qgmfa5c3x259rg.png",
+        "https://cdn.manifold.co/providers/memcachier/cache/images/aw8dngvbj1dteaurt9en0ccrj8.png"
+      ],
+      "integration": {
+        "base_url": "https://provisioner.memcachier.com/manifold/",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "user-specified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://provisioner.memcachier.com/manifold/",
+        "version": "v1"
+      },
+      "label": "memcachier-cache",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": false },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/memcachier/logos/8gugjy54514r5hev172up4ecug.png",
+      "name": "MemCachier",
+      "provider_id": "2344d2uxdefmte1j7vpthnu7qr0er",
+      "state": "available",
+      "support_email": "support@memcachier.com",
+      "tagline": "Reliable and powerful memcache-as-a-service.",
+      "tags": ["memory-store"],
+      "terms": { "provided": true, "url": "https://www.memcachier.com/legal/tos" },
+      "value_props": [
+        {
+          "body": "MemCachier is a completely new memcache implementation built from the ground up to perform well in the cloud.",
+          "header": "Reliably High-Performance"
+        },
+        {
+          "body": "Our production plans can be scaled instantly with a single command from you. No loss of data, just scale up or down as your application needs change.",
+          "header": "Scale With Ease"
+        },
+        {
+          "body": "All production cache’s are replicated and spread over many servers. If a node fails, you’re instantly switched to a new server for uninterrupted service.",
+          "header": "High Availability"
+        },
+        {
+          "body": "Our analytics dashboard gives you usage insights to help you get more out of your cache. We also support integration with New Relic.",
+          "header": "Analytics Dashboard"
+        },
+        {
+          "body": "All plans come with support from memcache experts. You’ll speak directly with engineers who’ve built the service. Contact us via email, gchat, irc or phone!",
+          "header": "Expert Support"
+        },
+        {
+          "body": "We've been in production since 2012 and support over 30,000 customers",
+          "header": "Proven Team \u0026 Technology"
+        }
+      ]
+    },
+    "id": "234yu3bya4z0t6zwrpvgbfbxrwabp",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://support.statushub.com/hc/en-us",
+      "feature_types": [
+        {
+          "label": "team-members",
+          "name": "Team Members",
+          "type": "string",
+          "values": [
+            { "label": "5-members", "name": "5", "price": {} },
+            { "label": "10-members", "name": "10", "price": {} },
+            { "label": "25-members", "name": "25", "price": {} },
+            { "label": "50-members", "name": "50", "price": {} }
+          ]
+        },
+        {
+          "label": "subscribers",
+          "name": "Subscribers",
+          "type": "string",
+          "values": [
+            { "label": "250", "name": "250", "price": {} },
+            { "label": "750", "name": "750", "price": {} },
+            { "label": "3000", "name": "3000", "price": {} },
+            { "label": "10000", "name": "10000", "price": {} }
+          ]
+        },
+        {
+          "label": "sms-per-month",
+          "name": "SMS credits per month",
+          "type": "string",
+          "values": [
+            { "label": "none", "name": "None", "price": {} },
+            { "label": "500", "name": "500", "price": {} },
+            { "label": "1000", "name": "1000", "price": {} },
+            { "label": "5000", "name": "5000", "price": {} },
+            { "label": "10000", "name": "10000", "price": {} }
+          ]
+        },
+        {
+          "label": "email-notifications",
+          "name": "Email notifications",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "Yes" }, { "label": "false", "name": "No" }]
+        },
+        {
+          "label": "custom-domain",
+          "name": "Custom domain",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "Yes" }, { "label": "false", "name": "No" }]
+        },
+        {
+          "label": "web-hook-notifications",
+          "name": "Webhook Notifications",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "Yes" }, { "label": "false", "name": "No" }]
+        },
+        {
+          "label": "status-hub-branding",
+          "name": "StatusHub Branding",
+          "type": "string",
+          "values": [
+            { "label": "branding", "name": "Branding", "price": {} },
+            { "label": "no-branding", "name": "No branding", "price": {} }
+          ]
+        },
+        {
+          "label": "microsoft-teams-notifications",
+          "name": "Microsoft Teams Notifications",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "Yes" }, { "label": "false", "name": "No" }]
+        },
+        {
+          "label": "whitelist",
+          "name": "Whitelist",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "Yes" }, { "label": "false", "name": "No" }]
+        },
+        {
+          "label": "platform-wide-alerts",
+          "name": "Platform-wide Alerts",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "Yes" }, { "label": "false", "name": "No" }]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/statushub/screenshots/0ffa356d-e3e1-4bf7-9fc9-cb70472cf0dc.png",
+        "https://cdn.manifold.co/providers/statushub/screenshots/b8c2ef8e-6764-4923-be83-ea64dc3ee049.png",
+        "https://cdn.manifold.co/providers/statushub/screenshots/7c16dac4-941e-4b18-bfc2-4bb02e373120.png"
+      ],
+      "integration": {
+        "base_url": "https://app.statushub.io/manifold/",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "unspecified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://app.statushub.io/manifold/",
+        "version": "v1"
+      },
+      "label": "statushub",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": true },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/statushub/logos/6bf2cdc1-dab2-44f2-84ec-0ae577e15484.png",
+      "name": "StatusHub",
+      "provider_id": "2348t89cxxnwf8fjpqh5xa5ntn7kc",
+      "state": "new",
+      "support_email": "support@statushub.com",
+      "tagline": "Downtime? Communicate with customers and maintain trust.",
+      "tags": ["monitoring"],
+      "terms": { "provided": true, "url": "https://statushub.com/terms/" },
+      "value_props": [
+        {
+          "body": "Let customers know about planned or unplanned downtime before they find out on their own.",
+          "header": "Proactively connect with customers."
+        },
+        {
+          "body": "Improve customer relationships with transparent incident management processes, and demonstrate reliability and availability to potential customers.",
+          "header": "Build company reputation and trust."
+        },
+        {
+          "body": "Ease strain on your support team from emails, calls, and social media backlash during unannounced service outages.",
+          "header": "Reduce customer service workload."
+        },
+        {
+          "body": "Shorten downtime with automated communication, and get systems back online with less stress.",
+          "header": "Real-time incident communication."
+        }
+      ]
+    },
+    "id": "234yzpzhu2x4wfc2w8y6x6zv55mam",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "http://helpdocs.blitline.com/",
+      "feature_types": [
+        {
+          "label": "free-hours",
+          "name": "Free Hours",
+          "type": "string",
+          "values": [{ "label": "two", "name": "2" }]
+        },
+        {
+          "label": "free-imagga-images",
+          "name": "Free Imagga Images",
+          "type": "string",
+          "values": [{ "label": "one-hundred", "name": "100" }]
+        },
+        {
+          "label": "bandwidth",
+          "name": "Bandwidth",
+          "type": "string",
+          "values": [{ "label": "unlimited", "name": "Unlimited" }]
+        },
+        {
+          "label": "processing-duration",
+          "measurable": true,
+          "name": "Processing Duration",
+          "type": "number",
+          "values": [
+            {
+              "label": "no-overtime",
+              "name": "No Overtime",
+              "numeric_details": { "cost_ranges": [], "suffix": "hour" }
+            },
+            {
+              "label": "processing-hours",
+              "name": "Processing Hours",
+              "numeric_details": {
+                "cost_ranges": [{ "cost_multiple": 790000000, "limit": -1 }],
+                "increment": 1,
+                "suffix": "hour"
+              }
+            }
+          ]
+        },
+        {
+          "label": "imagga-images",
+          "measurable": true,
+          "name": "Imagga Images",
+          "type": "number",
+          "values": [
+            {
+              "label": "no-overage",
+              "name": "No Overage",
+              "numeric_details": { "cost_ranges": [], "suffix": "image" }
+            },
+            {
+              "label": "imagga-images",
+              "name": "Imagga Images",
+              "numeric_details": {
+                "cost_ranges": [{ "cost_multiple": 10000000, "limit": -1 }],
+                "increment": 1,
+                "suffix": "image"
+              }
+            }
+          ]
+        },
+        {
+          "label": "video-encoding",
+          "measurable": true,
+          "name": "Video Encoding",
+          "type": "number",
+          "values": [
+            {
+              "label": "no-overage",
+              "name": "No Overage",
+              "numeric_details": { "cost_ranges": [], "suffix": "minute" }
+            },
+            {
+              "label": "video-encoding",
+              "name": "Video Encoding",
+              "numeric_details": {
+                "cost_ranges": [{ "cost_multiple": 38900000, "limit": -1 }],
+                "increment": 1,
+                "suffix": "minute"
+              }
+            }
+          ]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/blitline/screenshots/1.png",
+        "https://cdn.manifold.co/providers/blitline/screenshots/2.png",
+        "https://cdn.manifold.co/providers/blitline/screenshots/3.png",
+        "https://cdn.manifold.co/providers/blitline/screenshots/4.png"
+      ],
+      "integration": {
+        "base_url": "https://www.blitline.com/manifold/",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "unspecified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://www.blitline.com/manifold/",
+        "version": "v1"
+      },
+      "label": "blitline",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": true },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/blitline/logos/blitline.png",
+      "name": "Blitline",
+      "provider_id": "2343d7p36xwrydjy7120jxqxc7t22",
+      "state": "new",
+      "support_email": "support@blitline.com",
+      "tagline": "Premium image processing and rasterization API for enterprise systems",
+      "tags": ["optimization"],
+      "terms": { "provided": true, "url": "http://www.blitline.com/terms" },
+      "value_props": [
+        {
+          "body": "Blitline drastically reduces the amount of work you need to develop an application\nthat does any image processing. Stop rebuilding the same image processing functionality,\nlet us do it for much less than it would cost you to make and support it.\nPay for only the image processing time that your jobs use!\n",
+          "header": "Reduce Your Costs"
+        },
+        {
+          "body": "Need to process PDFs? Need to take screenshots of your website? Need HTML\nfor SEO? Want to run your own ImageMagick or other image processing scripts on\nour cloud? We do that!\n",
+          "header": "Broad spectrum functionality"
+        },
+        {
+          "body": "Instantly support thousands of concurrent image requests. Stop worrying about\nif you image processing is going to scale, we handle that for you, and we are\ngood at it. Blitline scales to let you manipulate hundreds of thousands images\nper hour, and millions per day.\n",
+          "header": "Massively Scalable"
+        },
+        {
+          "body": "We can push stuff into your S3 bucket for you. We can even read stuff out\nof your buckets so that you don’t have to make you images public.\n",
+          "header": "S3/Azure Integration"
+        },
+        {
+          "body": "Our customer support is top notch. Talk to developers, not support agents.",
+          "header": "Excellent Support"
+        },
+        {
+          "body": "Since we offer a language agnostic simple JSON API, you can do whatever you\nwant with Blitline from any language. You can manage your images with any language\nfrom Ruby to javascript. With our open and extensible API, you control the process,\nyou control you images, and you control your distribution. Since we operate strictly\nvia JSON, you are never locked in to using Blitline.\n",
+          "header": "Flexibility"
+        }
+      ]
+    },
+    "id": "234htwpkzvg1vuyez6uybfhv8rjb2",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://zerosix.ai/frequently-asked-questions/",
+      "feature_types": [
+        {
+          "label": "hourly-price",
+          "measurable": true,
+          "name": "Hourly Price",
+          "type": "number",
+          "values": [
+            {
+              "label": "dual-nvidia-1070ti-500-gb-ssd",
+              "name": "Dual NVIDIA 1070ti 500 GB SSD",
+              "numeric_details": {
+                "cost_ranges": [{ "cost_multiple": 900000000, "limit": -1 }],
+                "increment": 1,
+                "suffix": "hour"
+              }
+            },
+            {
+              "label": "nvidia-1060-250-gb-ssd",
+              "name": "NVIDIA 1060 250 GB SSD",
+              "numeric_details": {
+                "cost_ranges": [{ "cost_multiple": 250000000, "limit": -1 }],
+                "increment": 1,
+                "suffix": "hour"
+              }
+            },
+            {
+              "label": "nvidia-1070-50-gb-ssd",
+              "name": "NVIDIA 1070 50 GB SSD",
+              "numeric_details": {
+                "cost_ranges": [{ "cost_multiple": 300000000, "limit": -1 }],
+                "increment": 1,
+                "suffix": "hour"
+              }
+            },
+            {
+              "label": "nvidia-1080ti-100gb-ssd",
+              "name": "NVIDIA 1080ti 100GB SSD",
+              "numeric_details": {
+                "cost_ranges": [{ "cost_multiple": 500000000, "limit": -1 }],
+                "increment": 1,
+                "suffix": "hour"
+              }
+            },
+            {
+              "label": "nvidia-1080ti-250-gb-ssd",
+              "name": "NVIDIA 1080ti 250 GB SSD",
+              "numeric_details": {
+                "cost_ranges": [{ "cost_multiple": 600000000, "limit": -1 }],
+                "increment": 1,
+                "suffix": "hour"
+              }
+            }
+          ]
+        },
+        {
+          "label": "frame-buffer",
+          "name": "Frame Buffer",
+          "type": "string",
+          "values": [
+            { "label": "11-gb-gddr5x", "name": "11 GB GDDR5X", "price": {} },
+            { "label": "8-gb-gddr5", "name": "8 GB GDDR5", "price": {} },
+            { "label": "6-gb-gddr5x", "name": "6 GB GDDR5X", "price": {} }
+          ]
+        },
+        {
+          "label": "architecture",
+          "name": "Architecture",
+          "type": "string",
+          "values": [{ "label": "pascal", "name": "Pascal", "price": {} }]
+        },
+        {
+          "label": "ssd",
+          "name": "SSD",
+          "type": "string",
+          "values": [
+            { "label": "500-gb", "name": "500 GB", "price": {} },
+            { "label": "250-gb", "name": "250 GB", "price": {} },
+            { "label": "50-gb", "name": "50 GB", "price": {} },
+            { "label": "100-gb", "name": "100 GB", "price": {} }
+          ]
+        },
+        {
+          "label": "email-support",
+          "name": "Email Support",
+          "type": "string",
+          "values": [{ "label": "yes", "name": "Yes", "price": {} }]
+        }
+      ],
+      "images": [],
+      "integration": {
+        "base_url": "https://zerosix.ai/wp-json/manifold/",
+        "features": {
+          "access_code": false,
+          "plan_change": false,
+          "region": "unspecified",
+          "sso": false,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://zerosix.ai/wp-json/manifold/sso",
+        "version": "v1"
+      },
+      "label": "zerosix",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": true },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/zerosix/logos/4b9a4431-7ced-497d-b575-7ea741113bf3.png",
+      "name": "ZeroSix Cloud Compute Platform",
+      "provider_id": "234a6uzew2vfe1j69ntn67bf24ac0",
+      "state": "new",
+      "support_email": "support@zerosix.ai",
+      "tagline": "ZeroSix Marketplace provides access to compute power specifically for Machine Learning and Artificial Intelligence.",
+      "tags": ["worker", "ai-ml"],
+      "terms": { "provided": true, "url": "https://zerosix.ai/privacy-policy/" },
+      "value_props": [
+        {
+          "body": "Spend less time worrying about how much funding you need to train your models and more time working on your projects. Fully setup instances are available by the hour and come pre-installed with Docker, Keras, Scikit , NumPy, TensorFlow, Pytorch and more.",
+          "header": "Powerful GPUs for up to 1/5th the price of the other cloud platforms"
+        },
+        {
+          "body": "We support a number of the most popular frameworks out of the box (and if you need something specific we can pre-configure it for you). Sometimes you might want to leverage some containers to fully unlock your agile operation. We fully support docker and nvidia-docker to ensure there are no roadblocks.",
+          "header": "Docker Support"
+        },
+        {
+          "body": "Our support team is ready to help you every step of the way. You can reach us through direct email, chat on our website or even a phone call with a real person.",
+          "header": "Real Support"
+        },
+        {
+          "body": "Made with security in mind, your data and models are available to only you. Connect via SSH with identity files.",
+          "header": "Security"
+        },
+        {
+          "body": "All of our instances GPU enabled. This means your models get trained faster and we provide better processing power per dollar than traditional cloud vendors.",
+          "header": "Speed"
+        }
+      ]
+    },
+    "id": "234nbp17j5zrvb2ym49647kgtyv2a",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://gitlab.com/informantapp/informant-rails",
+      "feature_types": [
+        {
+          "label": "email-support",
+          "name": "Email Support",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "Yes" }, { "label": "false", "name": "No" }]
+        },
+        {
+          "label": "submission-limit",
+          "name": "Form Submission Limit",
+          "type": "string",
+          "values": [
+            { "label": "750", "name": "750 per month", "price": {} },
+            { "label": "3000", "name": "3000 per month", "price": {} },
+            { "label": "15000", "name": "15000 per month", "price": {} },
+            { "label": "45000", "name": "45000 per month", "price": {} },
+            { "label": "150000", "name": "150000 per month", "price": {} },
+            { "label": "1500000", "name": "1500000 per month", "price": {} }
+          ]
+        },
+        {
+          "label": "data-reporting",
+          "name": "Real-Time Data Reporting",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "Yes" }, { "label": "false", "name": "No" }]
+        },
+        {
+          "label": "error-aggregation",
+          "name": "Detailed Error Aggregation",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "Yes" }, { "label": "false", "name": "No" }]
+        }
+      ],
+      "images": [
+        "https://cdn.manifold.co/providers/informant/screenshots/29a4f1f9-0cb7-4570-a9c7-19739f95cfe3.png",
+        "https://cdn.manifold.co/providers/informant/screenshots/80d1b6f7-0e22-4ba2-b982-d0e071754ac7.png",
+        "https://cdn.manifold.co/providers/informant/screenshots/3fb94460-5e54-4105-8542-2de47a0d284f.png"
+      ],
+      "integration": {
+        "base_url": "https://api.informantapp.com/manifold",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "unspecified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://api.informantapp.com/manifold/",
+        "version": "v1"
+      },
+      "label": "informant",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": true },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/informant/logos/84ee44e2-fded-419e-85f4-dffdfafc8996.png",
+      "name": "Informant",
+      "provider_id": "23400t2qzjek86gq1ute8x2za76za",
+      "state": "new",
+      "support_email": "support@informantapp.com",
+      "tagline": "Form Validation Analytics for Ruby on Rails Applications",
+      "tags": ["monitoring"],
+      "terms": { "provided": true, "url": "https://www.informantapp.com/terms.html" },
+      "value_props": [
+        {
+          "body": "Informant provides real-time ActiveRecord validation monitoring, so you know when your users are making mistakes.",
+          "header": "Monitor user errors in real time"
+        },
+        {
+          "body": "Our validation monitoring extends to API calls, allowing you to monitor any validation issue, whether it’s caused by a user or an app.",
+          "header": "Keep an eye on your API"
+        },
+        {
+          "body": "Our handy visualizations and line-by-line tracking allow you to find the location \u0026 identity of any offending form submission.",
+          "header": "Drill down to the issue"
+        },
+        {
+          "body": "Informant respects Rails’ data security – we won’t store data from any sensitive fields, and if you need maximum security, you can configure Informant to only track errors without storing any field data at all.",
+          "header": "Rest easy with security"
+        },
+        {
+          "body": "Getting Informant running on a Rails installation is a breeze – just install the gem and you’re ready to go!",
+          "header": "Integrate in minutes"
+        }
+      ]
+    },
+    "id": "234jgrbpyg8ht242yu6tmq072w6tu",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "http://dev.iron.io/",
+      "feature_types": [
+        {
+          "label": "requests-month",
+          "name": "Requests per month",
+          "type": "string",
+          "values": [
+            { "label": "requests-month-generated-0", "name": "100000" },
+            { "label": "requests-month-generated-11", "name": "30000000" },
+            { "label": "requests-month-generated-12", "name": "1000000" },
+            { "label": "requests-month-generated-13", "name": "10000000" }
+          ]
+        },
+        {
+          "label": "unlimited-queues",
+          "name": "Unlimited Queues",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "high-availability",
+          "name": "High Availability",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "persistent-messages",
+          "name": "Persistent Messages",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "push-queues",
+          "name": "Push Queues",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "long-polling",
+          "name": "Long Polling",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "message-size-limit",
+          "name": "Message Size Limit",
+          "type": "string",
+          "values": [{ "label": "message-size-limit-generated-6", "name": "250" }]
+        },
+        {
+          "label": "alerts",
+          "name": "Alerts",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "error-queues",
+          "name": "Error Queues",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "advanced-dashboard",
+          "name": "Advanced Dashboard",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        },
+        {
+          "label": "fifo-delivery",
+          "name": "FIFO Delivery",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "true" }, { "label": "false", "name": "false" }]
+        }
+      ],
+      "images": ["https://cdn.manifold.co/providers/iron-io/screenshots/mq-lowres.png"],
+      "integration": {
+        "base_url": "https://billy.iron.io/manifold",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "user-specified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://billy.iron.io/manifold",
+        "version": "v1"
+      },
+      "label": "iron_mq",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": true },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/iron-io/logos/mq-200x200.png",
+      "name": "IronMQ",
+      "provider_id": "23423wffqvcmbdyyktzjy9wu6d120",
+      "state": "new",
+      "support_email": "support@iron.io",
+      "tagline": "Highly Available, Lightning Fast Message Queue Starting at $9.99/mo.",
+      "tags": ["messaging", "memory-store"],
+      "terms": { "provided": true, "url": "\u003chttps://www.iron.io/terms\u003e" },
+      "value_props": [
+        {
+          "body": "Just connect to IronMQ endpoints and you have instant access to unlimited message queueing.",
+          "header": "Instant and Elastic Message Queuing"
+        },
+        {
+          "body": "Written with elasticity and scale at its core, IronMQ is built using Go, a high-performance language designed for concurrency.",
+          "header": "Messaging at Scale"
+        },
+        {
+          "body": "IronMQ offers message persistence and redundancy right from the start so your queues are durable and highly available.",
+          "header": "Durable and Secure"
+        },
+        {
+          "body": "Make use of a large set of IronMQ language libraries including Ruby, PHP, Python, Java, .NET, Go, and more.",
+          "header": "Use Language of Your Choice"
+        }
+      ]
+    },
+    "id": "234tv2aj7n5vf7zc7hbqzvxeft91e",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://help.aiven.io/postgresql",
+      "feature_types": [
+        {
+          "label": "cpus",
+          "name": "CPUs",
+          "type": "string",
+          "values": [
+            { "label": "1-cpu", "name": "1 CPU", "price": {} },
+            { "label": "2-cpu", "name": "2 CPU", "price": {} }
+          ]
+        },
+        {
+          "label": "ram",
+          "name": "RAM",
+          "type": "string",
+          "values": [
+            { "label": "4-gb", "name": "4 GB", "price": {} },
+            { "label": "8-gb", "name": "8 GB", "price": {} }
+          ]
+        },
+        {
+          "label": "disk-space",
+          "name": "Disk space",
+          "type": "string",
+          "values": [
+            { "label": "80-gb", "name": "80 GB", "price": {} },
+            { "label": "175-gb", "name": "175 GB", "price": {} }
+          ]
+        },
+        {
+          "label": "highly-available",
+          "name": "Highly Available",
+          "type": "boolean",
+          "values": [{ "label": "true", "name": "Yes" }, { "label": "false", "name": "No" }]
+        }
+      ],
+      "images": [],
+      "integration": {
+        "base_url": "https://console.aiven.io/v1/marketplace/manifold/",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "user-specified",
+          "sso": false,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://aiven-rest-aiven-public-smulis-test.avns.net/v1/marketplace/manifold/",
+        "version": "v1"
+      },
+      "label": "aiven-pg",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": true },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/aiven/logos/a999d517-5fce-4d41-b77c-eaf80fe17680.png",
+      "name": "Aiven PostgreSQL",
+      "provider_id": "2341k8ga6p3d9qv3t42vmcjkb6kqe",
+      "state": "new",
+      "support_email": "support-manifold@aiven.io",
+      "tagline": "The most complete cloud Postgres on the market",
+      "tags": ["database"],
+      "terms": { "provided": true, "url": "https://aiven.io/terms" },
+      "value_props": [
+        {
+          "body": "Because of its maturity, Postgres is chock-full of extensions. Turn PostgreSQL into a time series database with the timescaledb extension or set it up to include spatial and geographic objects with postgis extension. With a growing list of over 40 popular extensions, you have a lot of options with Aiven.",
+          "header": "Choose from over 40 extensions"
+        },
+        {
+          "body": "It doesn't matter how fast, stable, and advanced a PostgreSQL offering is if it isn't secure. All Aiven services are run on dedicated virtual machines instead of multi-tenant ones most providers use. Your data is encrypted in transit and at rest, and our automation takes care of  all security updates.",
+          "header": "Enjoy end-to-end security"
+        },
+        {
+          "body": "It's simple, if you're running in production, your data needs to be backed up. Your data is essential and that's why Aiven PostgreSQL includes full daily back-ups and continuously recorded write-ahead logs (WAL). You can rest assured that if something happens to your service, we've got your back.",
+          "header": "Know that you can recover your data"
+        }
+      ]
+    },
+    "id": "234tmxeupmrt5rx93qx70yar4de1m",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://help.aiven.io/cassandra",
+      "feature_types": [
+        {
+          "label": "cpus-per-vm",
+          "name": "CPUs per VM",
+          "type": "string",
+          "values": [
+            { "label": "1-cpu", "name": "1 CPU", "price": {} },
+            { "label": "2-cpu", "name": "2 CPU", "price": {} }
+          ]
+        },
+        {
+          "label": "ram-per-vm",
+          "name": "RAM per VM",
+          "type": "string",
+          "values": [
+            { "label": "4-gb", "name": "4 GB", "price": {} },
+            { "label": "8-gb", "name": "8 GB", "price": {} },
+            { "label": "15-gb", "name": "15 GB", "price": {} }
+          ]
+        },
+        {
+          "label": "disk-space",
+          "name": "Disk space",
+          "type": "string",
+          "values": [
+            { "label": "450-gb", "name": "450 GB", "price": {} },
+            { "label": "900-gb", "name": "900 GB", "price": {} },
+            { "label": "1320-gb", "name": "1320 GB", "price": {} }
+          ]
+        }
+      ],
+      "images": [],
+      "integration": {
+        "base_url": "https://console.aiven.io/v1/marketplace/manifold/",
+        "features": {
+          "access_code": false,
+          "plan_change": false,
+          "region": "user-specified",
+          "sso": false,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://aiven-rest-aiven-public-smulis-test.avns.net/v1/marketplace/manifold/",
+        "version": "v1"
+      },
+      "label": "aiven-cassandra",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": true },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/aiven/logos/73be9a5e-dbd4-465e-a16c-4a24d0a86293.png",
+      "name": "Aiven Cassandra",
+      "provider_id": "2341k8ga6p3d9qv3t42vmcjkb6kqe",
+      "state": "new",
+      "support_email": "support-manifold@aiven.io",
+      "tagline": "The most complete cloud Cassandra on the market",
+      "tags": ["database"],
+      "terms": { "provided": true, "url": "https://aiven.io/terms" },
+      "value_props": [
+        {
+          "body": "If you have two nodes, you've got flexibility and some built-in resilience. What's better than two? Three...especially when they're spread across availability zones. Ours are and we think that's pretty bullet proof.",
+          "header": "Bullet proof multi-node clusters"
+        },
+        {
+          "body": "Even with the best team and partner, databases are finicky. That is why you need to be able to recover your data, especially if you're running in production. You can do this with Aiven Cassandra, every day of every year.",
+          "header": "365 backups per year"
+        },
+        {
+          "body": "If your data isn't secure, nothing else matters. All services run on dedicated VMs instead of multi-tenant ones most providers use. Your data is encrypted in transit and at rest, and our automation takes care of all security updates.",
+          "header": "Full-spectrum security"
+        }
+      ]
+    },
+    "id": "234qqazjcy9xm55tf0xner1nrb2tj",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://help.aiven.io/grafana",
+      "feature_types": [
+        {
+          "label": "cpus-per-vm",
+          "name": "CPUs per VM",
+          "type": "string",
+          "values": [
+            { "label": "1-cpu", "name": "1 CPU", "price": {} },
+            { "label": "2-cpu", "name": "2 CPU", "price": {} }
+          ]
+        },
+        {
+          "label": "ram-per-vm",
+          "name": "RAM per VM",
+          "type": "string",
+          "values": [
+            { "label": "1-gb", "name": "1 GB", "price": {} },
+            { "label": "4-gb", "name": "4 GB", "price": {} },
+            { "label": "8-gb", "name": "8 GB", "price": {} }
+          ]
+        }
+      ],
+      "images": [],
+      "integration": {
+        "base_url": "https://console.aiven.io/v1/marketplace/manifold/",
+        "features": {
+          "access_code": false,
+          "plan_change": true,
+          "region": "user-specified",
+          "sso": false,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://aiven-rest-aiven-public-smulis-test.avns.net/v1/marketplace/manifold/",
+        "version": "v1"
+      },
+      "label": "aiven-grafana",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": true },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/aiven/logos/b78667bf-1f5d-4729-b797-3c9bcf8bb94c.png",
+      "name": "Aiven Grafana",
+      "provider_id": "2341k8ga6p3d9qv3t42vmcjkb6kqe",
+      "state": "new",
+      "support_email": "support-manifold@aiven.io",
+      "tagline": "Your graphing and alerting needs in one platform",
+      "tags": ["monitoring"],
+      "terms": { "provided": true, "url": "https://aiven.io/terms" },
+      "value_props": [
+        {
+          "body": "It doesn't matter how fast, stable, and advanced a Kafka offering is if it isn't secure. All Aiven services are run on dedicated virtual machines instead of multi-tenant ones most providers use. Your data is encrypted in transit and at rest, and our automation takes care of all security updates.",
+          "header": "Enjoy end-to-end security"
+        }
+      ]
+    },
+    "id": "234vbqa39t933a05x3ce2ge2pe9nm",
+    "type": "product",
+    "version": 1
+  },
+  {
+    "body": {
+      "billing": { "currency": "usd", "type": "monthly-prorated" },
+      "documentation_url": "https://docs.manifold.co/docs/integration_phases-oKYp5R7fOKK6wYgKSMi6K",
+      "feature_types": [],
+      "images": [
+        "https://cdn.manifold.co/providers/manifold/screenshots/8719a658-90dd-49d3-96ef-d18e1320d8a8.jpg",
+        "https://cdn.manifold.co/providers/manifold/screenshots/a56c74d8-bb63-4cd6-ab3c-54407ceb0488.jpg",
+        "https://cdn.manifold.co/providers/manifold/screenshots/9cea7516-ccd7-46be-88bb-35dbc0ed1c6b.jpg",
+        "https://cdn.manifold.co/providers/manifold/screenshots/9645f393-36c8-4443-8d77-621e823156a5.jpg"
+      ],
+      "integration": {
+        "base_url": "https://api.provider.manifold.co/grafton",
+        "features": {
+          "access_code": false,
+          "plan_change": false,
+          "region": "unspecified",
+          "sso": true,
+          "credential": "unknown"
+        },
+        "provisioning": "public",
+        "sso_url": "https://api.provider.manifold.co/grafton",
+        "version": "v1"
+      },
+      "label": "provider-dashboard",
+      "listing": {
+        "listed": true,
+        "marketing": { "beta": false, "featured": false, "new": false },
+        "public": true
+      },
+      "logo_url": "https://cdn.manifold.co/providers/manifold/logos/169426da-3038-4029-8dd5-4f277028da87.png",
+      "name": "Manifold Provider Dashboard",
+      "provider_id": "23471nvu599e2zfvvg3gq2f024w5m",
+      "state": "available",
+      "support_email": "support@manifold.co",
+      "tagline": "Onboard as a Service Provider on the Manifold marketplace",
+      "tags": ["sell-your-service"],
+      "terms": { "provided": true, "url": "https://www.manifold.co/terms" },
+      "value_props": [
+        {
+          "body": "Your product is stronger on a platform of complimentary services.",
+          "header": "Be part of a stack"
+        },
+        {
+          "body": "You integrate one time and grow with Manifold automatically and forever.",
+          "header": "Enjoy infinite upside"
+        },
+        {
+          "body": "List your product in the same context as other world-class services.",
+          "header": "Punch above your weight"
+        }
+      ]
+    },
+    "id": "234h92g4yp7r53td9xte0e1uv48g2",
+    "type": "product",
+    "version": 1
+  }
+]

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -9,6 +9,7 @@ export const config: Config = {
   globalStyle: 'src/global/theme.css',
   globalScript: 'src/global/app.ts',
   outputTargets: [{ type: 'dist' }],
+  excludeSrc: ['**/*-happo.*', '**/spec/mock/*'],
   plugins: [
     postcss({
       plugins: [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "jsx": "react",
     "jsxFactory": "h",
     "strictNullChecks": true,
+    "resolveJsonModule": true,
     "paths": {
       "*": ["../node_modules/*", "*"]
     }


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

Continuing VRT work for UI. This adds a screenshot for:

* The plan selector with JawsDB, using JSON retrieved from the API as mock data for the component.
* The skeleton screen for the marketplace grid 
* Marketplace grid with services

To get the screenshot to work for the marketplace with services, I had to change `skeleton` to `false` by default, and switch it to true when we first try to display services if we detect that none have been given.

## Testing
<!-- For someone unfamiliar with the issue, how should this be tested? -->
