### PR TITLE
Adding toggle screenshots

### DIFF
--- a/src/components/manifold-toggle/manifold-toggle-happo.ts
+++ b/src/components/manifold-toggle/manifold-toggle-happo.ts
@@ -3,3 +3,24 @@ export const primary = () => {
 
   document.body.appendChild(toggle);
 };
+
+export const labeled = () => {
+  const toggle = document.createElement('manifold-toggle');
+  toggle.label = 'Happo Test Label';
+
+  document.body.appendChild(toggle);
+};
+
+export const disabled = () => {
+  const toggle = document.createElement('manifold-toggle');
+  toggle.disabled = true;
+
+  document.body.appendChild(toggle);
+};
+
+export const checked = () => {
+  const toggle = document.createElement('manifold-toggle');
+  toggle.defaultValue = true;
+
+  document.body.appendChild(toggle);
+};

--- a/src/components/manifold-toggle/manifold-toggle-happo.ts
+++ b/src/components/manifold-toggle/manifold-toggle-happo.ts
@@ -1,0 +1,5 @@
+export const primary = () => {
+  const toggle = document.createElement('manifold-toggle');
+
+  document.body.appendChild(toggle);
+};


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change
Adds tests for disabled, checked, labeled and default toggle buttons.
Tests visible here: https://happo.io/a/67/p/129/report/dev-5ae7dc260dae5d035797#manifold-toggle

## Testing
Test can be run locally with `npm run happo dev`.
