### PR TITLE
Make optional props optional

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -957,7 +957,10 @@
       "integrity": "sha512-mmi4h29UcJyGYF5Fx0wZoZVuTDS1x21paYFJzWbvpHKi4FrpEuqI5IkR3KRLvFgL+zb8G2O8GUX5pdXehR9EYw=="
     },
     "@manifoldco/ui": {
-      "version": "file:.."
+      "version": "file:..",
+      "requires": {
+        "@stencil/state-tunnel": "^1.0.1"
+      }
     },
     "@mikaelkristiansson/domready": {
       "version": "1.0.9",
@@ -1005,6 +1008,11 @@
       "version": "1.5.6-b",
       "resolved": "https://registry.npmjs.org/@stefanprobst/lokijs/-/lokijs-1.5.6-b.tgz",
       "integrity": "sha512-MNodHp46og+Sdde/LCxTLrxcD5Dimu21R/Fer2raXMG1XtHSV2+vZnkIV87OPAxuf2NiDj1W5hN7Q2MYUfQQ8w=="
+    },
+    "@stencil/state-tunnel": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stencil/state-tunnel/-/state-tunnel-1.0.1.tgz",
+      "integrity": "sha512-DYG8uROgL9hkjVTCtCfRBb0d3FwpiFB0muRrNZQ2X1Qo5hxMuNNji76/ILddqeq0AfgkKCW82xrMPDpy+rNIhQ=="
     },
     "@types/configstore": {
       "version": "2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1333,9 +1333,9 @@
       }
     },
     "@stencil/core": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-1.0.4.tgz",
-      "integrity": "sha512-QGwH+h4qVzQ+Y+33DFFFnGzL+CnYuDx8/e1Y0xb4d+hc5BkHmNTheXeMFz/qN6umviF/Oojspjg8RIepyvZHUw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-1.0.6.tgz",
+      "integrity": "sha512-E2AK73WqjYkGVYZ68eUPUBNU4win4GBJdLAbwn32m0XsrIZUo8CfgjWj7Eenk70oVkYDgQjyGlYbF+IPQ5S0Ag==",
       "dev": true,
       "requires": {
         "typescript": "3.5.2"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@manifoldco/eslint-plugin-stencil": "^0.2.1",
     "@manifoldco/icons": "0.0.3",
     "@reach/observe-rect": "^1.0.3",
-    "@stencil/core": "^1.0.4",
+    "@stencil/core": "^1.0.6",
     "@stencil/postcss": "^1.0.1",
     "@storybook/html": "^5.1.8",
     "@types/jest": "24.0.14",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -44,7 +44,7 @@ export namespace Components {
   interface ManifoldButtonLink {
     'color'?: 'black' | 'gray' | 'orange' | 'pink' | 'white';
     'href': string;
-    'preserveEvent': boolean;
+    'preserveEvent'?: boolean;
     'rel'?: string;
     'size'?: 'medium' | 'small';
     'stencilClickEvent'?: (e: MouseEvent) => void;
@@ -67,14 +67,14 @@ export namespace Components {
     * _(hidden)_ Passed by `<manifold-connection>`
     */
     'connection': Connection;
-    'features': Gateway.FeatureMap;
-    'planId': string;
-    'productId': string;
+    'features'?: Gateway.FeatureMap;
+    'planId'?: string;
+    'productId'?: string;
     'regionId'?: string;
     /**
     * Name of resource
     */
-    'resourceName': string;
+    'resourceName'?: string;
   }
   interface ManifoldDataProductLogo {
     /**
@@ -113,18 +113,18 @@ export namespace Components {
     * _(hidden)_ Passed by `<manifold-connection>`
     */
     'connection': Connection;
-    'features': Gateway.FeatureMap;
+    'features'?: Gateway.FeatureMap;
     /**
     * ID of input (useful for `<label>`)
     */
-    'inputId': string;
-    'ownerId': string;
-    'planId': string;
-    'productId': string;
+    'inputId'?: string;
+    'ownerId'?: string;
+    'planId'?: string;
+    'productId'?: string;
     /**
     * Product to provision (slug)
     */
-    'productLabel': string;
+    'productLabel'?: string;
     'regionId'?: string;
   }
   interface ManifoldDataResourceList {
@@ -135,11 +135,11 @@ export namespace Components {
     /**
     * Disable auto-updates?
     */
-    'paused': boolean;
+    'paused'?: boolean;
     /**
     * Should the JS event still fire, even if product-link-format is passed?
     */
-    'preserveEvent': boolean;
+    'preserveEvent'?: boolean;
     /**
     * Link format structure, with `:resource` placeholder
     */
@@ -150,7 +150,7 @@ export namespace Components {
     /**
     * a CSS variable starting with `--manifold-c-*`
     */
-    'color': string;
+    'color'?: string;
     /**
     * a CSS variable starting with `--manifold-g-*`
     */
@@ -159,15 +159,15 @@ export namespace Components {
     * The icon ID
     */
     'icon': string;
-    'marginLeft': boolean;
-    'marginRight': boolean;
+    'marginLeft'?: boolean;
+    'marginRight'?: boolean;
   }
   interface ManifoldImageGallery {
     'images'?: string[];
   }
   interface ManifoldLazyImage {
     'alt': string;
-    'itemprop': string;
+    'itemprop'?: string;
     'src': string;
   }
   interface ManifoldMarketplace {
@@ -194,7 +194,7 @@ export namespace Components {
     /**
     * Should the JS event still fire, even if product-link-format is passed?
     */
-    'preserveEvent': boolean;
+    'preserveEvent'?: boolean;
     /**
     * Product link structure, with `:product` placeholder
     */
@@ -277,7 +277,7 @@ export namespace Components {
     /**
     * _(optional)_ Hide the CTA on the left?
     */
-    'productLabel': string;
+    'productLabel'?: string;
   }
   interface ManifoldProductDetails {
     'product'?: Catalog.Product;
@@ -335,10 +335,10 @@ export namespace Components {
     'label'?: string;
     'logo'?: string;
     'name'?: string;
-    'preserveEvent': boolean;
+    'preserveEvent'?: boolean;
     'productId'?: string;
     'productLinkFormat'?: string;
-    'skeleton': boolean;
+    'skeleton'?: boolean;
   }
   interface ManifoldSkeletonImg {}
   interface ManifoldSkeletonText {}

--- a/src/components/manifold-button-link/manifold-button-link.tsx
+++ b/src/components/manifold-button-link/manifold-button-link.tsx
@@ -12,7 +12,7 @@ interface EventDetail {
 export class ManifoldButtonLink {
   @Prop() color?: 'black' | 'gray' | 'orange' | 'pink' | 'white' = 'white';
   @Prop() href: string;
-  @Prop() preserveEvent: boolean = false;
+  @Prop() preserveEvent?: boolean = false;
   @Prop() rel?: string;
   @Prop() size?: 'medium' | 'small' = 'medium';
   @Prop() target?: string;

--- a/src/components/manifold-data-manage-button/manifold-data-manage-button.tsx
+++ b/src/components/manifold-data-manage-button/manifold-data-manage-button.tsx
@@ -24,10 +24,10 @@ export class ManifoldDataManageButton {
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() connection: Connection = connections.prod;
   /** Name of resource */
-  @Prop() resourceName: string;
-  @Prop() features: Gateway.FeatureMap = {};
-  @Prop() planId: string = '';
-  @Prop({ mutable: true }) productId: string = '';
+  @Prop() resourceName?: string;
+  @Prop() features?: Gateway.FeatureMap = {};
+  @Prop() planId?: string = '';
+  @Prop({ mutable: true }) productId?: string = '';
   @Prop() regionId?: string = globalRegion.id;
   @State() resourceId: string = '';
   @Event({ eventName: 'manifold-manageButton-click', bubbles: true })
@@ -51,6 +51,11 @@ export class ManifoldDataManageButton {
   }
 
   async update() {
+    if (typeof this.features !== 'object') {
+      console.error('Property “features” is missing!');
+      return;
+    }
+
     this.clickEvent.emit({ planId: this.planId });
     const req: Gateway.ResourceUpdateRequest = { plan_id: this.planId };
 

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
@@ -31,13 +31,13 @@ export class ManifoldDataProvisionButton {
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() connection: Connection = connections.prod;
   /** Product to provision (slug) */
-  @Prop() productLabel: string;
+  @Prop() productLabel?: string;
   /** ID of input (useful for `<label>`) */
-  @Prop() inputId: string = 'manifold-provision-resource';
-  @Prop() features: Gateway.FeatureMap = {};
-  @Prop() ownerId: string = '';
-  @Prop() planId: string = '';
-  @Prop({ mutable: true }) productId: string = '';
+  @Prop() inputId?: string = 'manifold-provision-resource';
+  @Prop() features?: Gateway.FeatureMap = {};
+  @Prop() ownerId?: string = '';
+  @Prop() planId?: string = '';
+  @Prop({ mutable: true }) productId?: string = '';
   @Prop() regionId?: string = globalRegion.id;
   @State() resourceName: string = '';
   @Event({ eventName: 'manifold-provisionButton-click', bubbles: true })
@@ -52,10 +52,22 @@ export class ManifoldDataProvisionButton {
   }
 
   componentWillLoad() {
-    this.fetchProductId(this.productLabel);
+    if (this.productLabel) {
+      this.fetchProductId(this.productLabel);
+    }
   }
 
   async provision() {
+    if (typeof this.features !== 'object') {
+      console.error('Property “features” is missing');
+      return;
+    }
+
+    if (!this.ownerId) {
+      console.error('Property “ownerId” is missing');
+      return;
+    }
+
     // We use Gateway b/c it’s much easier to provision w/o generating a base32 ID
     this.clickEvent.emit({ resourceName: this.resourceName });
 

--- a/src/components/manifold-data-resource-list/manifold-data-resource-list.tsx
+++ b/src/components/manifold-data-resource-list/manifold-data-resource-list.tsx
@@ -25,11 +25,11 @@ export class ManifoldDataResourceList {
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() connection: Connection = connections.prod; // Provided by manifold-connection
   /** Disable auto-updates? */
-  @Prop() paused: boolean = false;
+  @Prop() paused?: boolean = false;
   /** Link format structure, with `:resource` placeholder */
   @Prop() resourceLinkFormat?: string;
   /** Should the JS event still fire, even if product-link-format is passed?  */
-  @Prop() preserveEvent: boolean = false;
+  @Prop() preserveEvent?: boolean = false;
   @State() interval?: number;
   @State() resources?: Marketplace.Resource[];
   @Event({ eventName: 'manifold-resourceList-click', bubbles: true }) clickEvent: EventEmitter;

--- a/src/components/manifold-icon/manifold-icon.tsx
+++ b/src/components/manifold-icon/manifold-icon.tsx
@@ -6,14 +6,14 @@ import { h, Component, Element, Prop } from '@stencil/core';
   shadow: true,
 })
 export class ManifoldIcon {
-  @Prop() marginRight: boolean = false;
-  @Prop() marginLeft: boolean = false;
+  @Prop() marginRight?: boolean = false;
+  @Prop() marginLeft?: boolean = false;
   /** The icon ID */
   @Prop() icon: string;
   /** a CSS variable starting with `--manifold-g-*` */
   @Prop() gradient?: string;
   /** a CSS variable starting with `--manifold-c-*` */
-  @Prop() color: string = 'currentColor';
+  @Prop() color?: string = 'currentColor';
   @Element() element: HTMLElement;
 
   get gradientID() {
@@ -63,7 +63,7 @@ export class ManifoldIcon {
         ) : (
           <path
             d={this.icon}
-            fill={this.color.startsWith('--') ? `var(${this.color})` : this.color}
+            fill={this.color && this.color.startsWith('--') ? `var(${this.color})` : this.color}
           />
         )}
       </svg>

--- a/src/components/manifold-lazy-image/manifold-lazy-image.tsx
+++ b/src/components/manifold-lazy-image/manifold-lazy-image.tsx
@@ -3,7 +3,7 @@ import { h, Component, Prop, State } from '@stencil/core';
 @Component({ tag: 'manifold-lazy-image' })
 export class ManifoldLazyImage {
   @Prop() src: string;
-  @Prop() itemprop: string;
+  @Prop() itemprop?: string;
   @Prop() alt: string;
   @State() observer: IntersectionObserver;
 

--- a/src/components/manifold-marketplace/manifold-marketplace.tsx
+++ b/src/components/manifold-marketplace/manifold-marketplace.tsx
@@ -18,7 +18,7 @@ export class ManifoldMarketplace {
   /** Hide categories & side menu? */
   @Prop() hideCategories?: boolean = false;
   /** Should the JS event still fire, even if product-link-format is passed?  */
-  @Prop() preserveEvent: boolean = false;
+  @Prop() preserveEvent?: boolean = false;
   /** Product link structure, with `:product` placeholder */
   @Prop() productLinkFormat?: string;
   /** Comma-separated list of shown products (labels) */

--- a/src/components/manifold-product/manifold-product.tsx
+++ b/src/components/manifold-product/manifold-product.tsx
@@ -10,7 +10,7 @@ export class ManifoldProduct {
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() connection: Connection = connections.prod;
   /** _(optional)_ Hide the CTA on the left? */
-  @Prop() productLabel: string;
+  @Prop() productLabel?: string;
   @State() product?: Catalog.Product;
   @State() provider?: Catalog.Provider;
   @Watch('productLabel') productChange(newLabel: string) {
@@ -18,7 +18,9 @@ export class ManifoldProduct {
   }
 
   componentWillLoad() {
-    this.fetchProduct(this.productLabel);
+    if (this.productLabel) {
+      this.fetchProduct(this.productLabel);
+    }
   }
 
   fetchProduct = async (productLabel: string) => {

--- a/src/components/manifold-service-card/manifold-service-card.tsx
+++ b/src/components/manifold-service-card/manifold-service-card.tsx
@@ -23,9 +23,9 @@ export class ManifoldServiceCard {
   @Prop() label?: string;
   @Prop() productLinkFormat?: string;
   @Prop() logo?: string;
-  @Prop() preserveEvent: boolean = false;
+  @Prop() preserveEvent?: boolean = false;
   @Prop() productId?: string;
-  @Prop() skeleton: boolean = false;
+  @Prop() skeleton?: boolean = false;
   @State() isFree: boolean = false;
   @Event({ eventName: 'manifold-marketplace-click', bubbles: true }) marketplaceClick: EventEmitter;
   @Watch('skeleton') skeletonChange(skeleton: boolean) {


### PR DESCRIPTION
## Reason for change
This is 1/2 of a TypeScript issue with UI. Even if you specify a prop like so: `@Prop() color = 'gray'`, TypeScript will still require you to specify that prop within React: `<my-element color="gray">`. This isn’t ideal; optional properties should be better enforced.

<img width="765" alt="Screen Shot 2019-06-19 at 08 32 57" src="https://user-images.githubusercontent.com/1369770/59776203-9d530680-926f-11e9-8771-56aee4dba413.png">
☝️ `preserve-event` should be optional (it’s calling it `preserveEvent`, which is actually the other half of this problem, but the required part is the problem here).

This PR focuses on the entry-level component properties and tries to make as many things optional as possible.

## Testing
Docs & Storybook should still build & work