### PR TITLE
Fix IntersectionObserver in Chrome

### DIFF
--- a/src/components/manifold-lazy-image/manifold-lazy-image.tsx
+++ b/src/components/manifold-lazy-image/manifold-lazy-image.tsx
@@ -8,29 +8,25 @@ export class ManifoldLazyImage {
   @State() observer: IntersectionObserver;
 
   componentWillLoad() {
-    this.observer = new IntersectionObserver(this.observe, {
-      rootMargin: '0px 0px 50px 0px',
-      threshold: 0,
-    });
+    this.observer = new IntersectionObserver(this.observe);
   }
 
   private observe = (
     entries: IntersectionObserverEntry[],
     observer: IntersectionObserver
   ): void => {
-    const entry = entries[0];
+    const entry = entries.find(({ isIntersecting }) => isIntersecting === true);
+    if (!entry) return;
+
     const image = entry.target as HTMLImageElement;
     image.onload = () => image.setAttribute('data-loaded', 'true');
+    const source = image.getAttribute('data-src');
 
-    if (entry && entry.isIntersecting) {
-      const source = image.getAttribute('data-src');
-
-      if (source) {
-        image.src = source;
-      }
-
-      observer.unobserve(image);
+    if (source) {
+      image.src = source;
     }
+
+    observer.unobserve(image);
   };
 
   private observeImage = (el?: HTMLElement) => {


### PR DESCRIPTION
Fixes manifoldco/engineering#8239.

This fixes a bug where on page load, Chrome wouldn’t load the images in view. It would only load on scroll.

## Reason for change
**Before**
![Screen Shot 2019-05-23 at 11 25 30](https://user-images.githubusercontent.com/1369770/58273369-d28e3680-7d4d-11e9-8bdf-8a5cf25b1fa7.png)

**After**
![Screen Shot 2019-05-23 at 11 40 02](https://user-images.githubusercontent.com/1369770/58274179-8e9c3100-7d4f-11e9-9d4a-b0da4f1f4716.png)

## Testing
Preview the Storybook link in Chrome (not Gatsby). The images have to be in the initial viewport to break (the Gatsby docs require you to scroll, so you won’t notice it).
