### PR TITLE
Adds a new deprovision button and it's resource-container wrapper

### DIFF
--- a/docs/docs/data/manifold-data-deprovision-button.md
+++ b/docs/docs/data/manifold-data-deprovision-button.md
@@ -28,22 +28,22 @@ Set the CTA text by adding anything between the opening and closing tags:
 For validation, error, and success messages, it will emit custom events.
 
 ```js
-document.addEventListener('manifold-deprovisionButton-click', ({ detail: { resourceLabel } }) =>
-  console.info(`⌛ Derovisioning ${resourceLabel} …`)
+document.addEventListener('manifold-deprovisionButton-click', ({ detail: { resourceName } }) =>
+  console.info(`⌛ Derovisioning ${resourceName} …`)
 );
 document.addEventListener(
   'manifold-deprovisionButton-success',
-  ({ details: { resourceLabel } }) =>alert(`${resourceLabel} deprovisioned successfully!`)
+  ({ details: { resourceName } }) =>alert(`${resourceName} deprovisioned successfully!`)
 );
 document.addEventListener('manifold-deprovisionButton-error', ({ detail }) => console.log(detail));
-// {message: "bad_request: bad_request: No plan_id provided", resourceid: "1234", resourceLabel: "my-resource"}
+// {message: "bad_request: bad_request: No plan_id provided", resourceid: "1234", resourceName: "my-resource"}
 ```
 
 | Name                               |                       Returns                        | Description                                                                                                                 |
 | :--------------------------------- | :--------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------- |
-| `manifold-provisionButton-click`   |                    `resourceLabel`                   | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
-| `manifold-provisionButton-success` |     `message`, `resourceId`, `resourceLabel`         | Successful deprovision. Returns a resource ID and resource Label.                                                                              |
-| `manifold-provisionButton-error`   |     `message`, `resourceId`, `resourceLabel`         | Erred provision, along with information on what went wrong.                                                                 |
+| `manifold-provisionButton-click`   |                    `resourceName`                   | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
+| `manifold-provisionButton-success` |     `message`, `resourceId`, `resourceName`         | Successful deprovision. Returns a resource ID and resource Label.                                                                              |
+| `manifold-provisionButton-error`   |     `message`, `resourceId`, `resourceName`         | Erred provision, along with information on what went wrong.                                                                 |
 
 ## Styling
 

--- a/docs/docs/data/manifold-data-deprovision-button.md
+++ b/docs/docs/data/manifold-data-deprovision-button.md
@@ -1,0 +1,57 @@
+---
+title: 🔒 Deprovision Button
+path: /data/deprovision-button
+example: |
+  <manifold-data-deprovision-button resource-label="my-resource">
+    Deprovison resource
+  </manifold-data-provision-button>
+---
+
+# 🔒 Derovision Button
+
+An unstyled button for deprovisioning resources. 🔒 Requires authentication.
+
+## CTA text
+
+Set the CTA text by adding anything between the opening and closing tags:
+
+```html
+<manifold-data-deprovision-button>
+  Deprovision My Resource
+</manifold-data-provision-button>
+```
+
+`slot` can be attached to any HTML or JSX element. To read more about slots, see [Stencil’s Documentation][stencil-slot]
+
+## Events
+
+For validation, error, and success messages, it will emit custom events.
+
+```js
+document.addEventListener('manifold-deprovisionButton-click', ({ detail: { resourceLabel } }) =>
+  console.info(`⌛ Derovisioning ${resourceLabel} …`)
+);
+document.addEventListener(
+  'manifold-deprovisionButton-success',
+  ({ details: { resourceLabel } }) =>alert(`${resourceLabel} deprovisioned successfully!`)
+);
+document.addEventListener('manifold-deprovisionButton-error', ({ detail }) => console.log(detail));
+// {message: "bad_request: bad_request: No plan_id provided", resourceid: "1234", resourceLabel: "my-resource"}
+```
+
+| Name                               |                       Returns                        | Description                                                                                                                 |
+| :--------------------------------- | :--------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------- |
+| `manifold-provisionButton-click`   |                    `resourceLabel`                   | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
+| `manifold-provisionButton-success` |     `message`, `resourceId`, `resourceLabel`         | Successful deprovision. Returns a resource ID and resource Label.                                                                              |
+| `manifold-provisionButton-error`   |     `message`, `resourceId`, `resourceLabel`         | Erred provision, along with information on what went wrong.                                                                 |
+
+## Styling
+
+Whereas other components in this system take advantage of [Shadow
+DOM][shadow-dom] encapsulation for ease of use, we figured this component
+should be customizable. As such, style it however you’d like! We recommend
+attaching styles to a parent element using any CSS-in-JS framework of your
+choice, or plain ol’ CSS.
+
+[shadow-dom]: https://developers.google.com/web/fundamentals/web-components/shadowdom
+[stencil-slot]: https://stenciljs.com/docs/templating-jsx/

--- a/docs/docs/data/manifold-data-deprovision-button.md
+++ b/docs/docs/data/manifold-data-deprovision-button.md
@@ -7,7 +7,7 @@ example: |
   </manifold-data-provision-button>
 ---
 
-# 🔒 Derovision Button
+# 🔒 Deprovision Button
 
 An unstyled button for deprovisioning resources. 🔒 Requires authentication.
 
@@ -41,9 +41,9 @@ document.addEventListener('manifold-deprovisionButton-error', ({ detail }) => co
 
 | Name                               |                       Returns                        | Description                                                                                                                 |
 | :--------------------------------- | :--------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------- |
-| `manifold-provisionButton-click`   |                    `resourceName`                   | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
-| `manifold-provisionButton-success` |     `message`, `resourceId`, `resourceName`         | Successful deprovision. Returns a resource ID and resource Label.                                                                              |
-| `manifold-provisionButton-error`   |     `message`, `resourceId`, `resourceName`         | Erred provision, along with information on what went wrong.                                                                 |
+| `manifold-deprovisionButton-click`   |                    `resourceName`                   | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
+| `manifold-deprovisionButton-success` |     `message`, `resourceId`, `resourceName`         | Successful deprovision. Returns a resource ID and resource Label.                                                                              |
+| `manifold-deprovisionButton-error`   |     `message`, `resourceId`, `resourceName`         | Erred provision, along with information on what went wrong.                                                                 |
 
 ## Styling
 

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -69,6 +69,22 @@ export namespace Components {
     'isCustomizable'?: boolean;
     'measuredFeatures': Catalog.ExpandedFeature[];
   }
+  interface ManifoldDataDeprovisionButton {
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'authToken'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'connection': Connection;
+    'loading'?: boolean;
+    'resourceId'?: string;
+    /**
+    * The label of the resource to deprovision
+    */
+    'resourceLabel'?: string;
+  }
   interface ManifoldDataHasResource {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
@@ -435,6 +451,7 @@ export namespace Components {
     'credentials'?: Marketplace.Credential[];
     'resourceState': ResourceState;
   }
+  interface ManifoldResourceDeprovision {}
   interface ManifoldResourceDetails {}
   interface ManifoldResourceDetailsView {
     'data'?: Gateway.Resource;
@@ -563,6 +580,12 @@ declare global {
   var HTMLManifoldCostDisplayElement: {
     prototype: HTMLManifoldCostDisplayElement;
     new (): HTMLManifoldCostDisplayElement;
+  };
+
+  interface HTMLManifoldDataDeprovisionButtonElement extends Components.ManifoldDataDeprovisionButton, HTMLStencilElement {}
+  var HTMLManifoldDataDeprovisionButtonElement: {
+    prototype: HTMLManifoldDataDeprovisionButtonElement;
+    new (): HTMLManifoldDataDeprovisionButtonElement;
   };
 
   interface HTMLManifoldDataHasResourceElement extends Components.ManifoldDataHasResource, HTMLStencilElement {}
@@ -727,6 +750,12 @@ declare global {
     new (): HTMLManifoldResourceCredentialsViewElement;
   };
 
+  interface HTMLManifoldResourceDeprovisionElement extends Components.ManifoldResourceDeprovision, HTMLStencilElement {}
+  var HTMLManifoldResourceDeprovisionElement: {
+    prototype: HTMLManifoldResourceDeprovisionElement;
+    new (): HTMLManifoldResourceDeprovisionElement;
+  };
+
   interface HTMLManifoldResourceDetailsElement extends Components.ManifoldResourceDetails, HTMLStencilElement {}
   var HTMLManifoldResourceDetailsElement: {
     prototype: HTMLManifoldResourceDetailsElement;
@@ -812,6 +841,7 @@ declare global {
     'manifold-button-link': HTMLManifoldButtonLinkElement;
     'manifold-connection': HTMLManifoldConnectionElement;
     'manifold-cost-display': HTMLManifoldCostDisplayElement;
+    'manifold-data-deprovision-button': HTMLManifoldDataDeprovisionButtonElement;
     'manifold-data-has-resource': HTMLManifoldDataHasResourceElement;
     'manifold-data-manage-button': HTMLManifoldDataManageButtonElement;
     'manifold-data-product-logo': HTMLManifoldDataProductLogoElement;
@@ -839,6 +869,7 @@ declare global {
     'manifold-resource-container': HTMLManifoldResourceContainerElement;
     'manifold-resource-credentials': HTMLManifoldResourceCredentialsElement;
     'manifold-resource-credentials-view': HTMLManifoldResourceCredentialsViewElement;
+    'manifold-resource-deprovision': HTMLManifoldResourceDeprovisionElement;
     'manifold-resource-details': HTMLManifoldResourceDetailsElement;
     'manifold-resource-details-view': HTMLManifoldResourceDetailsViewElement;
     'manifold-resource-list': HTMLManifoldResourceListElement;
@@ -900,6 +931,25 @@ declare namespace LocalJSX {
     'compact'?: boolean;
     'isCustomizable'?: boolean;
     'measuredFeatures'?: Catalog.ExpandedFeature[];
+  }
+  interface ManifoldDataDeprovisionButton extends JSXBase.HTMLAttributes<HTMLManifoldDataDeprovisionButtonElement> {
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'authToken'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'connection'?: Connection;
+    'loading'?: boolean;
+    'onManifold-deprovisionButton-click'?: (event: CustomEvent<any>) => void;
+    'onManifold-deprovisionButton-error'?: (event: CustomEvent<any>) => void;
+    'onManifold-provisionButton-success'?: (event: CustomEvent<any>) => void;
+    'resourceId'?: string;
+    /**
+    * The label of the resource to deprovision
+    */
+    'resourceLabel'?: string;
   }
   interface ManifoldDataHasResource extends JSXBase.HTMLAttributes<HTMLManifoldDataHasResourceElement> {
     /**
@@ -1281,6 +1331,7 @@ declare namespace LocalJSX {
     'onCredentialsRequested'?: (event: CustomEvent<any>) => void;
     'resourceState'?: ResourceState;
   }
+  interface ManifoldResourceDeprovision extends JSXBase.HTMLAttributes<HTMLManifoldResourceDeprovisionElement> {}
   interface ManifoldResourceDetails extends JSXBase.HTMLAttributes<HTMLManifoldResourceDetailsElement> {}
   interface ManifoldResourceDetailsView extends JSXBase.HTMLAttributes<HTMLManifoldResourceDetailsViewElement> {
     'data'?: Gateway.Resource;
@@ -1377,6 +1428,7 @@ declare namespace LocalJSX {
     'manifold-button-link': ManifoldButtonLink;
     'manifold-connection': ManifoldConnection;
     'manifold-cost-display': ManifoldCostDisplay;
+    'manifold-data-deprovision-button': ManifoldDataDeprovisionButton;
     'manifold-data-has-resource': ManifoldDataHasResource;
     'manifold-data-manage-button': ManifoldDataManageButton;
     'manifold-data-product-logo': ManifoldDataProductLogo;
@@ -1404,6 +1456,7 @@ declare namespace LocalJSX {
     'manifold-resource-container': ManifoldResourceContainer;
     'manifold-resource-credentials': ManifoldResourceCredentials;
     'manifold-resource-credentials-view': ManifoldResourceCredentialsView;
+    'manifold-resource-deprovision': ManifoldResourceDeprovision;
     'manifold-resource-details': ManifoldResourceDetails;
     'manifold-resource-details-view': ManifoldResourceDetailsView;
     'manifold-resource-list': ManifoldResourceList;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -83,7 +83,7 @@ export namespace Components {
     /**
     * The label of the resource to deprovision
     */
-    'resourceLabel'?: string;
+    'resourceName'?: string;
   }
   interface ManifoldDataHasResource {
     /**
@@ -949,7 +949,7 @@ declare namespace LocalJSX {
     /**
     * The label of the resource to deprovision
     */
-    'resourceLabel'?: string;
+    'resourceName'?: string;
   }
   interface ManifoldDataHasResource extends JSXBase.HTMLAttributes<HTMLManifoldDataHasResourceElement> {
     /**

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
@@ -8,46 +8,46 @@ import { ManifoldDataDeprovisionButton } from './manifold-data-deprovision-butto
 
 describe('<manifold-data-provision-button>', () => {
   it('fetches the resource id on load if not set', () => {
-    const resourceLabel = 'test-resource';
+    const resourceName = 'test-resource';
 
     const provisionButton = new ManifoldDataDeprovisionButton();
     provisionButton.fetchResourceId = jest.fn();
-    provisionButton.resourceLabel = resourceLabel;
+    provisionButton.resourceName = resourceName;
     provisionButton.componentWillLoad();
-    expect(provisionButton.fetchResourceId).toHaveBeenCalledWith(resourceLabel);
+    expect(provisionButton.fetchResourceId).toHaveBeenCalledWith(resourceName);
   });
 
   it('does not fetch the resource id on load if set', () => {
-    const resourceLabel = 'test-resource';
+    const resourceName = 'test-resource';
 
     const provisionButton = new ManifoldDataDeprovisionButton();
     provisionButton.fetchResourceId = jest.fn();
-    provisionButton.resourceLabel = resourceLabel;
-    provisionButton.resourceId = resourceLabel;
+    provisionButton.resourceName = resourceName;
+    provisionButton.resourceId = resourceName;
     provisionButton.componentWillLoad();
     expect(provisionButton.fetchResourceId).not.toHaveBeenCalled();
   });
 
   it('fetches resource id on change if not set', () => {
-    const resourceLabel = 'new-resource';
+    const resourceName = 'new-resource';
 
     const provisionButton = new ManifoldDataDeprovisionButton();
     provisionButton.fetchResourceId = jest.fn();
-    provisionButton.resourceLabel = 'old-resource';
+    provisionButton.resourceName = 'old-resource';
 
-    provisionButton.labelChange(resourceLabel);
-    expect(provisionButton.fetchResourceId).toHaveBeenCalledWith(resourceLabel);
+    provisionButton.nameChange(resourceName);
+    expect(provisionButton.fetchResourceId).toHaveBeenCalledWith(resourceName);
   });
 
   it('does not resource id on change if set', () => {
-    const resourceLabel = 'new-resource';
+    const resourceName = 'new-resource';
 
     const provisionButton = new ManifoldDataDeprovisionButton();
     provisionButton.fetchResourceId = jest.fn();
-    provisionButton.resourceLabel = 'old-resource';
+    provisionButton.resourceName = 'old-resource';
     provisionButton.resourceId = '1234';
 
-    provisionButton.labelChange(resourceLabel);
+    provisionButton.nameChange(resourceName);
     expect(provisionButton.fetchResourceId).not.toHaveBeenCalled();
   });
 
@@ -57,9 +57,9 @@ describe('<manifold-data-provision-button>', () => {
     });
 
     it('will fetch the resource id', async () => {
-      const resourceLabel = 'new-resource';
+      const resourceName = 'new-resource';
 
-      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`, [
+      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${resourceName}`, [
         Resource,
       ]);
 
@@ -67,13 +67,13 @@ describe('<manifold-data-provision-button>', () => {
         components: [ManifoldDataDeprovisionButton],
         html: `
           <manifold-data-deprovision-button
-            resource-label="${resourceLabel}"
+            resource-name="${resourceName}"
           >Deprovision</manifold-data-deprovision-button>
         `,
       });
 
       expect(
-        fetchMock.called(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`)
+        fetchMock.called(`${connections.prod.marketplace}/resources/?me&label=${resourceName}`)
       ).toBe(true);
 
       const root = page.rootInstance as ManifoldDataDeprovisionButton;
@@ -81,21 +81,21 @@ describe('<manifold-data-provision-button>', () => {
     });
 
     it('will do nothing on a fetch error', async () => {
-      const resourceLabel = 'new-resource';
+      const resourceName = 'new-resource';
 
-      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`, []);
+      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&name=${resourceName}`, []);
 
       const page = await newSpecPage({
         components: [ManifoldDataDeprovisionButton],
         html: `
           <manifold-data-deprovision-button
-            resource-label="${resourceLabel}"
+            resource-label="${resourceName}"
           >Deprovision</manifold-data-deprovision-button>
         `,
       });
 
       expect(
-        fetchMock.called(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`)
+        fetchMock.called(`${connections.prod.marketplace}/resources/?me&label=${resourceName}`)
       ).toBe(true);
 
       const root = page.rootInstance as ManifoldDataDeprovisionButton;
@@ -119,7 +119,7 @@ describe('<manifold-data-provision-button>', () => {
         components: [ManifoldDataDeprovisionButton],
         html: `
           <manifold-data-deprovision-button
-            resource-label="test"
+            resource-name="test"
           >Deprovision</manifold-data-deprovision-button>
         `,
       });
@@ -132,7 +132,7 @@ describe('<manifold-data-provision-button>', () => {
       expect(fetchMock.called(`${connections.prod.gateway}/id/resource/${Resource.id}`)).toBe(true);
       expect(instance.successEvent.emit).toHaveBeenCalledWith({
         message: 'test successfully deprovisioned',
-        resourceLabel: 'test',
+        resourceName: 'test',
         resourceId: Resource.id,
       });
     });
@@ -149,7 +149,7 @@ describe('<manifold-data-provision-button>', () => {
         components: [ManifoldDataDeprovisionButton],
         html: `
           <manifold-data-deprovision-button
-            resource-label="test"
+            resource-name="test"
           >Provision</manifold-data-deprovision-button>
         `,
       });
@@ -162,7 +162,7 @@ describe('<manifold-data-provision-button>', () => {
       expect(fetchMock.called(`${connections.prod.gateway}/id/resource/${Resource.id}`)).toBe(true);
       expect(instance.errorEvent.emit).toHaveBeenCalledWith({
         message: 'ohnoes',
-        resourceLabel: 'test',
+        resourceName: 'test',
         resourceId: Resource.id,
       });
     });

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
@@ -1,0 +1,170 @@
+import { newSpecPage } from '@stencil/core/testing';
+import fetchMock from 'fetch-mock';
+
+import { Resource } from '../../spec/mock/marketplace';
+import { connections } from '../../utils/connections';
+
+import { ManifoldDataDeprovisionButton } from './manifold-data-deprovision-button';
+
+describe('<manifold-data-provision-button>', () => {
+  it('fetches the resource id on load if not set', () => {
+    const resourceLabel = 'test-resource';
+
+    const provisionButton = new ManifoldDataDeprovisionButton();
+    provisionButton.fetchResourceId = jest.fn();
+    provisionButton.resourceLabel = resourceLabel;
+    provisionButton.componentWillLoad();
+    expect(provisionButton.fetchResourceId).toHaveBeenCalledWith(resourceLabel);
+  });
+
+  it('does not fetch the resource id on load if set', () => {
+    const resourceLabel = 'test-resource';
+
+    const provisionButton = new ManifoldDataDeprovisionButton();
+    provisionButton.fetchResourceId = jest.fn();
+    provisionButton.resourceLabel = resourceLabel;
+    provisionButton.resourceId = resourceLabel;
+    provisionButton.componentWillLoad();
+    expect(provisionButton.fetchResourceId).not.toHaveBeenCalled();
+  });
+
+  it('fetches resource id on change if not set', () => {
+    const resourceLabel = 'new-resource';
+
+    const provisionButton = new ManifoldDataDeprovisionButton();
+    provisionButton.fetchResourceId = jest.fn();
+    provisionButton.resourceLabel = 'old-resource';
+
+    provisionButton.labelChange(resourceLabel);
+    expect(provisionButton.fetchResourceId).toHaveBeenCalledWith(resourceLabel);
+  });
+
+  it('does not resource id on change if set', () => {
+    const resourceLabel = 'new-resource';
+
+    const provisionButton = new ManifoldDataDeprovisionButton();
+    provisionButton.fetchResourceId = jest.fn();
+    provisionButton.resourceLabel = 'old-resource';
+    provisionButton.resourceId = '1234';
+
+    provisionButton.labelChange(resourceLabel);
+    expect(provisionButton.fetchResourceId).not.toHaveBeenCalled();
+  });
+
+  describe('when created without a resource ID', () => {
+    afterEach(() => {
+      fetchMock.restore();
+    });
+
+    it('will fetch the resource id', async () => {
+      const resourceLabel = 'new-resource';
+
+      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`, [
+        Resource,
+      ]);
+
+      const page = await newSpecPage({
+        components: [ManifoldDataDeprovisionButton],
+        html: `
+          <manifold-data-deprovision-button
+            resource-label="${resourceLabel}"
+          >Deprovision</manifold-data-deprovision-button>
+        `,
+      });
+
+      expect(
+        fetchMock.called(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`)
+      ).toBe(true);
+
+      const root = page.rootInstance as ManifoldDataDeprovisionButton;
+      expect(root.resourceId).toEqual(Resource.id);
+    });
+
+    it('will do nothing on a fetch error', async () => {
+      const resourceLabel = 'new-resource';
+
+      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`, []);
+
+      const page = await newSpecPage({
+        components: [ManifoldDataDeprovisionButton],
+        html: `
+          <manifold-data-deprovision-button
+            resource-label="${resourceLabel}"
+          >Deprovision</manifold-data-deprovision-button>
+        `,
+      });
+
+      expect(
+        fetchMock.called(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`)
+      ).toBe(true);
+
+      const root = page.rootInstance as ManifoldDataDeprovisionButton;
+      expect(root.resourceId).not.toEqual(Resource.id);
+    });
+  });
+
+  describe('When sending a request to deprovision', () => {
+    afterEach(() => {
+      fetchMock.restore();
+    });
+
+    beforeEach(() => {
+      fetchMock.mock(/.*\/resources\/.*/, [Resource]);
+    });
+
+    it('will trigger a dom event on successful deprovision', async () => {
+      fetchMock.mock(`${connections.prod.gateway}/id/resource/${Resource.id}`, 200);
+
+      const page = await newSpecPage({
+        components: [ManifoldDataDeprovisionButton],
+        html: `
+          <manifold-data-deprovision-button
+            resource-label="test"
+          >Deprovision</manifold-data-deprovision-button>
+        `,
+      });
+
+      const instance = page.rootInstance as ManifoldDataDeprovisionButton;
+      instance.successEvent.emit = jest.fn();
+
+      await instance.deprovision();
+
+      expect(fetchMock.called(`${connections.prod.gateway}/id/resource/${Resource.id}`)).toBe(true);
+      expect(instance.successEvent.emit).toHaveBeenCalledWith({
+        message: 'test successfully deprovisioned',
+        resourceLabel: 'test',
+        resourceId: Resource.id,
+      });
+    });
+
+    it('will trigger a dom event on failed provision', async () => {
+      fetchMock.mock(`${connections.prod.gateway}/id/resource/${Resource.id}`, {
+        status: 500,
+        body: {
+          message: 'ohnoes',
+        },
+      });
+
+      const page = await newSpecPage({
+        components: [ManifoldDataDeprovisionButton],
+        html: `
+          <manifold-data-deprovision-button
+            resource-label="test"
+          >Provision</manifold-data-deprovision-button>
+        `,
+      });
+
+      const instance = page.rootInstance as ManifoldDataDeprovisionButton;
+      instance.errorEvent.emit = jest.fn();
+
+      await instance.deprovision();
+
+      expect(fetchMock.called(`${connections.prod.gateway}/id/resource/${Resource.id}`)).toBe(true);
+      expect(instance.errorEvent.emit).toHaveBeenCalledWith({
+        message: 'ohnoes',
+        resourceLabel: 'test',
+        resourceId: Resource.id,
+      });
+    });
+  });
+});

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
@@ -9,13 +9,13 @@ import { Marketplace } from '../../types/marketplace';
 
 interface SuccessMessage {
   message: string;
-  resourceLabel: string;
+  resourceName: string;
   resourceId: string;
 }
 
 interface ErrorMessage {
   message: string;
-  resourceLabel: string;
+  resourceName: string;
   resourceId: string;
 }
 
@@ -27,7 +27,7 @@ export class ManifoldDataDeprovisionButton {
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() authToken?: string;
   /** The label of the resource to deprovision */
-  @Prop() resourceLabel?: string;
+  @Prop() resourceName?: string;
   @Prop({ mutable: true }) resourceId?: string = '';
   @Prop() loading?: boolean = false;
   @Event({ eventName: 'manifold-deprovisionButton-click', bubbles: true })
@@ -36,15 +36,15 @@ export class ManifoldDataDeprovisionButton {
   @Event({ eventName: 'manifold-provisionButton-success', bubbles: true })
   successEvent: EventEmitter;
 
-  @Watch('resourceLabel') labelChange(newLabel: string) {
+  @Watch('resourceName') nameChange(newName: string) {
     if (!this.resourceId) {
-      this.fetchResourceId(newLabel);
+      this.fetchResourceId(newName);
     }
   }
 
   componentWillLoad() {
-    if (this.resourceLabel && !this.resourceId) {
-      this.fetchResourceId(this.resourceLabel);
+    if (this.resourceName && !this.resourceId) {
+      this.fetchResourceId(this.resourceName);
     }
   }
 
@@ -57,7 +57,7 @@ export class ManifoldDataDeprovisionButton {
     // We use Gateway b/c it’s much easier to provision w/o generating a base32 ID
     this.clickEvent.emit({
       resourceId: this.resourceId,
-      resourceLabel: this.resourceLabel || '',
+      resourceName: this.resourceName || '',
     });
 
     const response = await fetch(
@@ -70,8 +70,8 @@ export class ManifoldDataDeprovisionButton {
     // If successful, this will return 200 and stop here
     if (response.status >= 200 && response.status < 300) {
       const success: SuccessMessage = {
-        message: `${this.resourceLabel} successfully deprovisioned`,
-        resourceLabel: this.resourceLabel || '',
+        message: `${this.resourceName} successfully deprovisioned`,
+        resourceName: this.resourceName || '',
         resourceId: this.resourceId,
       };
       this.successEvent.emit(success);
@@ -82,22 +82,22 @@ export class ManifoldDataDeprovisionButton {
       const message = Array.isArray(body) ? body[0].message : body.message;
       const error: ErrorMessage = {
         message,
-        resourceLabel: this.resourceLabel || '',
+        resourceName: this.resourceName || '',
         resourceId: this.resourceId,
       };
       this.errorEvent.emit(error);
     }
   }
 
-  async fetchResourceId(resourcelabel: string) {
+  async fetchResourceId(resourceName: string) {
     const resourceResp = await fetch(
-      `${this.connection.marketplace}/resources/?me&label=${resourcelabel}`,
+      `${this.connection.marketplace}/resources/?me&label=${resourceName}`,
       withAuth(this.authToken)
     );
     const resources: Marketplace.Resource[] = await resourceResp.json();
 
     if (!Array.isArray(resources) || !resources.length) {
-      console.error(`${resourcelabel} product not found`);
+      console.error(`${resourceName} product not found`);
       return;
     }
 

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
@@ -1,0 +1,120 @@
+import { h, Component, Prop, Element, Watch, Event, EventEmitter } from '@stencil/core';
+
+import Tunnel from '../../data/connection';
+import { withAuth } from '../../utils/auth';
+import { Connection, connections } from '../../utils/connections';
+import { Marketplace } from '../../types/marketplace';
+
+/* eslint-disable no-console */
+
+interface SuccessMessage {
+  message: string;
+  resourceLabel: string;
+  resourceId: string;
+}
+
+interface ErrorMessage {
+  message: string;
+  resourceLabel: string;
+  resourceId: string;
+}
+
+@Component({ tag: 'manifold-data-deprovision-button' })
+export class ManifoldDataDeprovisionButton {
+  @Element() el: HTMLElement;
+  /** _(hidden)_ Passed by `<manifold-connection>` */
+  @Prop() connection: Connection = connections.prod;
+  /** _(hidden)_ Passed by `<manifold-connection>` */
+  @Prop() authToken?: string;
+  /** The label of the resource to deprovision */
+  @Prop() resourceLabel?: string;
+  @Prop({ mutable: true }) resourceId?: string = '';
+  @Prop() loading?: boolean = false;
+  @Event({ eventName: 'manifold-deprovisionButton-click', bubbles: true })
+  clickEvent: EventEmitter;
+  @Event({ eventName: 'manifold-deprovisionButton-error', bubbles: true }) errorEvent: EventEmitter;
+  @Event({ eventName: 'manifold-provisionButton-success', bubbles: true })
+  successEvent: EventEmitter;
+
+  @Watch('resourceLabel') labelChange(newLabel: string) {
+    if (!this.resourceId) {
+      this.fetchResourceId(newLabel);
+    }
+  }
+
+  componentWillLoad() {
+    if (this.resourceLabel && !this.resourceId) {
+      this.fetchResourceId(this.resourceLabel);
+    }
+  }
+
+  async deprovision() {
+    if (!this.resourceId) {
+      console.error('Property “resourceId” is missing');
+      return;
+    }
+
+    // We use Gateway b/c it’s much easier to provision w/o generating a base32 ID
+    this.clickEvent.emit({
+      resourceId: this.resourceId,
+      resourceLabel: this.resourceLabel || '',
+    });
+
+    const response = await fetch(
+      `${this.connection.gateway}/id/resource/${this.resourceId}`,
+      withAuth(this.authToken, {
+        method: 'DELETE',
+      })
+    );
+
+    // If successful, this will return 200 and stop here
+    if (response.status >= 200 && response.status < 300) {
+      const success: SuccessMessage = {
+        message: `${this.resourceLabel} successfully deprovisioned`,
+        resourceLabel: this.resourceLabel || '',
+        resourceId: this.resourceId,
+      };
+      this.successEvent.emit(success);
+    } else {
+      const body = await response.json();
+
+      // Sometimes messages are an array, sometimes they aren’t. Different strokes!
+      const message = Array.isArray(body) ? body[0].message : body.message;
+      const error: ErrorMessage = {
+        message,
+        resourceLabel: this.resourceLabel || '',
+        resourceId: this.resourceId,
+      };
+      this.errorEvent.emit(error);
+    }
+  }
+
+  async fetchResourceId(resourcelabel: string) {
+    const resourceResp = await fetch(
+      `${this.connection.marketplace}/resources/?me&label=${resourcelabel}`,
+      withAuth(this.authToken)
+    );
+    const resources: Marketplace.Resource[] = await resourceResp.json();
+
+    if (!Array.isArray(resources) || !resources.length) {
+      console.error(`${resourcelabel} product not found`);
+      return;
+    }
+
+    this.resourceId = resources[0].id;
+  }
+
+  render() {
+    return (
+      <button
+        type="submit"
+        onClick={() => this.deprovision()}
+        disabled={!this.resourceId && !this.loading}
+      >
+        <slot />
+      </button>
+    );
+  }
+}
+
+Tunnel.injectProps(ManifoldDataDeprovisionButton, ['connection', 'authToken']);

--- a/src/components/manifold-resource-deprovision/manifold-resource-deprovision.tsx
+++ b/src/components/manifold-resource-deprovision/manifold-resource-deprovision.tsx
@@ -7,14 +7,12 @@ export class ManifoldResourceDeprovision {
   render() {
     return (
       <ResourceTunnel.Consumer>
-        {(state: ResourceState) => state.loading && state.data ? (
-          <manifold-data-deprovision-button resourceId={state.data.id} resourceName={state.data.label}>
-            <manifold-forward-slot>
-              <slot />
-            </manifold-forward-slot>
-          </manifold-data-deprovision-button>
-        ) : (
-          <manifold-data-deprovision-button loading={true}>
+        {(state: ResourceState) => (
+          <manifold-data-deprovision-button
+            resourceId={state.data && state.data.id}
+            resourceName={state.data && state.data.label}
+            loading={state.loading}
+          >
             <manifold-forward-slot>
               <slot />
             </manifold-forward-slot>

--- a/src/components/manifold-resource-deprovision/manifold-resource-deprovision.tsx
+++ b/src/components/manifold-resource-deprovision/manifold-resource-deprovision.tsx
@@ -1,0 +1,26 @@
+import { h, Component } from '@stencil/core';
+
+import ResourceTunnel, { ResourceState } from '../../data/resource';
+
+@Component({ tag: 'manifold-resource-deprovision' })
+export class ManifoldResourceDeprovision {
+  render() {
+    return (
+      <ResourceTunnel.Consumer>
+        {(state: ResourceState) => state.loading && state.data ? (
+          <manifold-data-deprovision-button resourceId={state.data.id} resourceLabel={state.data.label}>
+            <manifold-forward-slot>
+              <slot />
+            </manifold-forward-slot>
+          </manifold-data-deprovision-button>
+        ) : (
+          <manifold-data-deprovision-button loading={true}>
+            <manifold-forward-slot>
+              <slot />
+            </manifold-forward-slot>
+          </manifold-data-deprovision-button>
+        )}
+      </ResourceTunnel.Consumer>
+    );
+  }
+}

--- a/src/components/manifold-resource-deprovision/manifold-resource-deprovision.tsx
+++ b/src/components/manifold-resource-deprovision/manifold-resource-deprovision.tsx
@@ -8,7 +8,7 @@ export class ManifoldResourceDeprovision {
     return (
       <ResourceTunnel.Consumer>
         {(state: ResourceState) => state.loading && state.data ? (
-          <manifold-data-deprovision-button resourceId={state.data.id} resourceLabel={state.data.label}>
+          <manifold-data-deprovision-button resourceId={state.data.id} resourceName={state.data.label}>
             <manifold-forward-slot>
               <slot />
             </manifold-forward-slot>

--- a/stories/manifold-data-deprovision-button.stories.js
+++ b/stories/manifold-data-deprovision-button.stories.js
@@ -6,7 +6,7 @@ storiesOf('Provision Button [Data]', module)
   .add(
     'default',
     () => `
-      <manifold-data-provision-button resource-label="my-resource">
+      <manifold-data-provision-button resource-name="my-resource">
         Deprovision resource
       </manifold-data-provision-button>
     `

--- a/stories/manifold-data-deprovision-button.stories.js
+++ b/stories/manifold-data-deprovision-button.stories.js
@@ -1,0 +1,13 @@
+import { storiesOf } from '@storybook/html';
+import markdown from '../docs/docs/data/manifold-data-deprovision-button.md';
+
+storiesOf('Provision Button [Data]', module)
+  .addParameters({ readme: { sidebar: markdown } })
+  .add(
+    'default',
+    () => `
+      <manifold-data-provision-button resource-label="my-resource">
+        Deprovision resource
+      </manifold-data-provision-button>
+    `
+  );


### PR DESCRIPTION
Work is related to manifoldco/engineering#8688

## Reason for change
This adds a deprovision button based on the code for the provision button. This button can be used standalone and will fetch the resource id if not provided, or as a `manifold-resource-deprovision` component that will get it's data from the `resource-container` component.

## Testing
Test with storybook
