### PR TITLE
implement lower-level theming for input fields

### DIFF
--- a/docs/docs/theming.md
+++ b/docs/docs/theming.md
@@ -70,7 +70,7 @@ manifold-marketplace {
 ### Grayscales & Dark Theming
 
 | Name                                 | Default         | Description                                        |
-|--------------------------------------|-----------------|----------------------------------------------------|
+| ------------------------------------ | --------------- | -------------------------------------------------- |
 | `--manifold-grayscale-base`          | `0, 0, 0`       | The darkest color on your grayscale in RGB values  |
 | `--manifold-grayscale-base-inverted` | `255, 255, 255` | The lightest color on your grayscale in RGB values |
 
@@ -101,7 +101,7 @@ By default, `--manifold-grayscale-[opacity]` values range from solid black down 
 There are four theming levels:
 
 | Level       | Name              | Description                                                          |
-|-------------|-------------------|----------------------------------------------------------------------|
+| ----------- | ----------------- | -------------------------------------------------------------------- |
 | 1 (highest) | Base              | The base theme provided by Manifold UI                               |
 | 2           | Top-level         | Your custom theme and branding                                       |
 | 3           | Common Components | Reusable UI elements like cards, buttons, and tags                   |
@@ -165,14 +165,14 @@ Some variables that are for a specific state `*-hover`, `*-focus`, `*-active` wi
 ### Grayscale
 
 | Name                                 | Default         | Description                                        |
-|--------------------------------------|-----------------|----------------------------------------------------|
+| ------------------------------------ | --------------- | -------------------------------------------------- |
 | `--manifold-grayscale-base`          | `0, 0, 0`       | The darkest color on your grayscale in RGB values  |
 | `--manifold-grayscale-base-inverted` | `255, 255, 255` | The lightest color on your grayscale in RGB values |
 
 ### Top Level Properties
 
 | Name                               | Default                                   | Description                                        |
-|------------------------------------|-------------------------------------------|----------------------------------------------------|
+| ---------------------------------- | ----------------------------------------- | -------------------------------------------------- |
 | `--manifold-color-primary`         | `rgb(30, 80, 218)`                        | Primary color                                      |
 | `--manifold-color-success`         | `rgb(49, 186, 162)`                       | Success color<sup>\*</sup>                         |
 | `--manifold-color-info`            | `rgb(30, 80, 218)`                        | General info message color<sup>\*</sup>            |
@@ -197,7 +197,7 @@ Some variables that are for a specific state `*-hover`, `*-focus`, `*-active` wi
 Text components are used thoughout most components.
 
 | Name                                                                  | Default                          | Description                                                                                              |
-|-----------------------------------------------------------------------|----------------------------------|----------------------------------------------------------------------------------------------------------|
+| --------------------------------------------------------------------- | -------------------------------- | -------------------------------------------------------------------------------------------------------- |
 | `--manifold-text-color-secondary`                                     | `var(--manifold-grayscale-50)`   | Secondary text color; provides additional context to some primary text. Examples: suffixes, descriptions |
 | `--manifold-text-color-accent`                                        | `var(--manifold-grayscale-100i)` | Accent text color; overlays on `--manifold-color-primary` for buttons, tags, etc.                        |
 | `--manifold-text-color-body`                                          | `var(--manifold-text-color)`     | Body text color; paragraphs of text.                                                                     |
@@ -210,7 +210,7 @@ Text components are used thoughout most components.
 Cards are used in Marketplace (service cards) and Plan Selector (plan buttons, plan details panel).
 
 | Name                                | Default                           | Description       |
-|-------------------------------------|-----------------------------------|-------------------|
+| ----------------------------------- | --------------------------------- | ----------------- |
 | `--manifold-card-background`        | `var(--manifold-grayscale-100i)`  | Background        |
 | `--manifold-card-border`            | `var(--manifold-border)`          | Border            |
 | `--manifold-card-radius`            | `var(--manifold-radius)`          | Corner radius     |
@@ -226,25 +226,22 @@ Cards are used in Marketplace (service cards) and Plan Selector (plan buttons, p
 
 #### Input Fields
 
-| Name                                                                      | Default                                  | Description      |
-|---------------------------------------------------------------------------|------------------------------------------|------------------|
-| <span class="tag part-implemented" /> `--manifold-input-background`       | `var(--manifold-grayscale-100i)`         | Background       |
-| <span class="tag part-implemented" /> `--manifold-input-border`           | `var(--manifold-border)`                 | Border           |
-| <span class="tag not-implemented" /> `--manifold-input-radius`            | `var(--manifold-radius)`                 | Radius           |
-| <span class="tag part-implemented" /> `--manifold-input-shadow`           | `none`                                   | Shadow           |
-|                                                                           |                                          |                  |
-| <span class="tag not-implemented" /> `--manifold-input-background-hover`  | `var(--manifold-input-background)`       | Background:hover |
-| <span class="tag not-implemented" /> `--manifold-input-border-hover`      | `var(--manifold-input-border)`           | Background:hover |
-| <span class="tag not-implemented" /> `--manifold-input-shadow-hover`      | `var(--manifold-input-shadow)`           | Shadow:hover     |
-|                                                                           |                                          |                  |
-| <span class="tag part-implemented" /> `--manifold-input-background-focus` | `var(--manifold-input-background-hover)` | Background:focus |
-| <span class="tag part-implemented" /> `--manifold-input-border-focus`     | `var(--manifold-input-border-hover)`     | Border:focus     |
-| <span class="tag part-implemented" /> `--manifold-input-shadow-focus`     | `var(--manifold-input-shadow-hover)`     | Shadow:focus     |
+| Name                                | Default                                  | Description      |
+| ----------------------------------- | ---------------------------------------- | ---------------- |
+| `--manifold-input-background`       | `var(--manifold-grayscale-100i)`         | Background       |
+| `--manifold-input-text-color`       | `var(--manifold-text-color)`             | Text color       |
+| `--manifold-input-border`           | `var(--manifold-border)`                 | Border           |
+| `--manifold-input-radius`           | `var(--manifold-radius)`                 | Radius           |
+| `--manifold-input-shadow`           | `none`                                   | Shadow           |
+|                                     |                                          |                  |
+| `--manifold-input-background-focus` | `var(--manifold-input-background-hover)` | Background:focus |
+| `--manifold-input-border-focus`     | `var(--manifold-input-border-focus)`     | Border:focus     |
+| `--manifold-input-shadow-focus`     | `var(--manifold-input-shadow-hover)`     | Shadow:focus     |
 
 #### Tags
 
 | Name                                                                  | Default                             | Description                |
-|-----------------------------------------------------------------------|-------------------------------------|----------------------------|
+| --------------------------------------------------------------------- | ----------------------------------- | -------------------------- |
 | `--manifold-tag-background`                                           | `var(--manifold-color-primary)`     | Background                 |
 | `--manifold-tag-text-color`                                           | `var(--manifold-text-color-accent)` | Text color                 |
 | <span class="tag not-implemented" /> `--manifold-tag-font-size`       | `1rem`                              | Font size                  |
@@ -261,7 +258,7 @@ Cards are used in Marketplace (service cards) and Plan Selector (plan buttons, p
 #### Marketplace
 
 | Name                                                                   | Default                                | Description                             |
-|------------------------------------------------------------------------|----------------------------------------|-----------------------------------------|
+| ---------------------------------------------------------------------- | -------------------------------------- | --------------------------------------- |
 | <span class="tag not-implemented" /> `--link-text-color`               | `var(--manifold-text-color-secondary)` | Category menu link text color           |
 | <span class="tag not-implemented" /> `--link-font-weight`              | `inherit`                              | Category menu link font weight          |
 | <span class="tag not-implemented" /> `--link-text-color-hover`         | `var(--manifold-text-color-primary)`   | Category menu link text color (hover)   |
@@ -288,7 +285,7 @@ Cards are used in Marketplace (service cards) and Plan Selector (plan buttons, p
 #### Plan Selector
 
 | Name                                                                      | Default                            | Description                   |
-|---------------------------------------------------------------------------|------------------------------------|-------------------------------|
+| ------------------------------------------------------------------------- | ---------------------------------- | ----------------------------- |
 | <span class="tag not-implemented" /> `--plan-menu-grid-gap`               | `1rem`                             | Gap between plan menu buttons |
 |                                                                           |                                    |                               |
 | <span class="tag not-implemented" /> `--plan-menu-card-background`        | `var(--manifold-card-background)`  | Background                    |
@@ -312,7 +309,7 @@ Cards are used in Marketplace (service cards) and Plan Selector (plan buttons, p
 #### Product
 
 | Name                                                                    | Default                                | Description                      |
-|-------------------------------------------------------------------------|----------------------------------------|----------------------------------|
+| ----------------------------------------------------------------------- | -------------------------------------- | -------------------------------- |
 | <span class="tag not-implemented" /> `--product-card-background`        | Branded Gradient                       | Background                       |
 | <span class="tag not-implemented" /> `--product-card-border`            | `var(--manifold-border)`               | Border                           |
 | <span class="tag not-implemented" /> `--product-card-radius`            | `var(--manifold-radius)`               | Corner radius                    |

--- a/docs/src/lib/theme-ruby.ts
+++ b/docs/src/lib/theme-ruby.ts
@@ -45,8 +45,7 @@ export default css`
 
     /* Input Fields */
     --manifold-input-background: var(--theme-lightest-gray);
-    --manifold-input-border: var(--theme-lightest-gray);
-    --manifold-input-border-focus: var(--theme-lightest-gray);
+    --manifold-input-border: 1px solid var(--theme-lightest-gray);
 
     /* Borders */
     --manifold-radius: 0;

--- a/src/components/manifold-marketplace-grid/manifold-marketplace-grid.css
+++ b/src/components/manifold-marketplace-grid/manifold-marketplace-grid.css
@@ -12,15 +12,17 @@
   --heading-border: 1px solid var(--manifold-grayscale-10);
 
   /* search */
-  --search-text-color: var(--manifold-grayscale-100);
-  --search-background: var(--manifold-input-background, var(--manifold-grayscale-05));
-  --search-shadow: var(--manifold-input-shadow, none);
-  --search-shadow-focus: var(--manifold-input-shadow-focus, --search-shadow);
-  --search-background-focus: var(--manifold-input-background-focus, var(--search-background));
-  --search-border: var(--manifold-input-border, var(--manifold-border));
-  --search-border-focus: var(--manifold-input-border-focus, var(--manifold-border-focus));
-  --search-radius: var(--manifold-radius);
+  --search-text-color: var(--manifold-input-text-color);
+  --search-background: var(--manifold-input-background);
+  --search-border: var(--manifold-input-border);
+  --search-shadow: var(--manifold-input-shadow);
+  --search-radius: var(--manifold-input-radius);
   --search-placeholder-color: var(--manifold-text-color-secondary);
+
+  /* focus */
+  --search-shadow-focus: var(--manifold-input-shadow-focus, var(--search-shadow));
+  --search-background-focus: var(--manifold-input-background-focus, var(--search-background));
+  --search-border-focus: var(--manifold-input-border-focus, var(--search-border));
 
   color: var(--manifold-text-color);
   font-family: var(--manifold-font-family);

--- a/src/components/manifold-number-input/mf-number-input.css
+++ b/src/components/manifold-number-input/mf-number-input.css
@@ -1,12 +1,19 @@
 :host {
-  --input-background: var(--manifold-grayscale-100i);
-  --input-placeholder-color: var(--manifold-text-color-secondary);
-  --input-border: var(--manfold-input-border, var(--manifold-border));
-  --input-border-focus: 1px solid var(--manifold-color-primary);
   --button-background: var(--manifold-grayscale-05);
-  --text-color: var(--manifold-grayscale-100);
-  --radius: var(--manifold-radius);
+  --text-color: var(--manifold-input-text-color);
   --range-text-color: var(--manifold-text-color-secondary);
+
+  /* field */
+  --input-background: var(--manifold-input-background);
+  --input-placeholder-color: var(--manifold-text-color-secondary);
+  --input-border: var(--manfold-input-border);
+  --input-shadow: var(--manifold-input-shadow);
+  --radius: var(--manifold-input-radius);
+
+  /* field:focus */
+  --input-background-focus: var(--input-background-focus);
+  --input-border-focus: var(--input-border-focus);
+  --input-shadow-focus: var(--input-shadow);
 }
 
 .container {
@@ -27,6 +34,7 @@
   background: var(--input-background);
   border: var(--input-border);
   border-radius: var(--radius);
+  box-shadow: var(--input-shadow);
   -webkit-appearance: none;
   -moz-appearance: textfield; /* hides up/down buttons on firefox */
   font-variant-ligatures: none;
@@ -45,8 +53,10 @@
   }
 
   &:focus {
+    background: var(--input-background-focus);
     border: var(--input-border-focus);
     outline: 0;
+    box-shadow: var(--input-shadow-focus);
   }
 }
 

--- a/src/components/manifold-number-input/mf-number-input.css
+++ b/src/components/manifold-number-input/mf-number-input.css
@@ -6,13 +6,13 @@
   /* field */
   --input-background: var(--manifold-input-background);
   --input-placeholder-color: var(--manifold-text-color-secondary);
-  --input-border: var(--manfold-input-border);
+  --input-border: var(--manifold-input-border);
   --input-shadow: var(--manifold-input-shadow);
   --radius: var(--manifold-input-radius);
 
   /* field:focus */
-  --input-background-focus: var(--input-background-focus);
-  --input-border-focus: var(--input-border-focus);
+  --input-background-focus: var(--input-background);
+  --input-border-focus: var(--manifold-border-focus);
   --input-shadow-focus: var(--input-shadow);
 }
 

--- a/src/components/manifold-select/mf-select.css
+++ b/src/components/manifold-select/mf-select.css
@@ -3,12 +3,17 @@
   --default-color: var(--manifold-grayscale-40);
   --focus-color: var(--manifold-color-primary);
 
-  /* theme */
-  --radius: var(--manifold-radius, 4px);
-  --border: var(--manfold-input-border, var(--manifold-border));
-  --border-focus: var(--manfold-border-active, 1px solid var(--manifold-color-primary));
-  --background: var(--manifold-grayscale-100i);
-  --text-color: var(--manifold-text-color);
+  /* field */
+  --text-color: var(--manifold-input-text-color);
+  --background: var(--manifold-input-background);
+  --border: var(--manfold-input-border);
+  --shadow: var(--manifold-input-shadow);
+  --radius: var(--manifold-input-radius);
+
+  /* field:focus */
+  --background-focus: var(--background-focus);
+  --border-focus: var(--border-focus);
+  --shadow-focus: var(--shadow);
 }
 
 select {
@@ -30,13 +35,16 @@ select {
   background-size: 5px 5px, 5px 5px, 1px 1.5em;
   border: var(--border);
   border-radius: var(--radius);
+  box-shadow: var(--shadow);
   appearance: none;
 }
 
 select:focus {
+  background-color: var(--background-focus);
   background-image: linear-gradient(45deg, transparent 50%, var(--focus-color) 50%),
     linear-gradient(135deg, var(--focus-color) 50%, transparent 50%),
     linear-gradient(to right, var(--focus-color), var(--focus-color));
   border-color: var(--focus-color);
   outline: 0;
+  box-shadow: var(--shadow-focus);
 }

--- a/src/components/manifold-select/mf-select.css
+++ b/src/components/manifold-select/mf-select.css
@@ -6,13 +6,13 @@
   /* field */
   --text-color: var(--manifold-input-text-color);
   --background: var(--manifold-input-background);
-  --border: var(--manfold-input-border);
+  --border: var(--manifold-input-border);
   --shadow: var(--manifold-input-shadow);
   --radius: var(--manifold-input-radius);
 
   /* field:focus */
-  --background-focus: var(--background-focus);
-  --border-focus: var(--border-focus);
+  --background-focus: var(--background);
+  --border-focus: var(--manifold-border-focus);
   --shadow-focus: var(--shadow);
 }
 

--- a/src/components/manifold-select/mf-select.css
+++ b/src/components/manifold-select/mf-select.css
@@ -44,7 +44,7 @@ select:focus {
   background-image: linear-gradient(45deg, transparent 50%, var(--focus-color) 50%),
     linear-gradient(135deg, var(--focus-color) 50%, transparent 50%),
     linear-gradient(to right, var(--focus-color), var(--focus-color));
-  border-color: var(--focus-color);
+  border: var(--border-focus);
   outline: 0;
   box-shadow: var(--shadow-focus);
 }

--- a/src/global/theme.css
+++ b/src/global/theme.css
@@ -63,9 +63,6 @@
   --manifold-color-success: var(--manifold-green);
   --manifold-color-warn: var(--manifold-orange);
   --manifold-color-error: var(--manifold-red);
-  --manifold-radius: 4px;
-  --manifold-border: 1px solid var(--manifold-grayscale-10);
-  --manifold-border-focus: 1px solid var(--manifold-color-primary);
 
   /* Text */
   --manifold-text-color: var(--manifold-grayscale-100);
@@ -164,9 +161,4 @@
   --manifold-input-border: var(--manifold-border);
   --manifold-input-radius: var(--manifold-radius);
   --manifold-input-shadow: none;
-
-  /* Input:focus */
-  --manifold-input-background-focus: var(--manifold-input-background);
-  --manifold-input-border-focus: var(--manifold-border-focus);
-  --manifold-input-shadow-focus: var(--manifold-input-shadow);
 }

--- a/src/global/theme.css
+++ b/src/global/theme.css
@@ -157,4 +157,16 @@
   --manifold-card-radius: var(--manifold-radius);
   --manifold-card-shadow: none;
   --manifold-card-text-color: var(--manifold-text-color);
+
+  /* Input */
+  --manifold-input-background: var(--manifold-grayscale-100i);
+  --manifold-input-text-color: var(--manifold-text-color);
+  --manifold-input-border: var(--manifold-border);
+  --manifold-input-radius: var(--manifold-radius);
+  --manifold-input-shadow: none;
+
+  /* Input:focus */
+  --manifold-input-background-focus: var(--manifold-input-background);
+  --manifold-input-border-focus: var(--manifold-border-focus);
+  --manifold-input-shadow-focus: var(--manifold-input-shadow);
 }


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

- Theming for input fields (text and select elements)

## Testing
<!-- For someone unfamiliar with the issue, how should this be tested? -->
check the default and focus states for all themes work as expected