### PR TITLE
Remove the input from `manifold-data-provision-button`

### DIFF
--- a/docs/docs/data/manifold-data-provision-button.md
+++ b/docs/docs/data/manifold-data-provision-button.md
@@ -3,15 +3,15 @@ title: 🔒 Provision Button
 path: /data/provision-button
 example: |
   <label for="my-provision-button">Resource Name</label>
-  <manifold-data-provision-button input-id="my-provision-button">
+  <input id="my-provision-button" value="my-resource"></input>
+  <manifold-data-provision-button resource-name="my-resource">
     🚀 Provision Business plan on Prefab.cloud
   </manifold-data-provision-button>
 ---
 
 # 🔒 Provision Button
 
-An unstyled text input + button combination for provisioning resources. 🔒
-Requires authentication.
+An unstyled button for provisioning resources. 🔒 Requires authentication.
 
 ## Using with Plan Selector
 
@@ -21,15 +21,17 @@ selector](#manifold-plan-selector) component. You could do that like so:
 
 ```js
 const userId = ''; // Note: must be set
+const resourceName = ''; // Can be obtained from your own input
 
-function updateButton({ detail: { features, planId, productLabel, regionId } }) {
+function updateButton({ detail: { features, planLabel, productLabel, regionName } }) {
   const provisionButton = document.querySelector('manifold-data-provision-button');
   provisionButton.features = features;
-  provisionButton.planId = planId;
+  provisionButton.planLabel = planLabel;
   provisionButton.productLabel = productLabel;
-  provisionButton.regionId = regionId;
+  provisionButton.regionName = regionName;
+  provisionButton.resourceName = resourceName;
 
-  provisionButton.userId = userId;
+  provisionButton.ownerId = userId;
 }
 
 document.addEventListener('manifold-planSelector-load', updateButton);

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -150,19 +150,23 @@ export namespace Components {
     * _(hidden)_ Passed by `<manifold-connection>`
     */
     'connection': Connection;
-    'features'?: Gateway.FeatureMap;
-    /**
-    * ID of input (useful for `<label>`)
-    */
-    'inputId'?: string;
     'ownerId'?: string;
-    'planId'?: string;
-    'productId'?: string;
+    /**
+    * Plan to provision (slug)
+    */
+    'planLabel'?: string;
     /**
     * Product to provision (slug)
     */
     'productLabel'?: string;
-    'regionId'?: string;
+    /**
+    * Region to provision (complete name), omit for all region
+    */
+    'regionName'?: string;
+    /**
+    * The name of the resource to provision
+    */
+    'resourceName'?: string;
   }
   interface ManifoldDataResourceList {
     /**
@@ -981,23 +985,27 @@ declare namespace LocalJSX {
     * _(hidden)_ Passed by `<manifold-connection>`
     */
     'connection'?: Connection;
-    'features'?: Gateway.FeatureMap;
-    /**
-    * ID of input (useful for `<label>`)
-    */
-    'inputId'?: string;
     'onManifold-provisionButton-click'?: (event: CustomEvent<any>) => void;
     'onManifold-provisionButton-error'?: (event: CustomEvent<any>) => void;
     'onManifold-provisionButton-invalid'?: (event: CustomEvent<any>) => void;
     'onManifold-provisionButton-success'?: (event: CustomEvent<any>) => void;
     'ownerId'?: string;
-    'planId'?: string;
-    'productId'?: string;
+    /**
+    * Plan to provision (slug)
+    */
+    'planLabel'?: string;
     /**
     * Product to provision (slug)
     */
     'productLabel'?: string;
-    'regionId'?: string;
+    /**
+    * Region to provision (complete name), omit for all region
+    */
+    'regionName'?: string;
+    /**
+    * The name of the resource to provision
+    */
+    'resourceName'?: string;
   }
   interface ManifoldDataResourceList extends JSXBase.HTMLAttributes<HTMLManifoldDataResourceListElement> {
     /**

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.spec.ts
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.spec.ts
@@ -1,23 +1,288 @@
+import { newSpecPage } from '@stencil/core/testing';
+import fetchMock from 'fetch-mock';
+
+import { Product, ExpandedPlan, ZiggeoPlan } from '../../spec/mock/catalog';
+import { GatewayResource } from '../../spec/mock/gateway';
+import { connections } from '../../utils/connections';
+
 import { ManifoldDataProvisionButton } from './manifold-data-provision-button';
 
 describe('<manifold-data-provision-button>', () => {
-  it('fetches product id on load', () => {
+  it('fetches product and plan id on load', () => {
     const productLabel = 'test-product';
+    const planLabel = 'test-plan';
 
     const provisionButton = new ManifoldDataProvisionButton();
-    provisionButton.fetchProductId = jest.fn();
+    provisionButton.fetchProductPlanId = jest.fn();
     provisionButton.productLabel = productLabel;
+    provisionButton.planLabel = planLabel;
     provisionButton.componentWillLoad();
-    expect(provisionButton.fetchProductId).toHaveBeenCalledWith(productLabel);
+    expect(provisionButton.fetchProductPlanId).toHaveBeenCalledWith(productLabel, planLabel);
   });
 
-  it('fetches product id on change', () => {
+  it('fetches product and plan id on change', () => {
     const newProduct = 'new-product';
+    const newPlan = 'new-plan';
 
     const provisionButton = new ManifoldDataProvisionButton();
-    provisionButton.fetchProductId = jest.fn();
+    provisionButton.fetchProductPlanId = jest.fn();
     provisionButton.productLabel = 'old-product';
+    provisionButton.planLabel = 'old-plan';
+
     provisionButton.productChange(newProduct);
-    expect(provisionButton.fetchProductId).toHaveBeenCalledWith(newProduct);
+    expect(provisionButton.fetchProductPlanId).toHaveBeenCalledWith(newProduct, 'old-plan');
+
+    provisionButton.planChange(newPlan);
+    expect(provisionButton.fetchProductPlanId).toHaveBeenCalledWith('old-product', newPlan);
+  });
+
+  describe('when created with product and plans labels', () => {
+    afterEach(() => {
+      fetchMock.restore();
+    });
+
+    it('will fetch the products and find the plan', async () => {
+      const productLabel = 'test-product';
+      const planLabel = 'test-plan';
+
+      fetchMock
+        .mock(`${connections.prod.catalog}/products/?label=${productLabel}`, [Product])
+        .mock(`${connections.prod.catalog}/plans/?product_id=${Product.id}&label=${planLabel}`, [
+          ExpandedPlan,
+        ]);
+
+      const page = await newSpecPage({
+        components: [ManifoldDataProvisionButton],
+        html: `
+          <manifold-data-provision-button
+            product-label="${productLabel}"
+            plan-label="${planLabel}"
+          >Provision</manifold-data-provision-button>
+        `,
+      });
+
+      expect(fetchMock.called(`${connections.prod.catalog}/products/?label=${productLabel}`)).toBe(
+        true
+      );
+      expect(
+        fetchMock.called(
+          `${connections.prod.catalog}/plans/?product_id=${Product.id}&label=${planLabel}`
+        )
+      ).toBe(true);
+
+      const root = page.rootInstance as ManifoldDataProvisionButton;
+      expect(root.productId).toEqual(Product.id);
+      expect(root.planId).toEqual(ExpandedPlan.id);
+    });
+
+    it('will fetch the products and find the plan even without a plan label', async () => {
+      const productLabel = 'test-product';
+
+      fetchMock
+        .mock(`${connections.prod.catalog}/products/?label=${productLabel}`, [Product])
+        .mock(`${connections.prod.catalog}/plans/?product_id=${Product.id}`, [
+          ExpandedPlan,
+          ZiggeoPlan,
+        ]);
+
+      const page = await newSpecPage({
+        components: [ManifoldDataProvisionButton],
+        html: `
+          <manifold-data-provision-button
+            product-label="${productLabel}"
+          >Provision</manifold-data-provision-button>
+        `,
+      });
+
+      expect(fetchMock.called(`${connections.prod.catalog}/products/?label=${productLabel}`)).toBe(
+        true
+      );
+      expect(
+        fetchMock.called(
+          `${connections.prod.catalog}/plans/?product_id=${Product.id}`
+        )
+      ).toBe(true);
+
+      const root = page.rootInstance as ManifoldDataProvisionButton;
+      expect(root.productId).toEqual(Product.id);
+      expect(root.planId).toEqual(ExpandedPlan.id);
+    });
+
+    it('will do nothing if no product label is given', async () => {
+
+      fetchMock.mock(`${connections.prod.catalog}/products/`, [Product]);
+
+      await newSpecPage({
+        components: [ManifoldDataProvisionButton],
+        html: `
+          <manifold-data-provision-button>Provision</manifold-data-provision-button>
+        `,
+      });
+
+      expect(fetchMock.called(`${connections.prod.catalog}/products/`)).toBe(
+        false
+      );
+    });
+
+    it('will do nothing if the products return an invalid value', async () => {
+      const productLabel = 'test-product';
+
+      fetchMock
+        .mock(`${connections.prod.catalog}/products/?label=${productLabel}`, {})
+        .mock(`${connections.prod.catalog}/plans/?product_id=${Product.id}`, {});
+
+      const page = await newSpecPage({
+        components: [ManifoldDataProvisionButton],
+        html: `
+          <manifold-data-provision-button
+            product-label="${productLabel}"
+          >Provision</manifold-data-provision-button>
+        `,
+      });
+
+      expect(fetchMock.called(`${connections.prod.catalog}/products/?label=${productLabel}`)).toBe(
+        true
+      );
+
+      const root = page.rootInstance as ManifoldDataProvisionButton;
+      expect(root.productId).toEqual('');
+    });
+
+    it('will do nothing if the products return an invalid value', async () => {
+      const productLabel = 'test-product';
+
+      fetchMock
+        .mock(`${connections.prod.catalog}/products/?label=${productLabel}`, [Product])
+        .mock(`${connections.prod.catalog}/plans/?product_id=${Product.id}`, {});
+
+      const page = await newSpecPage({
+        components: [ManifoldDataProvisionButton],
+        html: `
+          <manifold-data-provision-button
+            product-label="${productLabel}"
+          >Provision</manifold-data-provision-button>
+        `,
+      });
+
+      expect(fetchMock.called(`${connections.prod.catalog}/products/?label=${productLabel}`)).toBe(
+        true
+      );
+      expect(
+        fetchMock.called(
+          `${connections.prod.catalog}/plans/?product_id=${Product.id}`
+        )
+      ).toBe(true);
+
+      const root = page.rootInstance as ManifoldDataProvisionButton;
+      expect(root.productId).toEqual('');
+      expect(root.planId).toEqual('');
+    });
+  });
+
+  describe('When sending a request to provision', () => {
+    afterEach(() => {
+      fetchMock.restore();
+    });
+
+    beforeEach(() => {
+      fetchMock
+        .mock(/.*\/products\/.*/, [Product])
+        .mock(/.*\/plans\/.*/, [ExpandedPlan]);
+    });
+
+    it('will trigger a dom event on successful provision', async () => {
+      fetchMock.mock(`${connections.prod.gateway}/resource/`, GatewayResource);
+
+      const page = await newSpecPage({
+        components: [ManifoldDataProvisionButton],
+        html: `
+          <manifold-data-provision-button
+            product-label="test"
+            owner-id="1234"
+            resource-name="test"
+          >Provision</manifold-data-provision-button>
+        `,
+      });
+
+      const instance = page.rootInstance as ManifoldDataProvisionButton;
+      instance.successEvent.emit = jest.fn();
+
+      await instance.provision();
+
+      expect(fetchMock.called(`${connections.prod.gateway}/resource/`)).toBe(true);
+      expect(instance.successEvent.emit).toHaveBeenCalledWith({
+        createdAt: GatewayResource.created_at,
+        message: 'test successfully provisioned',
+        resourceId: GatewayResource.id,
+        resourceName: GatewayResource.label,
+      });
+    });
+
+    it('will trigger a dom event on failed provision', async () => {
+      fetchMock.mock(`${connections.prod.gateway}/resource/`, {
+        status: 500,
+        body: {
+          message: 'ohnoes',
+        },
+      });
+
+      const page = await newSpecPage({
+        components: [ManifoldDataProvisionButton],
+        html: `
+          <manifold-data-provision-button
+            product-label="test"
+            owner-id="1234"
+            resource-name="test"
+          >Provision</manifold-data-provision-button>
+        `,
+      });
+
+      const instance = page.rootInstance as ManifoldDataProvisionButton;
+      instance.errorEvent.emit = jest.fn();
+
+      await instance.provision();
+
+      expect(fetchMock.called(`${connections.prod.gateway}/resource/`)).toBe(true);
+      expect(instance.errorEvent.emit).toHaveBeenCalledWith({
+        message: 'ohnoes',
+        resourceName: 'test',
+      });
+    });
+
+    it('will trigger a dom event on an invalid resource name', async () => {
+      fetchMock.mock(`${connections.prod.gateway}/resource/`, 500);
+
+      const page = await newSpecPage({
+        components: [ManifoldDataProvisionButton],
+        html: `
+          <manifold-data-provision-button
+            product-label="test"
+            owner-id="1234"
+            resource-name="t"
+          >Provision</manifold-data-provision-button>
+        `,
+      });
+
+      const instance = page.rootInstance as ManifoldDataProvisionButton;
+      instance.invalidEvent.emit = jest.fn();
+
+      await instance.provision();
+
+      expect(fetchMock.called(`${connections.prod.gateway}/resource/`)).toBe(false);
+      expect(instance.invalidEvent.emit).toHaveBeenCalledWith({
+        message: 'Must be at least 3 characters.',
+        resourceName: 't',
+      });
+
+      instance.resourceName = 'Test';
+      await instance.provision();
+
+      expect(fetchMock.called(`${connections.prod.gateway}/resource/`)).toBe(false);
+      expect(instance.invalidEvent.emit).toHaveBeenCalledWith({
+        message:
+          'Must start with a lowercase letter, and use only lowercase, numbers, and hyphens.',
+        resourceName: 'Test',
+      });
+    });
   });
 });

--- a/src/spec/mock/gateway.ts
+++ b/src/spec/mock/gateway.ts
@@ -1,0 +1,59 @@
+import {
+  Product,
+  ExpandedPlan,
+  Regions,
+  Provider,
+} from './catalog';
+import { Resource } from './marketplace';
+import { Gateway } from '../../types/gateway';
+
+export const ResolvedProvider: Gateway.ResolvedProvider = {
+  id: Provider.id,
+  label: Provider.body.label,
+  name: Provider.body.name,
+};
+
+export const ResolvedProduct: Gateway.ResolvedProduct = {
+  id: Product.id,
+  ...Product.body,
+  state: 'available',
+  terms: {
+    provided: Product.body.terms.provided,
+    url: Product.body.terms.url || '',
+  },
+  billing: {
+    currency: 'usd',
+    type: 'monthly-prorated',
+  },
+  integration: {
+    ...Product.body.integration,
+    provisioning: 'public',
+  },
+  provider: ResolvedProvider,
+};
+
+export const ResolvedPlan: Gateway.ResolvedPlan = {
+  id: ExpandedPlan.id,
+  ...ExpandedPlan.body,
+  free: ExpandedPlan.body.free || true,
+};
+
+export const ResolvedRegion: Gateway.ResolvedRegion = {
+  id: Regions[0].id,
+  name: Regions[0].body.name,
+};
+
+export const GatewayResource: Gateway.Resource = {
+  id: Resource.id,
+  ...Resource.body,
+  type: 'resource',
+  owner: {
+    id: '1',
+    name: 'test',
+    type: 'user',
+  },
+  product: ResolvedProduct,
+  plan: ResolvedPlan,
+  region: ResolvedRegion,
+  features: [],
+};

--- a/stories/manifold-data-provision-button.stories.js
+++ b/stories/manifold-data-provision-button.stories.js
@@ -6,8 +6,10 @@ storiesOf('Provision Button [Data]', module)
   .add(
     'default',
     () => `
-  <label for="my-provision-button">Resource Name</label>
-  <manifold-data-provision-button input-id="my-provision-button">
-    🚀 Provision Business plan on Prefab.cloud
-  </manifold-data-provision-button>`
+      <label for="my-provision-button">Resource Name</label>
+      <input id="my-provision-button" value="my-resource">my-resource</input>
+      <manifold-data-provision-button resource-name="my-resource">
+        🚀 Provision Business plan on Prefab.cloud
+      </manifold-data-provision-button>
+    `
   );


### PR DESCRIPTION
Work is related to manifoldco/engineering#8687

## Reason for change
That input can now be added outside the component itself for an easier control of it's position, associated label and stylings. Instead, a `resource-name` attribute must be provided to the provision button for resources to be properly provisioned.

Also added a lot of spec tests to the provision button.

## Testing
Test with storybook
