### PR TITLE
Allow preloaded services for SSR apps

### DIFF
--- a/src/components/manifold-marketplace/manifold-marketplace.tsx
+++ b/src/components/manifold-marketplace/manifold-marketplace.tsx
@@ -25,7 +25,7 @@ export class ManifoldMarketplace {
   @Prop() products?: string;
   /** Template format structure, with `:product` placeholder */
   @Prop() templateLinkFormat?: string;
-  @Prop() preloadedServices?: Catalog.Product[] = [];
+  @Prop() preloadedServices?: Catalog.Product[];
   @State() parsedExcludes: string[] = [];
   @State() parsedFeatured: string[] = [];
   @State() parsedProducts: string[] = [];

--- a/src/components/manifold-marketplace/manifold-marketplace.tsx
+++ b/src/components/manifold-marketplace/manifold-marketplace.tsx
@@ -25,6 +25,7 @@ export class ManifoldMarketplace {
   @Prop() products?: string;
   /** Template format structure, with `:product` placeholder */
   @Prop() templateLinkFormat?: string;
+  @Prop() preloadedServices?: Catalog.Product[] = [];
   @State() parsedExcludes: string[] = [];
   @State() parsedFeatured: string[] = [];
   @State() parsedProducts: string[] = [];
@@ -36,10 +37,12 @@ export class ManifoldMarketplace {
   }
 
   fetchProducts = async () => {
-    const response = await fetch(`${this.connection.catalog}/products`, withAuth());
-    const products: Catalog.ExpandedProduct[] = await response.json();
-    // Alphabetize once, then don’t worry about it
-    this.services = [...products].sort((a, b) => a.body.name.localeCompare(b.body.name));
+    if (!this.preloadedServices) {
+      const response = await fetch(`${this.connection.catalog}/products`, withAuth());
+      const products: Catalog.ExpandedProduct[] = await response.json();
+      // Alphabetize once, then don’t worry about it
+      this.services = [...products].sort((a, b) => a.body.name.localeCompare(b.body.name));
+    }
   };
 
   private parse(list: string): string[] {
@@ -62,7 +65,7 @@ export class ManifoldMarketplace {
         productLinkFormat={this.productLinkFormat}
         preserveEvent={this.preserveEvent}
         products={this.parsedProducts}
-        services={this.services}
+        services={this.preloadedServices || this.services}
         templateLinkFormat={this.templateLinkFormat}
       />
     );


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

This allows `preloadedServices` to be attached to `manifold-marketplace`, which will prevent the fetch call. This change is intended to support the ability to SSR our web components.

## Testing

1. Publish an alpha release from this PR
2. Download the alpha to manifold-www
3. Use [this proof of concept](https://github.com/manifoldco/manifold-www/pull/534/files#diff-f091411e6abadaa4e61d67e0a25571f7) as guidance for how to render the marketplace grid.
