### PR TITLE
Ignore Stencil-managed dependencies on dependabot

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2,6 +2,8 @@ version: 1
 update_configs:
   - ignored_updates:
       - match:
+        dependency_name: '@types/jest' # Version-managed by Stencil
+      - match:
         dependency_name: 'fs-extra' # For a Travis script; doesn’t matter
       - match:
         dependency_name: 'jest' # Version-managed by Stencil

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,9 @@
+version: 1
+update_configs:
+  - ignored_updates:
+      - match:
+        dependency_name: 'fs-extra' # For a Travis script; doesn’t matter
+      - match:
+        dependency_name: 'jest' # Version-managed by Stencil
+      - match:
+        dependency_name: 'jest-cli' # Version-managed by Stencil


### PR DESCRIPTION
## Reason for change
Makes dependabot less-noisy by not opening PRs for dependencies that are either beyond our control or aren’t important to manage (e.g. Travis CI script deps don’t need PRs as long as the script is running)

## Testing
This PR should pass tests, etc.
