### PR TITLE
fix: local connection is http not https

### DIFF
--- a/src/utils/connections.ts
+++ b/src/utils/connections.ts
@@ -10,10 +10,10 @@ type Connections = { [K in Env]: Connection };
 
 export const connections: Connections = {
   local: {
-    billing: 'https://api.billing.arigato.tools/v1',
-    catalog: 'https://api.catalog.arigato.tools/v1',
-    gateway: 'https://api.arigato.tools/v1',
-    marketplace: 'https://api.marketplace.arigato.tools/v1',
+    billing: 'http://api.billing.arigato.tools/v1',
+    catalog: 'http://api.catalog.arigato.tools/v1',
+    gateway: 'http://api.arigato.tools/v1',
+    marketplace: 'http://api.marketplace.arigato.tools/v1',
   },
   stage: {
     billing: 'https://api.billing.stage.manifold.co/v1',


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

When using UI locally, we do not have TLS enabled.

## Testing
<!-- For someone unfamiliar with the issue, how should this be tested? -->

Using your local Manifold server, try to use the local connection.

## Screens

### Before
<img width="1509" alt="image" src="https://user-images.githubusercontent.com/6145422/59352308-52c10f80-8cee-11e9-881f-fd3e2645a0fc.png">

### After

<img width="758" alt="image" src="https://user-images.githubusercontent.com/6145422/59352391-88fe8f00-8cee-11e9-98a2-0c503016ac67.png">

