### PR TITLE
Moved tag styles to manifold-badge. Added free style support.

### DIFF
--- a/src/components/manifold-badge/mf-badge.css
+++ b/src/components/manifold-badge/mf-badge.css
@@ -11,9 +11,6 @@
 
   display: inline-flex;
   align-items: center;
-  margin-top: 0.125rem;
-  margin-bottom: 0.125rem; /* top & bottom help when tags stack */
-  margin-left: 0.5em;
   padding: var(--padding);
   color: var(--text-color);
   font-weight: var(--font-weight);

--- a/src/components/manifold-badge/mf-badge.css
+++ b/src/components/manifold-badge/mf-badge.css
@@ -3,13 +3,17 @@
   --text-color: var(--manifold-tag-text-color, var(--manifold-text-color-accent));
   --font-family: var(--manifold-tag-font-family, var(--manifold-font-family));
   --font-weight: var(--manifold-tag-font-weight, 700);
-  --font-size: var(--manifold-tag-font-size, var(--manifold-font-d2));
+  --font-size: var(--manifold-tag-font-size, var(--manifold-font-d3));
   --text-transform: var(--manifold-tag-text-transform, initial);
-  --background: var(--manifold-color-primary);
+  --background: var(--manifold-tag-free-background, var(--manifold-color-primary));
+  --free-background: var(--manifold-tag-free-background, var(--manifold-color-primary));
   --radius: var(--manifold-tag-radius, 3em);
 
   display: inline-flex;
   align-items: center;
+  margin-top: 0.125rem;
+  margin-bottom: 0.125rem; /* top & bottom help when tags stack */
+  margin-left: 0.5em;
   padding: var(--padding);
   color: var(--text-color);
   font-weight: var(--font-weight);
@@ -19,5 +23,7 @@
   background: var(--background);
   border-radius: var(--radius);
 
-  /* TODO: move .tag styles from service-card to here and unify naming */
+  &[data-tag='free'] {
+    background: var(--free-background);
+  }
 }

--- a/src/components/manifold-badge/mf-badge.css
+++ b/src/components/manifold-badge/mf-badge.css
@@ -5,7 +5,7 @@
   --font-weight: var(--manifold-tag-font-weight, 700);
   --font-size: var(--manifold-tag-font-size, var(--manifold-font-d3));
   --text-transform: var(--manifold-tag-text-transform, initial);
-  --background: var(--manifold-tag-free-background, var(--manifold-color-primary));
+  --background: var(--manifold-color-primary);
   --free-background: var(--manifold-tag-free-background, var(--manifold-color-primary));
   --radius: var(--manifold-tag-radius, 3em);
 

--- a/src/components/manifold-badge/mf-badge.css
+++ b/src/components/manifold-badge/mf-badge.css
@@ -5,8 +5,8 @@
   --font-weight: var(--manifold-tag-font-weight, 700);
   --font-size: var(--manifold-tag-font-size, var(--manifold-font-d3));
   --text-transform: var(--manifold-tag-text-transform, initial);
-  --background: var(--manifold-color-primary);
-  --free-background: var(--manifold-tag-free-background, var(--manifold-color-primary));
+  --background: var(--manifold-tag-background, var(--manifold-color-primary));
+  --free-background: var(--manifold-tag-free-background, var(--background));
   --radius: var(--manifold-tag-radius, 3em);
 
   display: inline-flex;
@@ -22,8 +22,8 @@
   text-transform: var(--text-transform);
   background: var(--background);
   border-radius: var(--radius);
+}
 
-  &[data-tag='free'] {
-    background: var(--free-background);
-  }
+:host([data-tag='free']) {
+  background: var(--free-background);
 }

--- a/src/components/manifold-cost-display/manifold-cost-display.e2e.ts
+++ b/src/components/manifold-cost-display/manifold-cost-display.e2e.ts
@@ -30,7 +30,7 @@ describe('<manifold-plan-cost>', () => {
     await page.waitForChanges();
     const el = await page.find('manifold-cost-display >>> [itemprop="price"]');
     expect(el).toEqualHtml(
-      '<span itemprop="price"><manifold-badge class="hydrated">Free</manifold-badge></span>'
+      '<span itemprop="price"><manifold-badge class="hydrated" data-tag="free">Free</manifold-badge></span>'
     );
   });
 

--- a/src/components/manifold-cost-display/manifold-cost-display.tsx
+++ b/src/components/manifold-cost-display/manifold-cost-display.tsx
@@ -22,7 +22,7 @@ export class ManifoldCostDisplay {
 
     if (this.isFreeMonthly) {
       // Show the badge for compact, large text otherwise
-      return this.compact ? <manifold-badge>Free</manifold-badge> : 'Free';
+      return this.compact ? <manifold-badge data-tag="free">Free</manifold-badge> : 'Free';
     }
     // $5 / mo
     return this.compact ? $(this.baseCost) : [$(this.baseCost), <small>&nbsp;/&nbsp;mo</small>];

--- a/src/components/manifold-service-card/manifold-service-card.css
+++ b/src/components/manifold-service-card/manifold-service-card.css
@@ -25,16 +25,6 @@
   --card-heading-font-family: var(--manifold-font-family-heading);
   --card-heading-font-weight: var(--manifold-font-weight-heading);
   --card-heading-text-color: var(--manifold-text-color-heading);
-
-  /* tag */
-  --tag-padding: var(--manifold-tag-padding, 0.25em 1em);
-  --tag-text-color: var(--manifold-tag-text-color, var(--manifold-text-color-accent));
-  --tag-font-family: var(--manifold-tag-font-family, var(--manifold-font-family));
-  --tag-font-weight: var(--manifold-tag-font-weight, 700);
-  --tag-font-size: var(--manifold-tag-font-size, var(--manifold-font-d3));
-  --tag-text-transform: var(--manifold-tag-text-transform, initial);
-  --tag-background: var(--manifold-color-primary);
-  --tag-radius: var(--manifold-tag-radius, 3em);
 }
 
 .wrapper {
@@ -154,27 +144,6 @@
 
   @media (--viewport-l) {
     padding-left: 0;
-  }
-}
-
-.tag {
-  display: inline-flex;
-  align-items: center;
-  margin-top: 0.125rem;
-  margin-bottom: 0.125rem; /* top & bottom help when tags stack */
-  margin-left: 0.5em;
-  padding: var(--tag-padding);
-  color: var(--tag-text-color);
-  font-weight: var(--tag-font-weight);
-  font-size: var(--tag-font-size);
-  font-family: var(--tag-font-family);
-  line-height: 1.5;
-  text-transform: var(--tag-text-transform);
-  background: var(--tag-background);
-  border-radius: var(--tag-radius);
-
-  &[data-tag='free'] {
-    background: var(--manifold-tag-free-background, var(--manifold-color-primary));
   }
 }
 

--- a/src/components/manifold-service-card/manifold-service-card.css
+++ b/src/components/manifold-service-card/manifold-service-card.css
@@ -157,3 +157,9 @@
   margin-right: -0.125rem;
   margin-bottom: -0.125rem; /* offset stacking margin from .tag */
 }
+
+manifold-badge {
+  margin-top: 0.125rem;
+  margin-bottom: 0.125rem; /* top & bottom help when tags stack */
+  margin-left: 0.5em;
+}

--- a/src/components/manifold-service-card/manifold-service-card.e2e.ts
+++ b/src/components/manifold-service-card/manifold-service-card.e2e.ts
@@ -32,13 +32,13 @@ describe('<manifold-service-card>', () => {
 
   it('displays a featured tag if featured', async () => {
     const page = await newE2EPage({ html: `<manifold-service-card is-featured />` });
-    const el = await page.find('manifold-service-card >>> .tag');
+    const el = await page.find('manifold-service-card >>> manifold-badge');
     expect(el.innerText).toBe('featured');
   });
 
   it('doesn’t display “free” tag by default (when not featured)', async () => {
     const page = await newE2EPage({ html: `<manifold-service-card />` });
-    const el = await page.find('manifold-service-card >>> .tag');
+    const el = await page.find('manifold-service-card >>> manifold-badge');
     expect(el).toBeNull();
   });
 });

--- a/src/components/manifold-service-card/manifold-service-card.tsx
+++ b/src/components/manifold-service-card/manifold-service-card.tsx
@@ -83,12 +83,8 @@ export class ManifoldServiceCard {
           </p>
         </div>
         <div class="tags">
-          {this.isFeatured && <div class="tag">featured</div>}
-          {this.isFree && (
-            <div class="tag" data-tag="free">
-              Free
-            </div>
-          )}
+          {this.isFeatured && <manifold-badge>featured</manifold-badge>}
+          {this.isFree && <manifold-badge data-tag="free">Free</manifold-badge>}
         </div>
       </a>
     ) : (

--- a/stories/manifold-badge.stories.js
+++ b/stories/manifold-badge.stories.js
@@ -1,0 +1,19 @@
+import { storiesOf } from '@storybook/html';
+
+const renderBadge = (text = 'Normal', tag) =>
+  `
+    <style>
+      :root {
+        --manifold-tag-radius: 1em;
+        --manifold-tag-free-background: var(--manifold-g-green);
+        --manifold-tag-text-transform: uppercase;
+      }
+    </style>
+    <div>
+      <manifold-badge ${tag && `data-tag="${tag}"`}>${text}</manifold-badge>
+    </div>
+  `;
+
+storiesOf('Badge', module)
+  .add('default', () => renderBadge())
+  .add('free', () => renderBadge('Free', 'free'));


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change
Plan selector didn't support free badge styles.

## Testing
Check the plan selector and the service card.