### PR TITLE
Add service template link formatting

### DIFF
--- a/docs/docs/components/manifold-marketplace.md
+++ b/docs/docs/components/manifold-marketplace.md
@@ -94,10 +94,13 @@ The following events are emitted:
 
 By default, service cards will only emit the `manifold-marketplace-click`
 event (above). But it can also be turned into an `<a>` tag by specifying
-`link-format`:
+`product-link-format` and `template-link-format`:
 
 ```html
-<manifold-marketplace link-format="/product/:product" template-link-format="/template/:template" />
+<manifold-marketplace
+  product-link-format="/product/:product"
+  template-link-format="/template/:template"
+/>
 <!-- <a href="/product/jawsdb-mysql"> -->
 ```
 

--- a/docs/docs/components/manifold-marketplace.md
+++ b/docs/docs/components/manifold-marketplace.md
@@ -97,11 +97,12 @@ event (above). But it can also be turned into an `<a>` tag by specifying
 `link-format`:
 
 ```html
-<manifold-marketplace link-format="/product/:product" />
+<manifold-marketplace link-format="/product/:product" template-link-format="/template/:template" />
 <!-- <a href="/product/jawsdb-mysql"> -->
 ```
 
-`:product` will be replaced with the url-friendly slug for the product.
+`:product` will be replaced with the url-friendly slug for the product, as
+will `:template` for custom resource templates.
 
 Note that this will disable the custom events unless `preserve-event` is
 passed as well.

--- a/docs/docs/components/manifold-service-card.md
+++ b/docs/docs/components/manifold-service-card.md
@@ -25,10 +25,10 @@ Compact view of a Manifold Product.
 
 By default, service cards will only emit the `manifold-marketplace-click`
 event (above). But it can also be turned into an `<a>` tag by specifying
-`link-format`:
+`product-link-format`:
 
 ```html
-<manifold-marketplace link-format="/product/:product" />
+<service-card product-link-format="/product/:product" />
 <!-- <a href="/product/jawsdb-mysql"> -->
 ```
 

--- a/docs/docs/components/manifold-service-card.md
+++ b/docs/docs/components/manifold-service-card.md
@@ -28,7 +28,7 @@ event (above). But it can also be turned into an `<a>` tag by specifying
 `product-link-format`:
 
 ```html
-<service-card product-link-format="/product/:product" />
+<manifold-service-card product-link-format="/product/:product" />
 <!-- <a href="/product/jawsdb-mysql"> -->
 ```
 

--- a/docs/docs/data/manifold-data-resource-list.md
+++ b/docs/docs/data/manifold-data-resource-list.md
@@ -30,14 +30,14 @@ Navigating client-side happens via the `manifold-resourceList-click` custom even
 
 ## Link format
 
-To navigate using a traditional `<a>` tag, specify a `link-format` attribute, using
-`:resource` as a placeholder:
+To navigate using a traditional `<a>` tag, specify a `resource-link-format`
+attribute, using `:resource` as a placeholder:
 
 ```html
-<manifold-data-resource-list link-format="/resource/:resource" />
+<manifold-data-resource-list resource-link-format="/resource/:resource" />
 ```
 
-Note that this will disable the custom events unless `preserve-event` is
+Note that this will disable the custom event unless `preserve-event` is
 passed as well.
 
 ## Pausing updates

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -6,7 +6,6 @@
 
 
 import { HTMLStencilElement, JSXBase } from '@stencil/core/internal';
-import { JSX } from '@stencil/core';
 import {
   Connection,
 } from './utils/connections';
@@ -186,6 +185,10 @@ export namespace Components {
     * Comma-separated list of shown products (labels)
     */
     'products'?: string;
+    /**
+    * Template format structure, with `:product` placeholder
+    */
+    'templateLinkFormat'?: string;
   }
   interface ManifoldMarketplaceGrid {
     'excludes'?: string[];
@@ -196,6 +199,7 @@ export namespace Components {
     'preserveEvent': boolean;
     'products'?: string[];
     'services'?: Catalog.Product[];
+    'templateLinkFormat'?: string;
   }
   interface ManifoldNumberInput {
     'decrementDisabledLabel'?: string;
@@ -322,8 +326,8 @@ export namespace Components {
   interface ManifoldSkeletonText {}
   interface ManifoldTemplateCard {
     'category': string;
-    'linkFormat'?: string;
     'preserveEvent': boolean;
+    'templateLinkFormat'?: string;
   }
   interface ManifoldToast {
     /**
@@ -527,6 +531,10 @@ declare namespace LocalJSX {
     * Comma-separated list of shown products (labels)
     */
     'products'?: string;
+    /**
+    * Template format structure, with `:product` placeholder
+    */
+    'templateLinkFormat'?: string;
   }
   interface ManifoldMarketplaceGrid extends JSXBase.HTMLAttributes {
     'excludes'?: string[];
@@ -537,6 +545,7 @@ declare namespace LocalJSX {
     'preserveEvent'?: boolean;
     'products'?: string[];
     'services'?: Catalog.Product[];
+    'templateLinkFormat'?: string;
   }
   interface ManifoldNumberInput extends JSXBase.HTMLAttributes {
     'decrementDisabledLabel'?: string;
@@ -670,9 +679,9 @@ declare namespace LocalJSX {
   interface ManifoldSkeletonText extends JSXBase.HTMLAttributes {}
   interface ManifoldTemplateCard extends JSXBase.HTMLAttributes {
     'category'?: string;
-    'linkFormat'?: string;
     'onManifold-template-click'?: (event: CustomEvent<any>) => void;
     'preserveEvent'?: boolean;
+    'templateLinkFormat'?: string;
   }
   interface ManifoldToast extends JSXBase.HTMLAttributes {
     /**

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -115,17 +115,17 @@ export namespace Components {
     */
     'connection': Connection;
     /**
-    * Link format structure, with `:resource` placeholder
-    */
-    'linkFormat'?: string;
-    /**
     * Disable auto-updates?
     */
     'paused': boolean;
     /**
-    * Should the JS event still fire, even if link-format is passed?
+    * Should the JS event still fire, even if product-link-format is passed?
     */
     'preserveEvent': boolean;
+    /**
+    * Link format structure, with `:resource` placeholder
+    */
+    'resourceLinkFormat'?: string;
   }
   interface ManifoldForwardSlot {}
   interface ManifoldIcon {
@@ -174,13 +174,13 @@ export namespace Components {
     */
     'hideTemplates'?: boolean;
     /**
-    * Link format structure, with `:product` placeholder
-    */
-    'linkFormat'?: string;
-    /**
-    * Should the JS event still fire, even if link-format is passed?
+    * Should the JS event still fire, even if product-link-format is passed?
     */
     'preserveEvent': boolean;
+    /**
+    * Product link structure, with `:product` placeholder
+    */
+    'productLinkFormat'?: string;
     /**
     * Comma-separated list of shown products (labels)
     */
@@ -195,8 +195,8 @@ export namespace Components {
     'featured'?: string[];
     'hideCategories'?: boolean;
     'hideTemplates'?: boolean;
-    'linkFormat'?: string;
     'preserveEvent': boolean;
+    'productLinkFormat'?: string;
     'products'?: string[];
     'services'?: Catalog.Product[];
     'templateLinkFormat'?: string;
@@ -315,11 +315,11 @@ export namespace Components {
     'description'?: string;
     'isFeatured'?: boolean;
     'label'?: string;
-    'linkFormat'?: string;
     'logo'?: string;
     'name'?: string;
     'preserveEvent': boolean;
     'productId'?: string;
+    'productLinkFormat'?: string;
     'skeleton': boolean;
   }
   interface ManifoldSkeletonImg {}
@@ -459,19 +459,19 @@ declare namespace LocalJSX {
     * _(hidden)_ Passed by `<manifold-connection>`
     */
     'connection'?: Connection;
-    /**
-    * Link format structure, with `:resource` placeholder
-    */
-    'linkFormat'?: string;
     'onManifold-resourceList-click'?: (event: CustomEvent<any>) => void;
     /**
     * Disable auto-updates?
     */
     'paused'?: boolean;
     /**
-    * Should the JS event still fire, even if link-format is passed?
+    * Should the JS event still fire, even if product-link-format is passed?
     */
     'preserveEvent'?: boolean;
+    /**
+    * Link format structure, with `:resource` placeholder
+    */
+    'resourceLinkFormat'?: string;
   }
   interface ManifoldForwardSlot extends JSXBase.HTMLAttributes {}
   interface ManifoldIcon extends JSXBase.HTMLAttributes {
@@ -520,13 +520,13 @@ declare namespace LocalJSX {
     */
     'hideTemplates'?: boolean;
     /**
-    * Link format structure, with `:product` placeholder
-    */
-    'linkFormat'?: string;
-    /**
-    * Should the JS event still fire, even if link-format is passed?
+    * Should the JS event still fire, even if product-link-format is passed?
     */
     'preserveEvent'?: boolean;
+    /**
+    * Product link structure, with `:product` placeholder
+    */
+    'productLinkFormat'?: string;
     /**
     * Comma-separated list of shown products (labels)
     */
@@ -541,8 +541,8 @@ declare namespace LocalJSX {
     'featured'?: string[];
     'hideCategories'?: boolean;
     'hideTemplates'?: boolean;
-    'linkFormat'?: string;
     'preserveEvent'?: boolean;
+    'productLinkFormat'?: string;
     'products'?: string[];
     'services'?: Catalog.Product[];
     'templateLinkFormat'?: string;
@@ -667,12 +667,12 @@ declare namespace LocalJSX {
     'description'?: string;
     'isFeatured'?: boolean;
     'label'?: string;
-    'linkFormat'?: string;
     'logo'?: string;
     'name'?: string;
     'onManifold-marketplace-click'?: (event: CustomEvent<any>) => void;
     'preserveEvent'?: boolean;
     'productId'?: string;
+    'productLinkFormat'?: string;
     'skeleton'?: boolean;
   }
   interface ManifoldSkeletonImg extends JSXBase.HTMLAttributes {}

--- a/src/components/manifold-data-resource-list/manifold-data-resource-list.tsx
+++ b/src/components/manifold-data-resource-list/manifold-data-resource-list.tsx
@@ -26,8 +26,8 @@ export class ManifoldDataResourceList {
   /** Disable auto-updates? */
   @Prop() paused: boolean = false;
   /** Link format structure, with `:resource` placeholder */
-  @Prop() linkFormat?: string;
-  /** Should the JS event still fire, even if link-format is passed?  */
+  @Prop() resourceLinkFormat?: string;
+  /** Should the JS event still fire, even if product-link-format is passed?  */
   @Prop() preserveEvent: boolean = false;
   @State() interval?: number;
   @State() resources?: Marketplace.Resource[];
@@ -53,7 +53,7 @@ export class ManifoldDataResourceList {
   }
 
   handleClick(resource: Marketplace.Resource, e: Event) {
-    if (!this.linkFormat || this.preserveEvent) {
+    if (!this.resourceLinkFormat || this.preserveEvent) {
       e.preventDefault();
       const detail: EventDetail = {
         resourceId: resource.id,
@@ -65,8 +65,8 @@ export class ManifoldDataResourceList {
   }
 
   formatLink(resource: Marketplace.Resource) {
-    if (!this.linkFormat) return undefined;
-    return this.linkFormat.replace(/:resource/gi, resource.body.label);
+    if (!this.resourceLinkFormat) return undefined;
+    return this.resourceLinkFormat.replace(/:resource/gi, resource.body.label);
   }
 
   userResources(resources: RealResource[]) {

--- a/src/components/manifold-marketplace-grid/manifold-marketplace-grid.tsx
+++ b/src/components/manifold-marketplace-grid/manifold-marketplace-grid.tsx
@@ -23,6 +23,7 @@ export class ManifoldMarketplaceGrid {
   @Prop() preserveEvent: boolean = false;
   @Prop() products?: string[] = [];
   @Prop() services?: Catalog.Product[];
+  @Prop() templateLinkFormat?: string;
   @State() filter: string | null;
   @State() activeCategory?: string;
   @State() observer: IntersectionObserver;
@@ -207,7 +208,7 @@ export class ManifoldMarketplaceGrid {
                   <manifold-template-card
                     category={category}
                     preserveEvent={this.preserveEvent}
-                    linkFormat={this.linkFormat}
+                    templateLinkFormat={this.templateLinkFormat}
                   />
                 ),
               ])

--- a/src/components/manifold-marketplace-grid/manifold-marketplace-grid.tsx
+++ b/src/components/manifold-marketplace-grid/manifold-marketplace-grid.tsx
@@ -19,8 +19,8 @@ export class ManifoldMarketplaceGrid {
   @Prop() featured?: string[] = [];
   @Prop() hideCategories?: boolean = false;
   @Prop() hideTemplates?: boolean = false;
-  @Prop() linkFormat?: string;
   @Prop() preserveEvent: boolean = false;
+  @Prop() productLinkFormat?: string;
   @Prop() products?: string[] = [];
   @Prop() services?: Catalog.Product[];
   @Prop() templateLinkFormat?: string;
@@ -161,7 +161,7 @@ export class ManifoldMarketplaceGrid {
       description={tagline}
       isFeatured={this.featured && this.featured.includes(label)}
       label={label}
-      linkFormat={this.linkFormat}
+      productLinkFormat={this.productLinkFormat}
       logo={logo_url}
       name={name}
       preserveEvent={this.preserveEvent}

--- a/src/components/manifold-marketplace/manifold-marketplace.tsx
+++ b/src/components/manifold-marketplace/manifold-marketplace.tsx
@@ -23,6 +23,8 @@ export class ManifoldMarketplace {
   @Prop() preserveEvent: boolean = false;
   /** Comma-separated list of shown products (labels) */
   @Prop() products?: string;
+  /** Template format structure, with `:product` placeholder */
+  @Prop() templateLinkFormat?: string;
   @State() parsedExcludes: string[] = [];
   @State() parsedFeatured: string[] = [];
   @State() parsedProducts: string[] = [];
@@ -61,6 +63,7 @@ export class ManifoldMarketplace {
         preserveEvent={this.preserveEvent}
         products={this.parsedProducts}
         services={this.services}
+        templateLinkFormat={this.templateLinkFormat}
       />
     );
   }

--- a/src/components/manifold-marketplace/manifold-marketplace.tsx
+++ b/src/components/manifold-marketplace/manifold-marketplace.tsx
@@ -17,10 +17,10 @@ export class ManifoldMarketplace {
   @Prop() hideTemplates?: boolean = false;
   /** Hide categories & side menu? */
   @Prop() hideCategories?: boolean = false;
-  /** Link format structure, with `:product` placeholder */
-  @Prop() linkFormat?: string;
-  /** Should the JS event still fire, even if link-format is passed?  */
+  /** Should the JS event still fire, even if product-link-format is passed?  */
   @Prop() preserveEvent: boolean = false;
+  /** Product link structure, with `:product` placeholder */
+  @Prop() productLinkFormat?: string;
   /** Comma-separated list of shown products (labels) */
   @Prop() products?: string;
   /** Template format structure, with `:product` placeholder */
@@ -59,7 +59,7 @@ export class ManifoldMarketplace {
         featured={this.parsedFeatured}
         hideCategories={this.hideCategories}
         hideTemplates={this.hideTemplates}
-        linkFormat={this.linkFormat}
+        productLinkFormat={this.productLinkFormat}
         preserveEvent={this.preserveEvent}
         products={this.parsedProducts}
         services={this.services}

--- a/src/components/manifold-service-card/ manifold-service-card.spec.ts
+++ b/src/components/manifold-service-card/ manifold-service-card.spec.ts
@@ -27,7 +27,7 @@ describe('<manifold-service-card>', () => {
     serviceCard.logo = Product.body.logo_url;
     serviceCard.name = Product.body.name;
     serviceCard.description = Product.body.tagline;
-    serviceCard.linkFormat = '/product/:product';
+    serviceCard.productLinkFormat = '/product/:product';
 
     expect(serviceCard.href).toBe(`/product/${Product.body.label}`);
   });

--- a/src/components/manifold-service-card/ manifold-service-card.spec.ts
+++ b/src/components/manifold-service-card/ manifold-service-card.spec.ts
@@ -1,20 +1,34 @@
 import { ManifoldServiceCard } from './manifold-service-card';
 import { Product } from '../../spec/mock/catalog';
 
-it('dispatches click event', () => {
-  const serviceCard = new ManifoldServiceCard();
-  serviceCard.label = Product.body.label;
-  serviceCard.productId = Product.id;
-  serviceCard.logo = Product.body.logo_url;
-  serviceCard.name = Product.body.name;
-  serviceCard.description = Product.body.tagline;
+describe('<manifold-service-card>', () => {
+  it('dispatches click event', () => {
+    const serviceCard = new ManifoldServiceCard();
+    serviceCard.label = Product.body.label;
+    serviceCard.productId = Product.id;
+    serviceCard.logo = Product.body.logo_url;
+    serviceCard.name = Product.body.name;
+    serviceCard.description = Product.body.tagline;
 
-  const mock = { emit: jest.fn() };
-  serviceCard.marketplaceClick = mock;
+    const mock = { emit: jest.fn() };
+    serviceCard.marketplaceClick = mock;
 
-  serviceCard.onClick(new Event('click'));
-  expect(mock.emit).toHaveBeenCalledWith({
-    productId: Product.id,
-    productLabel: Product.body.label,
+    serviceCard.onClick(new Event('click'));
+    expect(mock.emit).toHaveBeenCalledWith({
+      productId: Product.id,
+      productLabel: Product.body.label,
+    });
+  });
+
+  it('formats links correctly', () => {
+    const serviceCard = new ManifoldServiceCard();
+    serviceCard.label = Product.body.label;
+    serviceCard.productId = Product.id;
+    serviceCard.logo = Product.body.logo_url;
+    serviceCard.name = Product.body.name;
+    serviceCard.description = Product.body.tagline;
+    serviceCard.linkFormat = '/product/:product';
+
+    expect(serviceCard.href).toBe(`/product/${Product.body.label}`);
   });
 });

--- a/src/components/manifold-service-card/manifold-service-card.tsx
+++ b/src/components/manifold-service-card/manifold-service-card.tsx
@@ -21,7 +21,7 @@ export class ManifoldServiceCard {
   @Prop() description?: string;
   @Prop() isFeatured?: boolean;
   @Prop() label?: string;
-  @Prop() linkFormat?: string;
+  @Prop() productLinkFormat?: string;
   @Prop() logo?: string;
   @Prop() preserveEvent: boolean = false;
   @Prop() productId?: string;
@@ -36,8 +36,8 @@ export class ManifoldServiceCard {
   }
 
   get href() {
-    if (!this.linkFormat || !this.label) return '';
-    return this.linkFormat.replace(/:product/gi, this.label);
+    if (!this.productLinkFormat || !this.label) return '';
+    return this.productLinkFormat.replace(/:product/gi, this.label);
   }
 
   async fetchIsFree(productId: string) {
@@ -50,7 +50,7 @@ export class ManifoldServiceCard {
   }
 
   onClick = (e: Event): void => {
-    if (!this.linkFormat || this.preserveEvent) {
+    if (!this.productLinkFormat || this.preserveEvent) {
       e.preventDefault();
       const detail: EventDetail = {
         productId: this.productId,

--- a/src/components/manifold-template-card.tsx/manifold-template-card.spec.ts
+++ b/src/components/manifold-template-card.tsx/manifold-template-card.spec.ts
@@ -1,0 +1,26 @@
+import { ManifoldTemplateCard } from './manifold-template-card';
+
+const category = 'authentication';
+
+describe('<manifold-template-card>', () => {
+  it('dispatches click event', () => {
+    const serviceCard = new ManifoldTemplateCard();
+    serviceCard.category = category;
+
+    const mock = { emit: jest.fn() };
+    serviceCard.templateClick = mock;
+
+    serviceCard.onClick(new Event('click'));
+    expect(mock.emit).toHaveBeenCalledWith({
+      category,
+    });
+  });
+
+  it('formats links correctly', () => {
+    const serviceCard = new ManifoldTemplateCard();
+    serviceCard.category = category;
+    serviceCard.templateLinkFormat = '/custom/product/:template';
+
+    expect(serviceCard.href).toBe(`/custom/product/${category}`);
+  });
+});

--- a/src/components/manifold-template-card.tsx/manifold-template-card.tsx
+++ b/src/components/manifold-template-card.tsx/manifold-template-card.tsx
@@ -14,16 +14,16 @@ interface EventDetail {
 export class ManifoldTemplateCard {
   @Event({ eventName: 'manifold-template-click', bubbles: true }) templateClick: EventEmitter;
   @Prop() category: string;
-  @Prop() linkFormat?: string;
+  @Prop() templateLinkFormat?: string;
   @Prop() preserveEvent: boolean = false;
 
-  get formattedLink(): string {
-    if (this.linkFormat !== 'string') return '';
-    return this.linkFormat.replace(/:product/gi, this.category);
+  get href() {
+    if (!this.templateLinkFormat || !this.category) return '';
+    return this.templateLinkFormat.replace(/:template/gi, this.category);
   }
 
   onClick = (e: Event): void => {
-    if (!this.linkFormat || this.preserveEvent) {
+    if (!this.templateLinkFormat || this.preserveEvent) {
       e.preventDefault();
       const detail: EventDetail = { category: this.category };
       this.templateClick.emit(detail);
@@ -46,7 +46,7 @@ export class ManifoldTemplateCard {
         itemscope
         itemtype="https://schema.org/Product"
         itemprop="url"
-        href={this.formattedLink}
+        href={this.href}
         onClick={this.onClick}
       >
         <h4 class="heading">

--- a/stories/manifold-data-resource-list.stories.js
+++ b/stories/manifold-data-resource-list.stories.js
@@ -6,7 +6,7 @@ storiesOf('Resource List 🔒 [Data]', module)
   .add(
     'default',
     () => `
-  <manifold-data-resource-list link-format="/resources/:resource" paused>
+  <manifold-data-resource-list resource-link-format="/resources/:resource" paused>
   <ul>
     <li><a href="/resources/db-prod">db-prod</a></li>
     <li><a href="/resources/db-stage">db-stage</a></li>

--- a/stories/manifold-marketplace.stories.js
+++ b/stories/manifold-marketplace.stories.js
@@ -3,7 +3,11 @@ import markdown from '../docs/docs/components/manifold-marketplace.md';
 
 storiesOf('Marketplace', module)
   .addParameters({ readme: { sidebar: markdown } })
-  .add('default', () => '<manifold-marketplace></manifold-marketplace>')
+  .add(
+    'default',
+    () =>
+      '<manifold-marketplace link-format="/products/:product" template-link-format="/products/custom/:template" preserve-event></manifold-marketplace>'
+  )
   .add('no templates', () => '<manifold-marketplace hide-templates></manifold-marketplace>')
   .add('compact', () => '<manifold-marketplace hide-categories></manifold-marketplace>')
   .add(

--- a/stories/manifold-marketplace.stories.js
+++ b/stories/manifold-marketplace.stories.js
@@ -6,7 +6,7 @@ storiesOf('Marketplace', module)
   .add(
     'default',
     () =>
-      '<manifold-marketplace link-format="/products/:product" template-link-format="/products/custom/:template" preserve-event></manifold-marketplace>'
+      '<manifold-marketplace product-link-format="/products/:product" template-link-format="/products/custom/:template" preserve-event></manifold-marketplace>'
   )
   .add('no templates', () => '<manifold-marketplace hide-templates></manifold-marketplace>')
   .add('compact', () => '<manifold-marketplace hide-categories></manifold-marketplace>')


### PR DESCRIPTION
## Reason for change
In the DO rush we forgot to fully implement this. Custom service templates were technically emitting events, but the link couldn’t be formatted and it was left not completely finished.

This PR adds the ability to control where the custom service templates go, as well as adds tests to ensure the links are formatted correctly and the proper events are firing.

<img width="1280" alt="Screen Shot 2019-05-28 at 15 10 07" src="https://user-images.githubusercontent.com/1369770/58512807-36a06880-815b-11e9-9b90-a96d77a52904.png">

## Testing
1. In the Gatsby docs view, look at *Marketplace*
2. Copy + paste the following in your terminal: `document.addEventListener('manifold-template-click', e => console.log(e.detail.category))`
3. Click on a service card link. It should report the category in your console.