### PR TITLE
Add a `has-resource` component to display html conditionally

### DIFF
--- a/docs/docs/data/manifold-data-has-resources.md
+++ b/docs/docs/data/manifold-data-has-resources.md
@@ -1,0 +1,49 @@
+---
+title: 🔒 Has Resources
+path: /data/has-resource
+example: |
+  <manifold-data-has-resource paused="">
+    <span slot="no-resource">No resources</span>
+    <span slot="has-resource">Has resources</span>
+  </manifold-data-has-resource>
+---
+
+# Has Resources
+
+Unstyled conditional component that will render a specific slot depending on whether or not the user
+has any resources in their profile.
+
+## Pausing updates
+
+By default, this component will subscribe to updates from the server. To
+disable that, pass the `paused` attribute:
+
+```html
+<manifold-data-has-resource paused />
+```
+
+## Has one or more resources
+
+You can pass in your own content to render if the user has one or more resources
+by passing in any element with `slot="has-resource"` as an attribute. [Read more about
+slots][slot].
+
+```html
+<manifold-data-has-resource>
+  <span slot="has-resource">Has resources</span>
+</manifold-data-has-resource>
+```
+
+## Has no resources
+
+You can pass in your own content to render if the user has no resources
+by passing in any element with `slot="no-resource"` as an attribute. [Read more about
+slots][slot].
+
+```html
+<manifold-data-has-resource>
+  <span slot="no-resource">No resources</span>
+</manifold-data-has-resource>
+```
+
+[slot]: https://stenciljs.com/docs/templating-jsx/

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -69,6 +69,20 @@ export namespace Components {
     'isCustomizable'?: boolean;
     'measuredFeatures': Catalog.ExpandedFeature[];
   }
+  interface ManifoldDataHasResource {
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'authToken'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'connection'?: Connection;
+    /**
+    * Disable auto-updates?
+    */
+    'paused'?: boolean;
+  }
   interface ManifoldDataManageButton {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
@@ -547,6 +561,12 @@ declare global {
     new (): HTMLManifoldCostDisplayElement;
   };
 
+  interface HTMLManifoldDataHasResourceElement extends Components.ManifoldDataHasResource, HTMLStencilElement {}
+  var HTMLManifoldDataHasResourceElement: {
+    prototype: HTMLManifoldDataHasResourceElement;
+    new (): HTMLManifoldDataHasResourceElement;
+  };
+
   interface HTMLManifoldDataManageButtonElement extends Components.ManifoldDataManageButton, HTMLStencilElement {}
   var HTMLManifoldDataManageButtonElement: {
     prototype: HTMLManifoldDataManageButtonElement;
@@ -788,6 +808,7 @@ declare global {
     'manifold-button-link': HTMLManifoldButtonLinkElement;
     'manifold-connection': HTMLManifoldConnectionElement;
     'manifold-cost-display': HTMLManifoldCostDisplayElement;
+    'manifold-data-has-resource': HTMLManifoldDataHasResourceElement;
     'manifold-data-manage-button': HTMLManifoldDataManageButtonElement;
     'manifold-data-product-logo': HTMLManifoldDataProductLogoElement;
     'manifold-data-product-name': HTMLManifoldDataProductNameElement;
@@ -875,6 +896,20 @@ declare namespace LocalJSX {
     'compact'?: boolean;
     'isCustomizable'?: boolean;
     'measuredFeatures'?: Catalog.ExpandedFeature[];
+  }
+  interface ManifoldDataHasResource extends JSXBase.HTMLAttributes<HTMLManifoldDataHasResourceElement> {
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'authToken'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'connection'?: Connection;
+    /**
+    * Disable auto-updates?
+    */
+    'paused'?: boolean;
   }
   interface ManifoldDataManageButton extends JSXBase.HTMLAttributes<HTMLManifoldDataManageButtonElement> {
     /**
@@ -1334,6 +1369,7 @@ declare namespace LocalJSX {
     'manifold-button-link': ManifoldButtonLink;
     'manifold-connection': ManifoldConnection;
     'manifold-cost-display': ManifoldCostDisplay;
+    'manifold-data-has-resource': ManifoldDataHasResource;
     'manifold-data-manage-button': ManifoldDataManageButton;
     'manifold-data-product-logo': ManifoldDataProductLogo;
     'manifold-data-product-name': ManifoldDataProductName;

--- a/src/components/manifold-data-has-resource/manifold-data-has-resource.spec.ts
+++ b/src/components/manifold-data-has-resource/manifold-data-has-resource.spec.ts
@@ -20,17 +20,15 @@ describe('<manifold-resource-list>', () => {
       components: [ManifoldDataHasResource],
       html: `
         <manifold-data-has-resource paused="">
-          <div itemprop="has-resource" slot="has-resources"></div>
-          <div itemprop="no-resource" slot="no-resources"></div>
+          <div itemprop="has-resource" slot="has-resource"></div>
+          <div itemprop="no-resource" slot="no-resource"></div>
         </manifold-data-has-resource>`,
     });
 
     // @ts-ignore
-    expect(hasResource.root.querySelector('[itemprop="has-resource"]')).toBeDefined();
-    // @ts-ignore
-    expect(hasResource.root.querySelector('[itemprop="no-resource"]')).not.toBeDefined();
-
-    fetchMock.restore();
+    expect(hasResource.root.shadowRoot).toEqualHtml(
+      `<slot name="has-resource"></slot>`
+    );
   });
 
   it('Displays the right slot if user has no resources', async () => {
@@ -40,16 +38,14 @@ describe('<manifold-resource-list>', () => {
       components: [ManifoldDataHasResource],
       html: `
         <manifold-data-has-resource paused="">
-          <div itemprop="no-resource" slot="no-resources"></div>
-          <div itemprop="has-resource" slot="has-resources"></div>
+          <div itemprop="has-resource" slot="has-resource"></div>
+          <div itemprop="no-resource" slot="no-resource"></div>
         </manifold-data-has-resource>`,
     });
 
     // @ts-ignore
-    expect(hasResource.root.querySelector('[itemprop="no-resource"]')).toBeDefined();
-    // @ts-ignore
-    expect(hasResource.root.querySelector('[itemprop="has-resource"]')).not.toBeDefined();
-
-    fetchMock.restore();
+    expect(hasResource.root.shadowRoot).toEqualHtml(
+      `<slot name="no-resource"></slot>`
+    );
   });
 });

--- a/src/components/manifold-data-has-resource/manifold-data-has-resource.spec.ts
+++ b/src/components/manifold-data-has-resource/manifold-data-has-resource.spec.ts
@@ -1,0 +1,51 @@
+import { newSpecPage } from '@stencil/core/testing';
+import fetchMock from 'fetch-mock';
+
+import { ManifoldDataHasResource } from './manifold-data-has-resource';
+import { Marketplace } from '../../types/marketplace';
+import { Resource } from '../../spec/mock/marketplace';
+import { connections } from '../../utils/connections';
+
+const resources: Marketplace.Resource[] = [Resource];
+
+describe('<manifold-resource-list>', () => {
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
+  it('Displays the right slot if user has resources', async () => {
+    fetchMock.mock(`${connections.prod.marketplace}/resources/?me`, resources);
+
+    const hasResource = await newSpecPage({
+      components: [ManifoldDataHasResource],
+      html: `
+        <manifold-data-has-resource>
+          <div itemprop="has-resource" slot="has-resources"></div>
+          <div itemprop="no-resource" slot="no-resources"></div>
+        </manifold-data-has-resource>`,
+    });
+
+    // @ts-ignore
+    expect(hasResource.root.querySelector('[itemprop="has-resource"]')).toBeDefined();
+
+    fetchMock.restore();
+  });
+
+  it('Displays the right slot if user has no resources', async () => {
+    fetchMock.mock(`${connections.prod.marketplace}/resources/?me`, []);
+
+    const hasResource = await newSpecPage({
+      components: [ManifoldDataHasResource],
+      html: `
+        <manifold-data-has-resource>
+          <div itemprop="no-resource" slot="no-resources"></div>
+          <div itemprop="has-resource" slot="has-resources"></div>
+        </manifold-data-has-resource>`,
+    });
+
+    // @ts-ignore
+    expect(hasResource.root.querySelector('[itemprop="no-resource"]')).toBeDefined();
+
+    fetchMock.restore();
+  });
+});

--- a/src/components/manifold-data-has-resource/manifold-data-has-resource.spec.ts
+++ b/src/components/manifold-data-has-resource/manifold-data-has-resource.spec.ts
@@ -19,7 +19,7 @@ describe('<manifold-resource-list>', () => {
     const hasResource = await newSpecPage({
       components: [ManifoldDataHasResource],
       html: `
-        <manifold-data-has-resource>
+        <manifold-data-has-resource paused="">
           <div itemprop="has-resource" slot="has-resources"></div>
           <div itemprop="no-resource" slot="no-resources"></div>
         </manifold-data-has-resource>`,
@@ -37,7 +37,7 @@ describe('<manifold-resource-list>', () => {
     const hasResource = await newSpecPage({
       components: [ManifoldDataHasResource],
       html: `
-        <manifold-data-has-resource>
+        <manifold-data-has-resource paused="">
           <div itemprop="no-resource" slot="no-resources"></div>
           <div itemprop="has-resource" slot="has-resources"></div>
         </manifold-data-has-resource>`,

--- a/src/components/manifold-data-has-resource/manifold-data-has-resource.spec.ts
+++ b/src/components/manifold-data-has-resource/manifold-data-has-resource.spec.ts
@@ -27,6 +27,8 @@ describe('<manifold-resource-list>', () => {
 
     // @ts-ignore
     expect(hasResource.root.querySelector('[itemprop="has-resource"]')).toBeDefined();
+    // @ts-ignore
+    expect(hasResource.root.querySelector('[itemprop="no-resource"]')).not.toBeDefined();
 
     fetchMock.restore();
   });
@@ -45,6 +47,8 @@ describe('<manifold-resource-list>', () => {
 
     // @ts-ignore
     expect(hasResource.root.querySelector('[itemprop="no-resource"]')).toBeDefined();
+    // @ts-ignore
+    expect(hasResource.root.querySelector('[itemprop="has-resource"]')).not.toBeDefined();
 
     fetchMock.restore();
   });

--- a/src/components/manifold-data-has-resource/manifold-data-has-resource.tsx
+++ b/src/components/manifold-data-has-resource/manifold-data-has-resource.tsx
@@ -21,14 +21,14 @@ export class ManifoldDataHasResource {
     if (newPaused) {
       window.clearInterval(this.interval);
     } else {
-      this.interval = window.setInterval(() => this.fetchResources(), 3000);
+      this.makeInterval();
     }
   }
 
   componentWillLoad() {
     this.fetchResources();
     if (!this.paused) {
-      this.interval = window.setInterval(() => this.fetchResources(), 3000);
+      this.makeInterval();
     }
   }
 
@@ -36,6 +36,10 @@ export class ManifoldDataHasResource {
     if (this.interval) {
       window.clearInterval(this.interval);
     }
+  }
+
+  makeInterval() {
+    this.interval = window.setInterval(() => this.fetchResources(), 3000);
   }
 
   async fetchResources() {

--- a/src/components/manifold-data-has-resource/manifold-data-has-resource.tsx
+++ b/src/components/manifold-data-has-resource/manifold-data-has-resource.tsx
@@ -26,8 +26,8 @@ export class ManifoldDataHasResource {
   }
 
   componentWillLoad() {
+    this.fetchResources();
     if (!this.paused) {
-      this.fetchResources();
       this.interval = window.setInterval(() => this.fetchResources(), 3000);
     }
   }

--- a/src/components/manifold-data-has-resource/manifold-data-has-resource.tsx
+++ b/src/components/manifold-data-has-resource/manifold-data-has-resource.tsx
@@ -1,0 +1,61 @@
+import { h, Component, Prop, State, Element, Watch } from '@stencil/core';
+
+import { Marketplace } from '../../types/marketplace';
+import { withAuth } from '../../utils/auth';
+import { Connection, connections } from '../../utils/connections';
+import Tunnel from '../../data/connection';
+
+@Component({ tag: 'manifold-data-has-resource', shadow: true })
+export class ManifoldDataHasResource {
+  @Element() el: HTMLElement;
+  /** _(hidden)_ Passed by `<manifold-connection>` */
+  @Prop() connection?: Connection = connections.prod; // Provided by manifold-connection
+  /** _(hidden)_ Passed by `<manifold-connection>` */
+  @Prop() authToken?: string;
+  /** Disable auto-updates? */
+  @Prop() paused?: boolean = false;
+  @State() interval?: number;
+  @State() hasResources?: boolean = false;
+
+  @Watch('paused') pausedChange(newPaused: boolean) {
+    if (newPaused) {
+      window.clearInterval(this.interval);
+    } else {
+      this.interval = window.setInterval(() => this.fetchResources(), 3000);
+    }
+  }
+
+  componentWillLoad() {
+    if (!this.paused) {
+      this.fetchResources();
+      this.interval = window.setInterval(() => this.fetchResources(), 3000);
+    }
+  }
+
+  componentDidUnload() {
+    if (this.interval) {
+      window.clearInterval(this.interval);
+    }
+  }
+
+  async fetchResources() {
+    if (!this.connection) {
+      return;
+    }
+
+    const resourcesResp = await fetch(
+      `${this.connection.marketplace}/resources/?me`,
+      withAuth(this.authToken)
+    );
+    const resources: Marketplace.Resource[] = await resourcesResp.json();
+    if (Array.isArray(resources) && resources.length) {
+      this.hasResources = true;
+    }
+  }
+
+  render() {
+    return <slot name={this.hasResources ? 'has-resource' : 'no-resource'} />;
+  }
+}
+
+Tunnel.injectProps(ManifoldDataHasResource, ['connection', 'authToken']);

--- a/src/components/manifold-resource-list/manifold-resource-list.e2e.ts
+++ b/src/components/manifold-resource-list/manifold-resource-list.e2e.ts
@@ -8,7 +8,7 @@ fetchMock.restore(); // Is required because tests are run async and if fetch is 
 describe('<manifold-resource-list>', () => {
   // TODO: Find a way to test the internal state
 
-  it('renders the no resource state if no resources are found', async () => {
+  it.skip('renders the no resource state if no resources are found', async () => {
     const page = await newE2EPage({ html: `<manifold-resource-list />` });
     await page.$eval(
       'manifold-resource-list',

--- a/src/components/manifold-resource-list/manifold-resource-list.e2e.ts
+++ b/src/components/manifold-resource-list/manifold-resource-list.e2e.ts
@@ -8,8 +8,13 @@ fetchMock.restore(); // Is required because tests are run async and if fetch is 
 describe('<manifold-resource-list>', () => {
   // TODO: Find a way to test the internal state
 
-  it.skip('renders the no resource state if no resources are found', async () => {
-    const page = await newE2EPage({ html: `<manifold-resource-list />` });
+  it('renders the no resource state if no resources are found', async () => {
+    const page = await newE2EPage({
+      html: `
+        <manifold-resource-list>
+          <span itemprop="no-resources" slot="no-resources">No resources</span>
+        </manifold-resource-list>`,
+    });
     await page.$eval(
       'manifold-resource-list',
       (elm: any, props: any) => {

--- a/stories/manifold-data-has-resource.stories.js
+++ b/stories/manifold-data-has-resource.stories.js
@@ -1,0 +1,29 @@
+import { storiesOf } from '@storybook/html';
+import markdown from '../docs/docs/components/manifold-resource-list.md';
+
+storiesOf('Has Resources 🔒 [Data]', module)
+  .addParameters({ readme: { sidebar: markdown } })
+  .addDecorator(storyFn => localStorage.manifold_api_token ?
+    storyFn()
+    : 'Set your token under `manifold_api_token` in localstorage then refresh to view this story')
+  .add(
+    'The user has resources',
+    () => `
+      <manifold-connection>
+        <manifold-auth-token token="${localStorage.manifold_api_token}"/>
+        <manifold-data-has-resource>
+          <span slot="has-resource">Has resources</span>
+          <span slot="no-resource">No resources</span>
+        </manifold-data-has-resource>
+      </manifold-connection>
+    `
+  )
+  .add(
+    'The user has no resources',
+    () => `
+      <manifold-data-has-resource paused>
+        <span slot="has-resource">Has resources</span>
+        <span slot="no-resource">No resources</span>
+      </manifold-data-has-resource>
+    `
+  );


### PR DESCRIPTION
Work is related to manifoldco/engineering#8649

## Reason for change
If the user has resources on their account, the component will render the `has-resource` slot and will render the `no-resource` slot if the user has no resources.

This gives platforms a good way to render something based on the user's data without having to use our API.

## Testing
Test with storybook
