### PR TITLE
Update the resource status component

### DIFF
--- a/docs/docs/components/manifold-resource-status.md
+++ b/docs/docs/components/manifold-resource-status.md
@@ -1,9 +1,41 @@
 ---
 title: '🔒 Resource Status'
 path: '/components/resource-status'
-example: '<manifold-resource-container resource-name="my-resource"><manifold-resource-status></manifold-resource-status></manifold-resource-container>'
+example: '<manifold-mock-resource><manifold-resource-status></manifold-resource-status></manifold-mock-resource>'
 ---
 
 # 🔒 Resource Status
 
 Displays the current availability of the resource. 🔒 Requires authentication.
+
+```html
+  <manifold-resource-status state="available"></manifold-resource-product>
+```
+
+## Resource states
+
+You can use one of the four available resource states to display various statuses.
+
+```html
+  <manifold-resource-status state="available"></manifold-resource-product>
+  <manifold-resource-status state="provision"></manifold-resource-product>
+  <manifold-resource-status state="degraded"></manifold-resource-product>
+  <manifold-resource-status state="offline"></manifold-resource-product>
+```
+
+## Different sizes
+
+The component is available in two diffrent sizes, `small` and `medium`. Use the `size` attribute to set the component size.
+
+```html
+  <manifold-resource-status size="small" state="available"></manifold-resource-product>
+```
+
+## Loading
+
+The component can be set to a loading state.
+
+```html
+  <manifold-resource-status loading=""></manifold-resource-product>
+```
+

--- a/docs/docs/components/manifold-resource-status.md
+++ b/docs/docs/components/manifold-resource-status.md
@@ -9,7 +9,7 @@ example: '<manifold-mock-resource><manifold-resource-status></manifold-resource-
 Displays the current availability of the resource. 🔒 Requires authentication.
 
 ```html
-  <manifold-resource-status state="available"></manifold-resource-product>
+  <manifold-resource-status-view state="available"></manifold-resource-product>
 ```
 
 ## Resource states
@@ -17,18 +17,18 @@ Displays the current availability of the resource. 🔒 Requires authentication.
 You can use one of the four available resource states to display various statuses.
 
 ```html
-  <manifold-resource-status state="available"></manifold-resource-product>
-  <manifold-resource-status state="provision"></manifold-resource-product>
-  <manifold-resource-status state="degraded"></manifold-resource-product>
-  <manifold-resource-status state="offline"></manifold-resource-product>
+  <manifold-resource-status-view state="available"></manifold-resource-product>
+  <manifold-resource-status-view state="provision"></manifold-resource-product>
+  <manifold-resource-status-view state="degraded"></manifold-resource-product>
+  <manifold-resource-status-view state="offline"></manifold-resource-product>
 ```
 
 ## Different sizes
 
-The component is available in two diffrent sizes, `small` and `medium`. Use the `size` attribute to set the component size.
+The component is available in two different sizes, `small` and `medium`. Use the `size` attribute to set the component size.
 
 ```html
-  <manifold-resource-status size="small" state="available"></manifold-resource-product>
+  <manifold-resource-status-view size="small" state="available"></manifold-resource-product>
 ```
 
 ## Loading
@@ -36,6 +36,6 @@ The component is available in two diffrent sizes, `small` and `medium`. Use the 
 The component can be set to a loading state.
 
 ```html
-  <manifold-resource-status loading=""></manifold-resource-product>
+  <manifold-resource-status-view loading=""></manifold-resource-product>
 ```
 

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -468,9 +468,13 @@ export namespace Components {
   interface ManifoldResourceProduct {
     'asCard'?: boolean;
   }
-  interface ManifoldResourceStatus {}
+  interface ManifoldResourceStatus {
+    'size'?: 'small' | 'medium';
+  }
   interface ManifoldResourceStatusView {
-    'resourceState': ResourceState;
+    'loading'?: boolean;
+    'resourceState'?: string;
+    'size'?: 'small' | 'medium';
   }
   interface ManifoldSelect {
     'defaultValue'?: string;
@@ -1361,9 +1365,13 @@ declare namespace LocalJSX {
   interface ManifoldResourceProduct extends JSXBase.HTMLAttributes<HTMLManifoldResourceProductElement> {
     'asCard'?: boolean;
   }
-  interface ManifoldResourceStatus extends JSXBase.HTMLAttributes<HTMLManifoldResourceStatusElement> {}
+  interface ManifoldResourceStatus extends JSXBase.HTMLAttributes<HTMLManifoldResourceStatusElement> {
+    'size'?: 'small' | 'medium';
+  }
   interface ManifoldResourceStatusView extends JSXBase.HTMLAttributes<HTMLManifoldResourceStatusViewElement> {
-    'resourceState'?: ResourceState;
+    'loading'?: boolean;
+    'resourceState'?: string;
+    'size'?: 'small' | 'medium';
   }
   interface ManifoldSelect extends JSXBase.HTMLAttributes<HTMLManifoldSelectElement> {
     'defaultValue'?: string;

--- a/src/components/manifold-resource-status-view/manifold-resource-status-view-happo.tsx
+++ b/src/components/manifold-resource-status-view/manifold-resource-status-view-happo.tsx
@@ -1,9 +1,16 @@
-import resource from '../../spec/mock/cms-stage/resource.json';
-import fromJSON from '../../spec/mock/fromJSON';
-
 export const available = () => {
   const status = document.createElement('manifold-resource-status-view');
-  status.resourceState = { loading: false, data: fromJSON(resource) };
+  status.resourceState = 'available';
+
+  document.body.appendChild(status);
+
+  return status.componentOnReady();
+};
+
+export const availableSmall = () => {
+  const status = document.createElement('manifold-resource-status-view');
+  status.resourceState = 'available';
+  status.size = 'small';
 
   document.body.appendChild(status);
 
@@ -12,7 +19,6 @@ export const available = () => {
 
 export const offline = () => {
   const status = document.createElement('manifold-resource-status-view');
-  status.resourceState = { loading: false, data: undefined };
 
   document.body.appendChild(status);
 
@@ -21,7 +27,7 @@ export const offline = () => {
 
 export const resourceLoading = () => {
   const status = document.createElement('manifold-resource-status-view');
-  status.resourceState = { loading: true, data: undefined };
+  status.loading = true;
 
   document.body.appendChild(status);
 

--- a/src/components/manifold-resource-status-view/manifold-resource-status-view.css
+++ b/src/components/manifold-resource-status-view/manifold-resource-status-view.css
@@ -3,43 +3,6 @@
   font-family: var(--manifold-font-family);
 }
 
-.status {
-  --status-color: var(--manifold-color-success);
-
-  &[data-status='PROVISIONING'] {
-    --status-color: var(--manifold-color-info);
-  }
-
-  &[data-status='DEGRADED'] {
-    --status-color: var(--manifold-color-warn);
-  }
-
-  &[data-status='OFFLINE'] {
-    --status-color: var(--manifold-color-error);
-  }
-
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  height: 2.75rem;
-  padding-right: 1.5rem;
-  padding-left: 1rem;
-  overflow: hidden;
-  color: var(--manifold-grayscale-60);
-  border-radius: var(--manifold-tag-radius, var(--manifold-radius));
-
-  &::before {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    background: var(--status-color);
-    opacity: 0.1;
-    content: '';
-  }
-}
-
 .inner {
   position: relative;
   z-index: 2;
@@ -53,6 +16,55 @@
     margin-right: 0.5rem;
     background: var(--status-color);
     border-radius: 50%;
+    content: '';
+  }
+}
+
+.status {
+  --status-color: var(--manifold-color-success);
+
+  &[data-status='provision'] {
+    --status-color: var(--manifold-color-info);
+  }
+
+  &[data-status='degraded'] {
+    --status-color: var(--manifold-color-warn);
+  }
+
+  &[data-status='offline'] {
+    --status-color: var(--manifold-color-error);
+  }
+
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  height: 2.75rem;
+  padding-right: 1.5rem;
+  padding-left: 1rem;
+  overflow: hidden;
+  color: var(--manifold-grayscale-60);
+  border-radius: var(--manifold-tag-radius, var(--manifold-radius));
+
+  &[data-size='small'] {
+    height: 1.325rem;
+    padding-right: 0.75rem;
+    padding-left: 0.5rem;
+    font-size: var(--manifold-font-d1);
+
+    & .inner::before {
+        width: 0.5rem;
+        height: 0.5rem;
+    }
+  }
+
+  &::before {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background: var(--status-color);
+    opacity: 0.1;
     content: '';
   }
 }
@@ -81,5 +93,17 @@
     animation-duration: 1s;
     animation-timing-function: linear;
     animation-iteration-count: infinite;
+  }
+
+  &[data-size='small'] {
+    height: 1.325rem;
+    padding-right: 0.75rem;
+    padding-left: 0.5rem;
+    font-size: var(--manifold-font-d1);
+
+    & manifold-icon {
+        width: 0.5rem;
+        height: 0.5rem;
+    }
   }
 }

--- a/src/components/manifold-resource-status-view/manifold-resource-status-view.tsx
+++ b/src/components/manifold-resource-status-view/manifold-resource-status-view.tsx
@@ -1,42 +1,46 @@
 import { h, Component, Prop } from '@stencil/core';
 import { refresh_cw } from '@manifoldco/icons';
 
-import { ResourceState } from '../../data/resource';
+const AVAILABLE = 'available';
+const OFFLINE = 'offline';
+const PROVISIONING = 'provision';
+const DEGRADED = 'degraded';
 
-const AVAILABLE = 'AVAILABLE';
-const OFFLINE = 'OFFLINE';
-
-const message = {
+const message: {[s: string]: string} = {
   [AVAILABLE]: 'Available',
   [OFFLINE]: 'Offline',
+  [PROVISIONING]: 'Provision',
+  [DEGRADED]: 'Degraded',
 };
 
 @Component({
   tag: 'manifold-resource-status-view',
-  styleUrl: 'style.css',
+  styleUrl: 'manifold-resource-status-view.css',
   shadow: true,
 })
 export class ManifoldResourceStatusView {
-  @Prop() resourceState: ResourceState = { loading: false, data: undefined };
+  @Prop() loading?: boolean = false;
+  @Prop() resourceState?: string = OFFLINE;
+  @Prop() size?: 'small' | 'medium' = 'medium';
 
   status(resourceState = this.resourceState) {
-    if (resourceState.data) {
-      return AVAILABLE;
+    if (resourceState && message[resourceState]) {
+      return resourceState;
     }
     return OFFLINE;
   }
 
   statusMessage(resourceState = this.resourceState) {
-    if (resourceState.data) {
-      return message[AVAILABLE];
+    if (resourceState && message[resourceState]) {
+      return message[resourceState];
     }
     return message[OFFLINE];
   }
 
   render() {
-    if (this.resourceState.loading) {
+    if (this.loading) {
       return (
-        <div class="loading" data-status={this.status(this.resourceState)}>
+        <div class="loading" data-size={this.size} data-status={this.status(this.resourceState)}>
           <manifold-icon icon={refresh_cw} />
           Loading
         </div>
@@ -44,7 +48,7 @@ export class ManifoldResourceStatusView {
     }
 
     return (
-      <div class="status" data-status={this.status(this.resourceState)}>
+      <div class="status" data-size={this.size}  data-status={this.status(this.resourceState)}>
         <div class="inner">{this.statusMessage(this.resourceState)}</div>
       </div>
     );

--- a/src/components/manifold-resource-status/manifold-resource-status.tsx
+++ b/src/components/manifold-resource-status/manifold-resource-status.tsx
@@ -1,13 +1,21 @@
-import { h, Component } from '@stencil/core';
+import { h, Component, Prop } from '@stencil/core';
 
 import Tunnel, { ResourceState } from '../../data/resource';
 
 @Component({ tag: 'manifold-resource-status' })
 export class ManifoldResourceStatus {
+  @Prop() size?: 'small' | 'medium' = 'medium';
+
   render() {
     return (
       <Tunnel.Consumer>
-        {(state: ResourceState) => <manifold-resource-status-view resourceState={state} />}
+        {(state: ResourceState) => (
+          <manifold-resource-status-view
+            size={this.size}
+            resourceState={state.data && (state.data.state as string)}
+            loading={state.loading}
+          />
+        )}
       </Tunnel.Consumer>
     );
   }

--- a/stories/manifold-resource-status.stories.js
+++ b/stories/manifold-resource-status.stories.js
@@ -1,12 +1,15 @@
 import { storiesOf } from '@storybook/html';
 import markdown from '../docs/docs/components/manifold-resource-status.md';
 
-const view = `
-  <manifold-resource-container resource-name="my-resource">
-    <manifold-resource-status></manifold-resource-status>
-  </manifold-resource-container>
-`;
-
 storiesOf('Resource Status 🔒', module)
   .addParameters({ readme: { sidebar: markdown } })
-  .add('default', () => view);
+  .add('default', () => `
+    <manifold-mock-resource>
+      <manifold-resource-status></manifold-resource-status>
+    </manifold-mock-resource>
+  `)
+  .add('small tag', () => `
+    <manifold-mock-resource>
+      <manifold-resource-status size="small"></manifold-resource-status>
+    </manifold-mock-resource>
+  `);


### PR DESCRIPTION
Work is related to manifoldco/engineerging#8700

## Reason for change
This component can now be resized using the `size` attribute on the component. We also now use specific props to make the `view` version of the component more standalone.

As a follow up, it would be great to have a `resource-status` component that can fetch its own data.

## Testing
Test on storybook
