### PR TITLE
Add a plan display component that can be used independently

### DIFF
--- a/docs/docs/components/manifold-plan.md
+++ b/docs/docs/components/manifold-plan.md
@@ -1,0 +1,18 @@
+---
+title: Plan
+path: /components/plan
+example: |
+  <manifold-plan product-label="jawsdb-mysql" plan-label="kitefin" />
+---
+
+# Product
+
+Display the details for an individual plan.
+
+```html
+<manifold-plan product-label="jawsdb-mysql" plan-label="kitefin" />
+```
+
+## Product Label
+
+You can find the `:product` label for each at `https://manifold.co/services/:product`.

--- a/docs/docs/components/manifold-product.md
+++ b/docs/docs/components/manifold-product.md
@@ -23,14 +23,14 @@ You can find the `:product` label for each at `https://manifold.co/services/:pro
 
 ## CTA
 
-You can pass in your own button or link in the bottom-right of the component
+You can pass in your own button or link in left sidebar of the component
 by passing in any element with `slot="cta"` as an attribute. [Read more about
 slots][slot].
 
 ```html
-<manifold-plan-selector product-label="jawsdb-mysql">
+<manifold-product product-label="jawsdb-mysql">
   <a href="/services/jawsdb-mysql" slot="cta">Get JawsDB MySQL</a>
-</manifold-plan-selector>
+</manifold-product>
 ```
 
 [slot]: https://stenciljs.com/docs/templating-jsx/

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -230,6 +230,20 @@ export namespace Components {
     'suffix': string;
     'value': number;
   }
+  interface ManifoldPlan {
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'connection': Connection;
+    /**
+    * URL-friendly slug (e.g. `"kitefin"`)
+    */
+    'planLabel'?: string;
+    /**
+    * URL-friendly slug (e.g. `"jawsdb-mysql"`)
+    */
+    'productLabel'?: string;
+  }
   interface ManifoldPlanCost {
     'allFeatures': Catalog.ExpandedFeature[];
     'compact'?: boolean;
@@ -484,6 +498,12 @@ declare global {
     new (): HTMLManifoldNumberInputElement;
   };
 
+  interface HTMLManifoldPlanElement extends Components.ManifoldPlan, HTMLStencilElement {}
+  var HTMLManifoldPlanElement: {
+    prototype: HTMLManifoldPlanElement;
+    new (): HTMLManifoldPlanElement;
+  };
+
   interface HTMLManifoldPlanCostElement extends Components.ManifoldPlanCost, HTMLStencilElement {}
   var HTMLManifoldPlanCostElement: {
     prototype: HTMLManifoldPlanCostElement;
@@ -640,6 +660,7 @@ declare global {
     'manifold-marketplace': HTMLManifoldMarketplaceElement;
     'manifold-marketplace-grid': HTMLManifoldMarketplaceGridElement;
     'manifold-number-input': HTMLManifoldNumberInputElement;
+    'manifold-plan': HTMLManifoldPlanElement;
     'manifold-plan-cost': HTMLManifoldPlanCostElement;
     'manifold-plan-details': HTMLManifoldPlanDetailsElement;
     'manifold-plan-menu': HTMLManifoldPlanMenuElement;
@@ -882,6 +903,20 @@ declare namespace LocalJSX {
     'suffix'?: string;
     'value'?: number;
   }
+  interface ManifoldPlan extends JSXBase.HTMLAttributes<HTMLManifoldPlanElement> {
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'connection'?: Connection;
+    /**
+    * URL-friendly slug (e.g. `"kitefin"`)
+    */
+    'planLabel'?: string;
+    /**
+    * URL-friendly slug (e.g. `"jawsdb-mysql"`)
+    */
+    'productLabel'?: string;
+  }
   interface ManifoldPlanCost extends JSXBase.HTMLAttributes<HTMLManifoldPlanCostElement> {
     'allFeatures'?: Catalog.ExpandedFeature[];
     'compact'?: boolean;
@@ -1051,6 +1086,7 @@ declare namespace LocalJSX {
     'manifold-marketplace': ManifoldMarketplace;
     'manifold-marketplace-grid': ManifoldMarketplaceGrid;
     'manifold-number-input': ManifoldNumberInput;
+    'manifold-plan': ManifoldPlan;
     'manifold-plan-cost': ManifoldPlanCost;
     'manifold-plan-details': ManifoldPlanDetails;
     'manifold-plan-menu': ManifoldPlanMenu;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -269,7 +269,7 @@ export namespace Components {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'connection': Connection;
+    'connection'?: Connection;
     /**
     * URL-friendly slug (e.g. `"jawsdb-mysql"`)
     */

--- a/src/components/manifold-plan/manifold-plan.spec.ts
+++ b/src/components/manifold-plan/manifold-plan.spec.ts
@@ -1,0 +1,39 @@
+import { ManifoldPlan } from './manifold-plan';
+
+describe('<manifold-plan>', () => {
+  it('fetches product and plan by label on load, if given', () => {
+    const productLabel = 'test-label';
+    const planLabel = 'test-plan-label';
+
+    const planSelector = new ManifoldPlan();
+    planSelector.fetchProductAndPlan = jest.fn();
+    planSelector.productLabel = productLabel;
+    planSelector.planLabel = planLabel;
+    planSelector.componentWillLoad();
+    expect(planSelector.fetchProductAndPlan).toHaveBeenCalledWith(productLabel, planLabel);
+  });
+
+  it('refetches product and plan on product label change, if given', () => {
+    const newProduct = 'new-product';
+    const planLabel = 'test-plan-label';
+
+    const planSelector = new ManifoldPlan();
+    planSelector.fetchProductAndPlan = jest.fn();
+    planSelector.productLabel = 'old-product';
+    planSelector.planLabel = planLabel;
+    planSelector.productChange(newProduct);
+    expect(planSelector.fetchProductAndPlan).toHaveBeenCalledWith(newProduct, planLabel);
+  });
+
+  it('refetches product and plan on plan label change, if given', () => {
+    const productLabel = 'test-label';
+    const newPlan = 'new-plan';
+
+    const planSelector = new ManifoldPlan();
+    planSelector.fetchProductAndPlan = jest.fn();
+    planSelector.productLabel = productLabel;
+    planSelector.planLabel = 'old-plan';
+    planSelector.planChange(newPlan);
+    expect(planSelector.fetchProductAndPlan).toHaveBeenCalledWith(productLabel, newPlan);
+  });
+});

--- a/src/components/manifold-plan/manifold-plan.tsx
+++ b/src/components/manifold-plan/manifold-plan.tsx
@@ -1,0 +1,64 @@
+import { h, Component, State, Prop, Element, Watch } from '@stencil/core';
+import { Catalog } from '../../types/catalog';
+import Tunnel from '../../data/connection';
+import { withAuth } from '../../utils/auth';
+import { Connection, connections } from '../../utils/connections';
+
+@Component({ tag: 'manifold-plan' })
+export class ManifoldPlan {
+  @Element() el: HTMLElement;
+  /** _(hidden)_ Passed by `<manifold-connection>` */
+  @Prop() connection: Connection = connections.prod;
+  /** URL-friendly slug (e.g. `"jawsdb-mysql"`) */
+  @Prop() productLabel?: string;
+  /** URL-friendly slug (e.g. `"kitefin"`) */
+  @Prop() planLabel?: string;
+  @State() product?: Catalog.Product;
+  @State() plan?: Catalog.Plan;
+  @Watch('productLabel') productChange(newProduct: string) {
+    this.fetchProductAndPlan(newProduct, this.planLabel);
+  }
+  @Watch('planLabel') planChange(newPlan: string) {
+    this.fetchProductAndPlan(this.productLabel, newPlan);
+  }
+
+  componentWillLoad() {
+    this.fetchProductAndPlan(this.productLabel, this.planLabel);
+  }
+
+  async fetchProductAndPlan(productLabel?: string, planLabel?: string) {
+    if (!productLabel || !planLabel) {
+      return;
+    }
+
+    this.product = undefined;
+    const { catalog } = this.connection;
+
+    const productsResp = await fetch(`${catalog}/products/?label=${productLabel}`, withAuth());
+    const products: Catalog.ExpandedProduct[] = await productsResp.json();
+
+    this.product = products[0]; // eslint-disable-line prefer-destructuring
+    this.fetchPlan(products[0].id, planLabel);
+  }
+
+  async fetchPlan(productId: string, planLabel: string) {
+    this.plan = undefined;
+    const { catalog } = this.connection;
+
+    const plansResp = await fetch(`${catalog}/plans/?product_id=${productId}&label=${planLabel}`, withAuth());
+    const plans: Catalog.ExpandedPlan[] = await plansResp.json();
+
+    this.plan = plans[0]; // eslint-disable-line prefer-destructuring
+  }
+
+  render() {
+    return (
+      <manifold-plan-details
+        plan={this.plan}
+        product={this.product}
+      />
+    );
+  }
+}
+
+Tunnel.injectProps(ManifoldPlan, ['connection']);

--- a/stories/manifold-plan.stories.js
+++ b/stories/manifold-plan.stories.js
@@ -1,0 +1,17 @@
+import { storiesOf } from '@storybook/html';
+import markdown from '../docs/docs/components/manifold-plan.md';
+
+storiesOf('Plan', module)
+  .addParameters({ readme: { sidebar: markdown } })
+  .add(
+    'ElegantCMS Free',
+    () => '<manifold-plan product-label="elegant-cms" plan-label="manifold-developer"></manifold-plan>'
+  )
+  .add(
+    'JawsDB Kitefin',
+    () => '<manifold-plan product-label="jawsdb-mysql" plan-label="kitefin"></manifold-plan>'
+  )
+  .add(
+    'JawsDB Custom',
+    () => '<manifold-plan product-label="jawsdb-mysql" plan-label="custom"></manifold-plan>'
+  );


### PR DESCRIPTION
This component can be used by platforms to display a plan's information if require. This can power resource details page or custom product display pages.
