### PR TITLE
Refactor resource name to resource label for clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Deprecated
+- Deprecated the `resource-name` attribute in all the resource components for `resource-label` as to be more consistent with the other components and our other codebases.
+
+### Added
+- New `manifold-resource-product` and `manifold-resource-plan` component to load a resource's product and plan card.
+- New `manifold-data-deprovision-button` component that allows to deprovision a resource.
+- New `manifold-data-rename-button` component that allows to rename a resource.
+- New `manifold-credentials` component that allows to see a resource's credentials without needing to be in a `resource-container`.
+- New `manifold-mock-resource` component that allows to mock a `resource-container` with a fake resource.
+
+### Changed
+- Changed the input from the `manifold-data-provision-button` to remove the input make it a pure button.
+- Changed the `manifold-resource-status` component to now display in two different sizes.
+- Changed the `manifold-resource-credentials` component to use the standalone `manifold-credentials` component.
+
+[0.3.0]: https://github.com/manifoldco/ui/compare/v0.2.1...v0.3.0
+[0.2.2]: https://github.com/manifoldco/ui/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/manifoldco/ui/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/manifoldco/ui/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/manifoldco/ui/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/manifoldco/ui/compare/v0.0.2...v0.1.0
+[0.1.0]: https://github.com/manifoldco/ui/compare/v0.0.2...v0.1.0
+[0.0.3]: https://github.com/manifoldco/ui/releases/tag/v0.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 - Deprecated the `resource-name` attribute in all the resource components for `resource-label` as to be more consistent with the other components and our other codebases.
 
+## [0.3.1]
 ### Added
 - New `manifold-resource-product` and `manifold-resource-plan` component to load a resource's product and plan card.
 - New `manifold-data-deprovision-button` component that allows to deprovision a resource.

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -1,0 +1,35 @@
+---
+title: Changelog
+path: /changelog
+---
+
+# Changelog
+All notable changes to this project will be documented in this page.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Deprecated
+- Deprecated the `resource-name` attribute in all the resource components for `resource-label` as to be more consistent with the other components and our other codebases.
+
+### Added
+- New `manifold-resource-product` and `manifold-resource-plan` component to load a resource's product and plan card.
+- New `manifold-data-deprovision-button` component that allows to deprovision a resource.
+- New `manifold-data-rename-button` component that allows to rename a resource.
+- New `manifold-credentials` component that allows to see a resource's credentials without needing to be in a `resource-container`.
+- New `manifold-mock-resource` component that allows to mock a `resource-container` with a fake resource.
+
+### Changed
+- Changed the input from the `manifold-data-provision-button` to remove the input make it a pure button.
+- Changed the `manifold-resource-status` component to now display in two different sizes.
+- Changed the `manifold-resource-credentials` component to use the standalone `manifold-credentials` component.
+
+[0.3.0]: https://github.com/manifoldco/ui/compare/v0.2.1...v0.3.0
+[0.2.2]: https://github.com/manifoldco/ui/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/manifoldco/ui/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/manifoldco/ui/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/manifoldco/ui/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/manifoldco/ui/compare/v0.0.2...v0.1.0
+[0.1.0]: https://github.com/manifoldco/ui/compare/v0.0.2...v0.1.0
+[0.0.3]: https://github.com/manifoldco/ui/releases/tag/v0.0.3

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -4,7 +4,7 @@ path: /changelog
 ---
 
 # Changelog
-All notable changes to this project will be documented in this page.
+All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 - Deprecated the `resource-name` attribute in all the resource components for `resource-label` as to be more consistent with the other components and our other codebases.
 
+## [0.3.1]
 ### Added
 - New `manifold-resource-product` and `manifold-resource-plan` component to load a resource's product and plan card.
 - New `manifold-data-deprovision-button` component that allows to deprovision a resource.
@@ -33,3 +34,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.1.0]: https://github.com/manifoldco/ui/compare/v0.0.2...v0.1.0
 [0.1.0]: https://github.com/manifoldco/ui/compare/v0.0.2...v0.1.0
 [0.0.3]: https://github.com/manifoldco/ui/releases/tag/v0.0.3
+

--- a/docs/docs/components/manifold-credentials.md
+++ b/docs/docs/components/manifold-credentials.md
@@ -1,0 +1,16 @@
+---
+title: '🔒 Resource Credentials'
+path: '/components/credentials'
+example: '<manifold-credentials resource-name="cms-stage"></manifold-credentials>'
+---
+
+# 🔒 Credentials
+
+Display credentials for a resource. 🔒 Requires authentication.
+
+The resource label needs to be provided for the component to be able to fetch the resource's credentials on demand.
+
+```html
+<manifold-credentials resource-name="my-resource"></manifold-credentials>
+```
+

--- a/docs/docs/components/manifold-credentials.md
+++ b/docs/docs/components/manifold-credentials.md
@@ -11,6 +11,6 @@ Display credentials for a resource. 🔒 Requires authentication.
 The resource label needs to be provided for the component to be able to fetch the resource's credentials on demand.
 
 ```html
-<manifold-credentials resource-name="my-resource"></manifold-credentials>
+<manifold-credentials resource-label="my-resource"></manifold-credentials>
 ```
 

--- a/docs/docs/components/manifold-resource-card.md
+++ b/docs/docs/components/manifold-resource-card.md
@@ -2,7 +2,7 @@
 title: '🔒 Resource Card'
 path: '/components/manifold-resource-card'
 example: |
-  <manifold-resource-card-view label="my-resource" logo="https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png" resource-id="1234" resource-status="available" />
+  <manifold-resource-card-view label="my-resource" name="my resource" logo="https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png" resource-id="1234" resource-status="available" />
 ---
 
 # 🔒 Resource Card
@@ -65,6 +65,7 @@ The underlying `<manifold-resource-card-view />` component may be used to displa
 ```html
 <manifold-resource-card-view
   label="my-resource"
+  name="my resource"
   logo="http://logo.png"
   resource-id="123456"
   resource-status="available"
@@ -84,6 +85,7 @@ The `<manifold-resource-card-view />` can display a loading status rather than t
 ```html
 <manifold-resource-card-view
   label="my-resource"
+  name="my resource"
   logo="http://logo.png"
   resource-id="123456"
   resource-status="unknown"

--- a/docs/docs/components/manifold-resource-credentials.md
+++ b/docs/docs/components/manifold-resource-credentials.md
@@ -1,9 +1,0 @@
----
-title: '🔒 Resource Credentials'
-path: '/components/resource-credentials'
-example: '<manifold-resource-credentials></manifold-resource-credentials>'
----
-
-# 🔒 Credentials
-
-Display credentials for a resource. 🔒 Requires authentication.

--- a/docs/docs/components/manifold-resource-list.md
+++ b/docs/docs/components/manifold-resource-list.md
@@ -28,6 +28,10 @@ example: |
   </manifold-connection>
 ---
 
+<manifold-toast alert-type="warning">
+  <div><code>resource-name</code> has been deprecated in favor of <code>resource-label</code> starting in version 0.4.0.</div>
+</manifold-toast>
+
 # 🔒 Resource List
 
 Creates a list of resource cards that lists all the resources the user owns directly.

--- a/docs/docs/components/manifold-resource-plan.md
+++ b/docs/docs/components/manifold-resource-plan.md
@@ -7,12 +7,16 @@ example: |
   </manifold-mock-resource>
 ---
 
+<manifold-toast alert-type="warning">
+  <div><code>resource-name</code> has been deprecated in favor of <code>resource-label</code> starting in version 0.4.0.</div>
+</manifold-toast>
+
 # 🔒 Resource Plan
 
 View of a resource's plan overview. 🔒 Requires authentication and needs to be wrapped inside a `resource-container`.
 
 ```html
-  <manifold-resource-container resource-name="my-resource">
+  <manifold-resource-container resource-label="my-resource">
     <manifold-resource-plan></manifold-resource-plan>
   </manifold-resource-container>
 ```

--- a/docs/docs/components/manifold-resource-product.md
+++ b/docs/docs/components/manifold-resource-product.md
@@ -7,12 +7,16 @@ example: |
   </manifold-mock-resource>
 ---
 
+<manifold-toast alert-type="warning">
+  <div><code>resource-name</code> has been deprecated in favor of <code>resource-label</code> starting in version 0.4.0.</div>
+</manifold-toast>
+
 # 🔒 Resource Product
 
 View of a resource's product card. 🔒 Requires authentication and needs to be wrapped inside a `resource-container`.
 
 ```html
-  <manifold-resource-container resource-name="my-resource">
+  <manifold-resource-container resource-label="my-resource">
     <manifold-resource-product></manifold-resource-product>
   </manifold-resource-container>
 ```
@@ -23,7 +27,7 @@ The product view is rendered as a wrapper by default. Using the `as-card` attrib
 as a card, similar to how it is displayed on the marketplace.
 
 ```html
-  <manifold-resource-container resource-name="my-resource">
+  <manifold-resource-container resource-label="my-resource">
     <manifold-resource-product as-card=""></manifold-resource-product>
   </manifold-resource-container>
 ```

--- a/docs/docs/components/manifold-resource-status.md
+++ b/docs/docs/components/manifold-resource-status.md
@@ -1,12 +1,12 @@
 ---
-title: '🔒 Resource Status'
+title: 'Resource Status'
 path: '/components/resource-status'
 example: '<manifold-mock-resource><manifold-resource-status></manifold-resource-status></manifold-mock-resource>'
 ---
 
-# 🔒 Resource Status
+# Resource Status
 
-Displays the current availability of the resource. 🔒 Requires authentication.
+Displays an availability tag for a resource. Can be used standalone without any data fetching.
 
 ```html
   <manifold-resource-status-view state="available"></manifold-resource-product>

--- a/docs/docs/data/manifold-data-deprovision-button.md
+++ b/docs/docs/data/manifold-data-deprovision-button.md
@@ -16,7 +16,7 @@ An unstyled button for deprovisioning resources. 🔒 Requires authentication.
 Set the CTA text by adding anything between the opening and closing tags:
 
 ```html
-<manifold-data-deprovision-button>
+<manifold-data-deprovision-button resource-label="my-resource">
   Deprovision My Resource
 </manifold-data-provision-button>
 ```
@@ -28,22 +28,22 @@ Set the CTA text by adding anything between the opening and closing tags:
 For validation, error, and success messages, it will emit custom events.
 
 ```js
-document.addEventListener('manifold-deprovisionButton-click', ({ detail: { resourceName } }) =>
-  console.info(`⌛ Derovisioning ${resourceName} …`)
+document.addEventListener('manifold-deprovisionButton-click', ({ detail: { resourceLabel } }) =>
+  console.info(`⌛ Derovisioning ${resourceLabel} …`)
 );
 document.addEventListener(
   'manifold-deprovisionButton-success',
-  ({ details: { resourceName } }) =>alert(`${resourceName} deprovisioned successfully!`)
+  ({ details: { resourceLabel } }) =>alert(`${resourceLabel} deprovisioned successfully!`)
 );
 document.addEventListener('manifold-deprovisionButton-error', ({ detail }) => console.log(detail));
-// {message: "bad_request: bad_request: No plan_id provided", resourceid: "1234", resourceName: "my-resource"}
+// {message: "bad_request: bad_request: No plan_id provided", resourceid: "1234", resourceLabel: "my-resource"}
 ```
 
 | Name                               |                       Returns                        | Description                                                                                                                 |
 | :--------------------------------- | :--------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------- |
-| `manifold-deprovisionButton-click`   |                    `resourceName`                   | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
-| `manifold-deprovisionButton-success` |     `message`, `resourceId`, `resourceName`         | Successful deprovision. Returns a resource ID and resource Label.                                                                              |
-| `manifold-deprovisionButton-error`   |     `message`, `resourceId`, `resourceName`         | Erred provision, along with information on what went wrong.                                                                 |
+| `manifold-deprovisionButton-click`   |                    `resourceLabel`                 | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
+| `manifold-deprovisionButton-success` |     `message`, `resourceId`, `resourceLabel`       | Successful deprovision. Returns a resource ID and resource Label.                                                                              |
+| `manifold-deprovisionButton-error`   |     `message`, `resourceId`, `resourceLabel`       | Erred provision, along with information on what went wrong.                                                                 |
 
 ## Styling
 

--- a/docs/docs/data/manifold-data-deprovision-button.md
+++ b/docs/docs/data/manifold-data-deprovision-button.md
@@ -33,7 +33,7 @@ document.addEventListener('manifold-deprovisionButton-click', ({ detail: { resou
 );
 document.addEventListener(
   'manifold-deprovisionButton-success',
-  ({ details: { resourceLabel } }) =>alert(`${resourceLabel} deprovisioned successfully!`)
+  ({ detail: { resourceLabel } }) =>alert(`${resourceLabel} deprovisioned successfully!`)
 );
 document.addEventListener('manifold-deprovisionButton-error', ({ detail }) => console.log(detail));
 // {message: "bad_request: bad_request: No plan_id provided", resourceid: "1234", resourceLabel: "my-resource"}

--- a/docs/docs/data/manifold-data-manage-button.md
+++ b/docs/docs/data/manifold-data-manage-button.md
@@ -2,7 +2,7 @@
 title: 🔒 Manage Button
 path: /data/manage-button
 example: |
-  <manifold-data-manage-button resource-name="my-resource">
+  <manifold-data-manage-button resource-label="my-resource">
     💾 Save
   </manifold-data-manage-button>
 ---
@@ -17,22 +17,20 @@ authentication.
 For loading, error and success messages, it will emit custom events.
 
 ```js
-document.addEventListener('manifold-manageButton-click', ({ detail: { resourceName } }) =>
-  console.info(`⌛ Provisioning ${resourceName} …`)
+document.addEventListener('manifold-manageButton-click', ({ detail: { resourceLabel } }) =>
+  console.info(`⌛ Provisioning ${resourceLabel} …`)
 );
 document.addEventListener(
   'manifold-manageButton-success',
-  ({ detail: { createdAt, resourceName } }) =>
-    alert(`🚀 ${resourceName} provisioned successfully on ${createdAt}!`)
+  ({ detail: { resourceLabel } }) =>
+    alert(`🚀 ${resourceName} resized successfully!`)
 );
 document.addEventListener('manifold-manageButton-error', ({ detail }) => console.log(detail));
-// {message: "bad_request: bad_request: No plan_id provided", resourceName: "auauau"}
-document.addEventListener('manifold-manageButton-invalid', ({ detail }) => console.log(detail));
-// {resourceName: "MyResourceName", message: "Must start with a lowercase letter, and use only lowercase, numbers, and hyphens."}
+// {message: "bad_request: bad_request: No plan_id provided", resourceLabel: "auauau"}
 ```
 
-| Name                            |             Returns             | Description                                                                                                                 |
-| :------------------------------ | :-----------------------------: | :-------------------------------------------------------------------------------------------------------------------------- |
-| `manifold-manageButton-click`   |            `planId`             | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
-| `manifold-manageButton-success` | `message`, `planId`, `features` | Successful change. Returns plan name.                                                                                       |
-| `manifold-manageButton-error`   | `message`, `planId`, `features` | Erred change, along with information on what went wrong.                                                                    |
+| Name                            |             Returns                                            | Description                                                                                                                 |
+| :------------------------------ | :------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------- |
+| `manifold-manageButton-click`   |            `planId`, `resourceId`, `resourceLabel`             | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
+| `manifold-manageButton-success` | `message`, `planId`, `features`, `resourceId`, `resourceLabel` | Successful change with information on what was changed.                                                                                     |
+| `manifold-manageButton-error`   | `message`, `planId`, `features`, `resourceId`, `resourceLabel` | Erred change, along with information on what went wrong.                                                                    |

--- a/docs/docs/data/manifold-data-product-logo.md
+++ b/docs/docs/data/manifold-data-product-logo.md
@@ -6,6 +6,10 @@ example: |
   </manifold-data-product-logo>
 ---
 
+<manifold-toast alert-type="warning">
+  <div><code>resource-name</code> has been deprecated in favor of <code>resource-label</code> starting in version 0.4.0.</div>
+</manifold-toast>
+
 # Data Product Logo
 
 Retrieve an unstyled `<img>` tag with the product’s logo from a

--- a/docs/docs/data/manifold-data-product-logo.md
+++ b/docs/docs/data/manifold-data-product-logo.md
@@ -29,8 +29,8 @@ can override this by specifying one of your own:
 
 ## Resource Name
 
-You can look up a logo by resource name by passing `resource-name`:
+You can look up a logo by resource name by passing `resource-label`:
 
 ```html
-<manifold-data-product-logo resource-name="my-resource" />
+<manifold-data-product-logo resource-label="my-resource" />
 ```

--- a/docs/docs/data/manifold-data-product-name.md
+++ b/docs/docs/data/manifold-data-product-name.md
@@ -6,6 +6,10 @@ example: |
   </manifold-data-product-name>
 ---
 
+<manifold-toast alert-type="warning">
+  <div><code>resource-name</code> has been deprecated in favor of <code>resource-label</code> starting in version 0.4.0.</div>
+</manifold-toast>
+
 # Data Product Name
 
 Retrieve a product’s full name from a `:productLabel` as an unstyled text node.

--- a/docs/docs/data/manifold-data-product-name.md
+++ b/docs/docs/data/manifold-data-product-name.md
@@ -25,8 +25,8 @@ The loading slot supports text as well as HTML elements.
 
 ## Resource Name
 
-You can look up a logo by resource name by passing `resource-name`:
+You can look up a logo by resource label by passing `resource-label`:
 
 ```html
-<manifold-data-product-logo resource-name="my-resource" />
+<manifold-data-product-logo resource-label="my-resource" />
 ```

--- a/docs/docs/data/manifold-data-provision-button.md
+++ b/docs/docs/data/manifold-data-provision-button.md
@@ -9,6 +9,10 @@ example: |
   </manifold-data-provision-button>
 ---
 
+<manifold-toast alert-type="warning">
+  <div><code>resource-name</code> has been deprecated in favor of <code>resource-label</code> starting in version 0.4.0.</div>
+</manifold-toast>
+
 # 🔒 Provision Button
 
 An unstyled button for provisioning resources. 🔒 Requires authentication.

--- a/docs/docs/data/manifold-data-provision-button.md
+++ b/docs/docs/data/manifold-data-provision-button.md
@@ -4,7 +4,7 @@ path: /data/provision-button
 example: |
   <label for="my-provision-button">Resource Name</label>
   <input id="my-provision-button" value="my-resource"></input>
-  <manifold-data-provision-button resource-name="my-resource">
+  <manifold-data-provision-button resource-label="my-resource">
     🚀 Provision Business plan on Prefab.cloud
   </manifold-data-provision-button>
 ---
@@ -21,7 +21,7 @@ selector](#manifold-plan-selector) component. You could do that like so:
 
 ```js
 const userId = ''; // Note: must be set
-const resourceName = ''; // Can be obtained from your own input
+const resourceLabel = ''; // Can be obtained from your own input
 
 function updateButton({ detail: { features, planLabel, productLabel, regionName } }) {
   const provisionButton = document.querySelector('manifold-data-provision-button');
@@ -29,7 +29,7 @@ function updateButton({ detail: { features, planLabel, productLabel, regionName 
   provisionButton.planLabel = planLabel;
   provisionButton.productLabel = productLabel;
   provisionButton.regionName = regionName;
-  provisionButton.resourceName = resourceName;
+  provisionButton.resourceLabel = resourceLabel;
 
   provisionButton.ownerId = userId;
 }
@@ -57,26 +57,26 @@ Set the CTA text by adding anything between the opening and closing tags:
 For validation, error, and success messages, it will emit custom events.
 
 ```js
-document.addEventListener('manifold-provisionButton-click', ({ detail: { resourceName } }) =>
-  console.info(`⌛ Provisioning ${resourceName} …`)
+document.addEventListener('manifold-provisionButton-click', ({ detail: { resourceLabel } }) =>
+  console.info(`⌛ Provisioning ${resourceLabel} …`)
 );
 document.addEventListener(
   'manifold-provisionButton-success',
-  ({ detail: { createdAt, resourceName } }) =>
-    alert(`🚀 ${resourceName} provisioned successfully on ${createdAt}!`)
+  ({ detail: { createdAt, resourceLabel } }) =>
+    alert(`🚀 ${resourceLabel} provisioned successfully on ${createdAt}!`)
 );
 document.addEventListener('manifold-provisionButton-error', ({ detail }) => console.log(detail));
 // {message: "bad_request: bad_request: No plan_id provided", resourceName: "auauau"}
 document.addEventListener('manifold-provisionButton-invalid', ({ detail }) => console.log(detail));
-// {resourceName: "MyResourceName", message: "Must start with a lowercase letter, and use only lowercase, numbers, and hyphens."}
+// {resourceLabel: "MyResourceName", message: "Must start with a lowercase letter, and use only lowercase, numbers, and hyphens."}
 ```
 
-| Name                               |                       Returns                        | Description                                                                                                                 |
-| :--------------------------------- | :--------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------- |
-| `manifold-provisionButton-click`   |                    `resourceName`                    | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
-| `manifold-provisionButton-success` | `message`, `resourceName`, `resourceId`, `createdAt` | Successful provision. Returns name, along with a resource ID                                                                |
-| `manifold-provisionButton-error`   |              `message`, `resourceName`               | Erred provision, along with information on what went wrong.                                                                 |
-| `manifold-provisionButton-invalid` |              `message`, `resourceName`               | Fires if the resource name isn’t named properly.                                                                            |
+| Name                               |                       Returns                         | Description                                                                                                                 |
+| :--------------------------------- | :--------------------------------------------------:  | :-------------------------------------------------------------------------------------------------------------------------- |
+| `manifold-provisionButton-click`   |                    `resourceLabel`                    | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
+| `manifold-provisionButton-success` | `message`, `resourceLabel`, `resourceId`, `createdAt` | Successful provision. Returns name, along with a resource ID                                                                |
+| `manifold-provisionButton-error`   |              `message`, `resourceLabel`               | Erred provision, along with information on what went wrong.                                                                 |
+| `manifold-provisionButton-invalid` |              `message`, `resourceLabel`               | Fires if the resource name isn’t named properly.                                                                            |
 
 ## Styling
 

--- a/docs/docs/data/manifold-data-rename-button.md
+++ b/docs/docs/data/manifold-data-rename-button.md
@@ -33,7 +33,7 @@ document.addEventListener('manifold-renameButton-click', ({ detail: { resourceLa
 );
 document.addEventListener(
   'manifold-renameButton-success',
-  ({ details: { resourceLabel, newLabel } }) =>alert(`${resourceLabel} renamed to ${newLabel} successfully!`)
+  ({ detail: { resourceLabel, newLabel } }) => alert(`${resourceLabel} renamed to ${newLabel} successfully!`)
 );
 document.addEventListener('manifold-renameButton-error', ({ detail }) => console.log(detail));
 // {message: "bad_request: bad_request: No plan_id provided", resourceid: "1234", resourceLabel: "my-resource", newLabel: "new-name"}

--- a/docs/docs/data/manifold-data-rename-button.md
+++ b/docs/docs/data/manifold-data-rename-button.md
@@ -28,25 +28,25 @@ Set the CTA text by adding anything between the opening and closing tags:
 For validation, error, and success messages, it will emit custom events.
 
 ```js
-document.addEventListener('manifold-renameButton-click', ({ detail: { resourceName, newName } }) =>
-  console.info(`⌛ Renaming ${resourceName} to ${newName} …`)
+document.addEventListener('manifold-renameButton-click', ({ detail: { resourceLabel, newLabel } }) =>
+  console.info(`⌛ Renaming ${resourceLabel} to ${newLabel} …`)
 );
 document.addEventListener(
   'manifold-renameButton-success',
-  ({ details: { resourceName, newName } }) =>alert(`${resourceName} renamed to ${newName} successfully!`)
+  ({ details: { resourceLabel, newLabel } }) =>alert(`${resourceLabel} renamed to ${newLabel} successfully!`)
 );
 document.addEventListener('manifold-renameButton-error', ({ detail }) => console.log(detail));
-// {message: "bad_request: bad_request: No plan_id provided", resourceid: "1234", resourceName: "my-resource", newName: "new-name"}
+// {message: "bad_request: bad_request: No plan_id provided", resourceid: "1234", resourceLabel: "my-resource", newLabel: "new-name"}
 document.addEventListener('manifold-renameButton-invalid', ({ detail }) => console.log(detail));
-// {message: "bad_request: bad_request: No plan_id provided", resourceid: "1234", resourceName: "my-resource", newName: "new-name"}
+// {message: "bad_request: bad_request: No plan_id provided", resourceid: "1234", resourceLabel: "my-resource", newLabel: "new-name"}
 ```
 
-| Name                               |                       Returns                        | Description                                                                                                                 |
-| :--------------------------------- | :--------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------- |
-| `manifold-renameButton-click`   |      `resourceId`, `resourceName`, `newName`         | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
-| `manifold-renameButton-success` |  `message`, `resourceId`, `resourceName`, `newName`  | Successful renaming. Returns a resource ID and resource Label as well as a message and the new name for the resource.       |
-| `manifold-renameButton-error`   |  `message`, `resourceId`, `resourceName`, `newName`  | Erred rename, along with information on what went wrong.                                                                    |
-| `manifold-renameButton-error`   |  `message`, `resourceId`, `resourceName`, `newName`  | Invalid renaming, along with information on what went wrong.                                                                |
+| Name                            |                       Returns                            | Description                                                                                                                 |
+| :-------------------------------| :------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------- |
+| `manifold-renameButton-click`   |       `resourceId`, `resourceLabel`, `newLabel`          | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
+| `manifold-renameButton-success` |   `message`, `resourceId`, `resourceLabel`, `newLabel`   | Successful renaming. Returns a resource ID and resource Label as well as a message and the new name for the resource.       |
+| `manifold-renameButton-error`   |   `message`, `resourceId`, `resourceLabel`, `newLabel`   | Erred rename, along with information on what went wrong.                                                                    |
+| `manifold-renameButton-error`   |   `message`, `resourceId`, `resourceLabel`, `newLabel`   | Invalid renaming, along with information on what went wrong.                                                                |
 
 ## Styling
 

--- a/docs/docs/data/manifold-data-resource-list.md
+++ b/docs/docs/data/manifold-data-resource-list.md
@@ -24,9 +24,9 @@ Creates an unstyled, unordered list with `<a>` tags.
 
 Navigating client-side happens via the `manifold-resourceList-click` custom event.
 
-| Name                          | Details                    | Data                         |
-| :---------------------------- | :------------------------- | :--------------------------- |
-| `manifold-resourceList-click` | User has clicked on a link | `resourceId`, `resourceName` |
+| Name                          | Details                    | Data                                          |
+| :---------------------------- | :------------------------- | :-------------------------------------------- |
+| `manifold-resourceList-click` | User has clicked on a link | `resourceId`, `resourceName`, `resourceLabel` |
 
 ## Link format
 

--- a/docs/docs/data/manifold-data-resource-list.md
+++ b/docs/docs/data/manifold-data-resource-list.md
@@ -12,6 +12,10 @@ example: |
   </manifold-data-resource-list>
 ---
 
+<manifold-toast alert-type="warning">
+  <div><code>resource-name</code> has been deprecated in favor of <code>resource-label</code> starting in version 0.4.0.</div>
+</manifold-toast>
+
 # 🔒 Resource List
 
 Creates an unstyled, unordered list with `<a>` tags.

--- a/docs/docs/resource-details.md
+++ b/docs/docs/resource-details.md
@@ -1,0 +1,109 @@
+---
+title: Resource Details View
+path: /resource-details
+---
+
+# Creating a resource details view
+
+A specific set of component are available to use for creating a resource details view without having to keep
+giving the resource label as attributes to all the components in the library.
+
+To setup a resource details view, wrap all the structure you want to be part of the resource details view in
+a `manifold-resource-container` component with access to the resource label.
+
+```html
+<manifold-resource-container resource-label="my-resource">
+  <!--- Your structure goes here --->
+</manifold-resource-container>
+```
+
+<manifold-mock-resource>
+  <div style="display: flex; justify-content: space-between; margin-bottom: 1em;">
+    <div style="display: flex; align-items: center;">
+      <manifold-input default-value="my-resource" disabled></manifold-input>
+      <manifold-resource-status size="small" style="margin-left: 1em;"></manifold-resource-status>
+    </div>
+    <div>
+      <manifold-resource-rename>Rename</manifold-resource-rename>
+      <manifold-resource-deprovision>Deprovision</manifold-resource-deprovision>
+    </div>
+  </div>
+  <manifold-resource-product style="margin-bottom: 1em" as-card=""></manifold-resource-product>
+  <manifold-resource-plan style="margin-bottom: 1em"></manifold-resource-plan>
+  <manifold-resource-credentials></manifold-resource-credentials>
+</resource-mock-resource>
+
+## The resource credentials
+
+The [`manifold-credentials`](/components/credentials) component can be used inside the container without any attribute by
+using the `manifold-resource-credentials` component.
+
+```html
+<manifold-resource-container resource-label="my-resource">
+  <!--- Your structure goes here --->
+  <manifold-resource-credentials></manifold-resource-credentials>
+</manifold-resource-container>
+```
+
+## The resource deprovision Button
+
+The [`manifold-data-deprovision-button`](/data/deprovision-button) component can be used inside the container without any attribute by
+using the `manifold-resource-deprovision` component. This component is still acting as a data component and can
+be stylized or be given children.
+
+```html
+<manifold-resource-container resource-label="my-resource">
+  <!--- Your structure goes here --->
+  <manifold-resource-deprovision>Deprovision</manifold-resource-deprovision>
+</manifold-resource-container>
+```
+
+## The resource rename Button
+
+The [`manifold-data-rename-button`](/data/rename-button) component can be used inside the container without any attribute by
+using the `manifold-rename-deprovision` component. This component is still acting as a data component and can
+be stylized or be given children.
+
+```html
+<manifold-resource-container resource-label="my-resource">
+  <!--- Your structure goes here --->
+  <manifold-resource-rename>Rename</manifold-resource-rename>
+</manifold-resource-container>
+```
+
+## The resource product details
+
+The [`manifold-resource-card`](/components/manifold-service-card) component can be used inside the container without any attribute by
+using the [`manifold-resource-product`](/components/manifold-resource-product) component.
+
+```html
+<manifold-resource-container resource-label="my-resource">
+  <!--- Your structure goes here --->
+  <manifold-resource-product></manifold-resource-product>
+</manifold-resource-container>
+```
+
+## The resource plan details
+
+The [`manifold-plan`](/components/plan) component can be used inside the container without any attribute by
+using the [`manifold-resource-plan`](/components/manifold-resource-plan) component.
+
+```html
+<manifold-resource-container resource-label="my-resource">
+  <!--- Your structure goes here --->
+  <manifold-resource-plan></manifold-resource-plan>
+</manifold-resource-container>
+```
+
+## The resource status
+
+You can display the resource's status like on the `resource-card` component or the standalone
+[`manifold-resource-status-view`](/components/manifold-resource-card) component inside the container by
+using the `manifold-resource-status` component.
+
+```html
+<manifold-resource-container resource-label="my-resource">
+  <!--- Your structure goes here --->
+  <manifold-resource-status></manifold-resource-status>
+</manifold-resource-container>
+```

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -5413,7 +5413,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5431,11 +5432,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5448,15 +5451,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5559,7 +5565,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5569,6 +5576,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5581,17 +5589,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5608,6 +5619,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5680,7 +5692,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5690,6 +5703,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5765,7 +5779,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5795,6 +5810,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5812,6 +5828,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5850,11 +5867,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -7458,12 +7477,14 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "optional": true
         },
         "slice-ansi": {
           "version": "1.0.0",
@@ -7489,6 +7510,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "optional": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -8425,7 +8447,8 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -8448,6 +8471,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "optional": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }

--- a/docs/src/components/Sidebar.tsx
+++ b/docs/src/components/Sidebar.tsx
@@ -15,7 +15,7 @@ interface SidebarProps {
   pages: ([string, string])[];
 }
 
-const topPages = ['/getting-started', '/connection', '/theming', '/resource-details'];
+const topPages = ['/getting-started', '/connection', '/theming', '/resource-details', '/changelog'];
 
 const DEFAULT = 'default';
 const MANIFOLD = 'manifold';

--- a/docs/src/components/Sidebar.tsx
+++ b/docs/src/components/Sidebar.tsx
@@ -15,7 +15,7 @@ interface SidebarProps {
   pages: ([string, string])[];
 }
 
-const topPages = ['/getting-started', '/connection', '/theming'];
+const topPages = ['/getting-started', '/connection', '/theming', '/resource-details'];
 
 const DEFAULT = 'default';
 const MANIFOLD = 'manifold';

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -19,9 +19,6 @@ import {
   Marketplace,
 } from './types/marketplace';
 import {
-  ResourceState,
-} from './data/resource';
-import {
   Option,
 } from './types/Select';
 
@@ -80,7 +77,7 @@ export namespace Components {
     */
     'connection': Connection;
     'resourceId'?: string;
-    'resourceName': string;
+    'resourceLabel': string;
   }
   interface ManifoldDataDeprovisionButton {
     /**
@@ -96,7 +93,7 @@ export namespace Components {
     /**
     * The label of the resource to deprovision
     */
-    'resourceName'?: string;
+    'resourceLabel'?: string;
   }
   interface ManifoldDataHasResource {
     /**
@@ -128,7 +125,7 @@ export namespace Components {
     /**
     * Name of resource
     */
-    'resourceName'?: string;
+    'resourceLabel'?: string;
   }
   interface ManifoldDataProductLogo {
     /**
@@ -150,7 +147,7 @@ export namespace Components {
     /**
     * Look up product name from resource
     */
-    'resourceName'?: string;
+    'resourceLabel'?: string;
   }
   interface ManifoldDataProductName {
     /**
@@ -168,7 +165,7 @@ export namespace Components {
     /**
     * Look up product name from resource
     */
-    'resourceName'?: string;
+    'resourceLabel'?: string;
   }
   interface ManifoldDataProvisionButton {
     /**
@@ -193,9 +190,9 @@ export namespace Components {
     */
     'regionName'?: string;
     /**
-    * The name of the resource to provision
+    * The label of the resource to provision
     */
-    'resourceName'?: string;
+    'resourceLabel'?: string;
   }
   interface ManifoldDataRenameButton {
     /**
@@ -208,9 +205,9 @@ export namespace Components {
     'connection': Connection;
     'loading'?: boolean;
     /**
-    * The new name to give to the resource
+    * The new label to give to the resource
     */
-    'newName': string;
+    'newLabel': string;
     /**
     * The id of the resource to rename, will be fetched if not set
     */
@@ -218,7 +215,7 @@ export namespace Components {
     /**
     * The label of the resource to rename
     */
-    'resourceName'?: string;
+    'resourceLabel'?: string;
   }
   interface ManifoldDataResourceList {
     /**
@@ -385,6 +382,7 @@ export namespace Components {
     'regions'?: string[];
     'resourceFeatures'?: Gateway.ResolvedFeature[];
     'resourceRegion'?: string;
+    'scrollLocked'?: boolean;
   }
   interface ManifoldPlanMenu {
     'plans'?: Catalog.ExpandedPlan[];
@@ -411,7 +409,7 @@ export namespace Components {
     /**
     * Is this tied to an existing resource?
     */
-    'resourceName'?: string;
+    'resourceLabel'?: string;
   }
   interface ManifoldProduct {
     /**
@@ -466,6 +464,7 @@ export namespace Components {
     'label'?: string;
     'loading'?: boolean;
     'logo'?: string;
+    'name'?: string;
     'preserveEvent'?: boolean;
     'resourceId'?: string;
     'resourceLinkFormat'?: string;
@@ -483,15 +482,18 @@ export namespace Components {
     /**
     * Which resource does this belong to?
     */
-    'resourceName'?: string;
+    'resourceLabel'?: string;
   }
   interface ManifoldResourceCredentials {}
   interface ManifoldResourceCredentialsView {
     'credentials'?: Marketplace.Credential[];
     'loading': boolean;
-    'resourceName': string;
+    'resourceLabel': string;
   }
-  interface ManifoldResourceDeprovision {}
+  interface ManifoldResourceDeprovision {
+    'data'?: Gateway.Resource;
+    'loading': boolean;
+  }
   interface ManifoldResourceDetails {}
   interface ManifoldResourceDetailsView {
     'data'?: Gateway.Resource;
@@ -522,7 +524,10 @@ export namespace Components {
   interface ManifoldResourceProduct {
     'asCard'?: boolean;
   }
-  interface ManifoldResourceRename {}
+  interface ManifoldResourceRename {
+    'data'?: Gateway.Resource;
+    'loading': boolean;
+  }
   interface ManifoldResourceStatus {
     'size'?: 'small' | 'medium';
   }
@@ -1060,7 +1065,7 @@ declare namespace LocalJSX {
     */
     'connection'?: Connection;
     'resourceId'?: string;
-    'resourceName'?: string;
+    'resourceLabel'?: string;
   }
   interface ManifoldDataDeprovisionButton extends JSXBase.HTMLAttributes<HTMLManifoldDataDeprovisionButtonElement> {
     /**
@@ -1079,7 +1084,7 @@ declare namespace LocalJSX {
     /**
     * The label of the resource to deprovision
     */
-    'resourceName'?: string;
+    'resourceLabel'?: string;
   }
   interface ManifoldDataHasResource extends JSXBase.HTMLAttributes<HTMLManifoldDataHasResourceElement> {
     /**
@@ -1114,7 +1119,7 @@ declare namespace LocalJSX {
     /**
     * Name of resource
     */
-    'resourceName'?: string;
+    'resourceLabel'?: string;
   }
   interface ManifoldDataProductLogo extends JSXBase.HTMLAttributes<HTMLManifoldDataProductLogoElement> {
     /**
@@ -1136,7 +1141,7 @@ declare namespace LocalJSX {
     /**
     * Look up product name from resource
     */
-    'resourceName'?: string;
+    'resourceLabel'?: string;
   }
   interface ManifoldDataProductName extends JSXBase.HTMLAttributes<HTMLManifoldDataProductNameElement> {
     /**
@@ -1154,7 +1159,7 @@ declare namespace LocalJSX {
     /**
     * Look up product name from resource
     */
-    'resourceName'?: string;
+    'resourceLabel'?: string;
   }
   interface ManifoldDataProvisionButton extends JSXBase.HTMLAttributes<HTMLManifoldDataProvisionButtonElement> {
     /**
@@ -1183,9 +1188,9 @@ declare namespace LocalJSX {
     */
     'regionName'?: string;
     /**
-    * The name of the resource to provision
+    * The label of the resource to provision
     */
-    'resourceName'?: string;
+    'resourceLabel'?: string;
   }
   interface ManifoldDataRenameButton extends JSXBase.HTMLAttributes<HTMLManifoldDataRenameButtonElement> {
     /**
@@ -1198,9 +1203,9 @@ declare namespace LocalJSX {
     'connection'?: Connection;
     'loading'?: boolean;
     /**
-    * The new name to give to the resource
+    * The new label to give to the resource
     */
-    'newName'?: string;
+    'newLabel'?: string;
     'onManifold-renameButton-click'?: (event: CustomEvent<any>) => void;
     'onManifold-renameButton-error'?: (event: CustomEvent<any>) => void;
     'onManifold-renameButton-invalid'?: (event: CustomEvent<any>) => void;
@@ -1212,7 +1217,7 @@ declare namespace LocalJSX {
     /**
     * The label of the resource to rename
     */
-    'resourceName'?: string;
+    'resourceLabel'?: string;
   }
   interface ManifoldDataResourceList extends JSXBase.HTMLAttributes<HTMLManifoldDataResourceListElement> {
     /**
@@ -1384,6 +1389,7 @@ declare namespace LocalJSX {
     'regions'?: string[];
     'resourceFeatures'?: Gateway.ResolvedFeature[];
     'resourceRegion'?: string;
+    'scrollLocked'?: boolean;
   }
   interface ManifoldPlanMenu extends JSXBase.HTMLAttributes<HTMLManifoldPlanMenuElement> {
     'plans'?: Catalog.ExpandedPlan[];
@@ -1410,7 +1416,7 @@ declare namespace LocalJSX {
     /**
     * Is this tied to an existing resource?
     */
-    'resourceName'?: string;
+    'resourceLabel'?: string;
   }
   interface ManifoldProduct extends JSXBase.HTMLAttributes<HTMLManifoldProductElement> {
     /**
@@ -1466,6 +1472,7 @@ declare namespace LocalJSX {
     'label'?: string;
     'loading'?: boolean;
     'logo'?: string;
+    'name'?: string;
     'onManifold-resource-click'?: (event: CustomEvent<any>) => void;
     'preserveEvent'?: boolean;
     'resourceId'?: string;
@@ -1484,16 +1491,19 @@ declare namespace LocalJSX {
     /**
     * Which resource does this belong to?
     */
-    'resourceName'?: string;
+    'resourceLabel'?: string;
   }
   interface ManifoldResourceCredentials extends JSXBase.HTMLAttributes<HTMLManifoldResourceCredentialsElement> {}
   interface ManifoldResourceCredentialsView extends JSXBase.HTMLAttributes<HTMLManifoldResourceCredentialsViewElement> {
     'credentials'?: Marketplace.Credential[];
     'loading'?: boolean;
     'onCredentialsRequested'?: (event: CustomEvent<any>) => void;
-    'resourceName'?: string;
+    'resourceLabel'?: string;
   }
-  interface ManifoldResourceDeprovision extends JSXBase.HTMLAttributes<HTMLManifoldResourceDeprovisionElement> {}
+  interface ManifoldResourceDeprovision extends JSXBase.HTMLAttributes<HTMLManifoldResourceDeprovisionElement> {
+    'data'?: Gateway.Resource;
+    'loading'?: boolean;
+  }
   interface ManifoldResourceDetails extends JSXBase.HTMLAttributes<HTMLManifoldResourceDetailsElement> {}
   interface ManifoldResourceDetailsView extends JSXBase.HTMLAttributes<HTMLManifoldResourceDetailsViewElement> {
     'data'?: Gateway.Resource;
@@ -1524,7 +1534,10 @@ declare namespace LocalJSX {
   interface ManifoldResourceProduct extends JSXBase.HTMLAttributes<HTMLManifoldResourceProductElement> {
     'asCard'?: boolean;
   }
-  interface ManifoldResourceRename extends JSXBase.HTMLAttributes<HTMLManifoldResourceRenameElement> {}
+  interface ManifoldResourceRename extends JSXBase.HTMLAttributes<HTMLManifoldResourceRenameElement> {
+    'data'?: Gateway.Resource;
+    'loading'?: boolean;
+  }
   interface ManifoldResourceStatus extends JSXBase.HTMLAttributes<HTMLManifoldResourceStatusElement> {
     'size'?: 'small' | 'medium';
   }

--- a/src/components/manifold-active-plan/manifold-active-plan.tsx
+++ b/src/components/manifold-active-plan/manifold-active-plan.tsx
@@ -49,6 +49,7 @@ export class ManifoldActivePlan {
         selectPlan={this.selectPlan}
       />,
       <manifold-plan-details
+        scrollLocked={true}
         isExistingResource={this.isExistingResource}
         plan={this.selectedPlan}
         product={this.product}

--- a/src/components/manifold-credentials-view/manifold-credentials-view-happo.ts
+++ b/src/components/manifold-credentials-view/manifold-credentials-view-happo.ts
@@ -3,7 +3,7 @@ import fromJSON from '../../spec/mock/fromJSON';
 
 export const credsHidden = () => {
   const creds = document.createElement('manifold-resource-credentials-view');
-  creds.resourceName = 'test';
+  creds.resourceLabel = 'test';
 
   document.body.appendChild(creds);
 
@@ -12,7 +12,7 @@ export const credsHidden = () => {
 
 export const credsShown = () => {
   const creds = document.createElement('manifold-resource-credentials-view');
-  creds.resourceName = 'test';
+  creds.resourceLabel = 'test';
   creds.credentials = fromJSON(credentials);
 
   document.body.appendChild(creds);

--- a/src/components/manifold-credentials-view/manifold-credentials-view.tsx
+++ b/src/components/manifold-credentials-view/manifold-credentials-view.tsx
@@ -10,7 +10,7 @@ import { Marketplace } from '../../types/marketplace';
 })
 export class ManifoldResourceCredentials {
   @Prop() credentials?: Marketplace.Credential[];
-  @Prop() resourceName: string = '';
+  @Prop() resourceLabel: string = '';
   @Prop() loading: boolean = false;
   @Event() credentialsRequested: EventEmitter;
 
@@ -55,7 +55,7 @@ export class ManifoldResourceCredentials {
             <pre class="env">
               <code>
                 {this.credentials.map(({ body }) => [
-                  <span class="comment"># {this.resourceName}</span>,
+                  <span class="comment"># {this.resourceLabel}</span>,
                   '\n\n',
                   Object.entries(body.values).map(([key, value]) => [
                     <span class="env-key">{key}</span>,

--- a/src/components/manifold-credentials/manifold-credentials.spec.tsx
+++ b/src/components/manifold-credentials/manifold-credentials.spec.tsx
@@ -8,46 +8,46 @@ import { ManifoldCredentials } from './manifold-credentials';
 
 describe('<manifold-credentials>', () => {
   it('fetches the resource id on load if not set', () => {
-    const resourceName = 'test-resource';
+    const resourceLabel = 'test-resource';
 
     const provisionButton = new ManifoldCredentials();
     provisionButton.fetchResourceId = jest.fn();
-    provisionButton.resourceName = resourceName;
+    provisionButton.resourceLabel = resourceLabel;
     provisionButton.componentWillLoad();
-    expect(provisionButton.fetchResourceId).toHaveBeenCalledWith(resourceName);
+    expect(provisionButton.fetchResourceId).toHaveBeenCalledWith(resourceLabel);
   });
 
   it('does not fetch the resource id on load if set', () => {
-    const resourceName = 'test-resource';
+    const resourceLabel = 'test-resource';
 
     const provisionButton = new ManifoldCredentials();
     provisionButton.fetchResourceId = jest.fn();
-    provisionButton.resourceName = resourceName;
-    provisionButton.resourceId = resourceName;
+    provisionButton.resourceLabel = resourceLabel;
+    provisionButton.resourceId = resourceLabel;
     provisionButton.componentWillLoad();
     expect(provisionButton.fetchResourceId).not.toHaveBeenCalled();
   });
 
   it('fetches resource id on change if not set', () => {
-    const resourceName = 'new-resource';
+    const resourceLabel = 'new-resource';
 
     const provisionButton = new ManifoldCredentials();
     provisionButton.fetchResourceId = jest.fn();
-    provisionButton.resourceName = 'old-resource';
+    provisionButton.resourceLabel = 'old-resource';
 
-    provisionButton.nameChange(resourceName);
-    expect(provisionButton.fetchResourceId).toHaveBeenCalledWith(resourceName);
+    provisionButton.labelChange(resourceLabel);
+    expect(provisionButton.fetchResourceId).toHaveBeenCalledWith(resourceLabel);
   });
 
   it('does not resource id on change if set', () => {
-    const resourceName = 'new-resource';
+    const resourceLabel = 'new-resource';
 
     const provisionButton = new ManifoldCredentials();
     provisionButton.fetchResourceId = jest.fn();
-    provisionButton.resourceName = 'old-resource';
+    provisionButton.resourceLabel = 'old-resource';
     provisionButton.resourceId = '1234';
 
-    provisionButton.nameChange(resourceName);
+    provisionButton.labelChange(resourceLabel);
     expect(provisionButton.fetchResourceId).not.toHaveBeenCalled();
   });
 
@@ -57,9 +57,9 @@ describe('<manifold-credentials>', () => {
     });
 
     it('will fetch the resource id', async () => {
-      const resourceName = 'new-resource';
+      const resourceLabel = 'new-resource';
 
-      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${resourceName}`, [
+      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`, [
         Resource,
       ]);
 
@@ -67,13 +67,13 @@ describe('<manifold-credentials>', () => {
         components: [ManifoldCredentials],
         html: `
           <manifold-credentials
-            resource-name="${resourceName}"
+            resource-label="${resourceLabel}"
           ></manifold-credentials>
         `,
       });
 
       expect(
-        fetchMock.called(`${connections.prod.marketplace}/resources/?me&label=${resourceName}`)
+        fetchMock.called(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`)
       ).toBe(true);
 
       const root = page.rootInstance as ManifoldCredentials;
@@ -81,21 +81,21 @@ describe('<manifold-credentials>', () => {
     });
 
     it('will do nothing on a fetch error', async () => {
-      const resourceName = 'new-resource';
+      const resourceLabel = 'new-resource';
 
-      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&name=${resourceName}`, []);
+      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&name=${resourceLabel}`, []);
 
       const page = await newSpecPage({
         components: [ManifoldCredentials],
         html: `
           <manifold-credentials
-            resource-name="${resourceName}"
+            resource-label="${resourceLabel}"
           ></manifold-credentials>
         `,
       });
 
       expect(
-        fetchMock.called(`${connections.prod.marketplace}/resources/?me&label=${resourceName}`)
+        fetchMock.called(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`)
       ).toBe(true);
 
       const root = page.rootInstance as ManifoldCredentials;
@@ -119,7 +119,7 @@ describe('<manifold-credentials>', () => {
         components: [ManifoldCredentials],
         html: `
           <manifold-credentials
-            resource-name="test"
+            resource-label="test"
           ></manifold-credentials>
         `,
       });
@@ -138,7 +138,7 @@ describe('<manifold-credentials>', () => {
         components: [ManifoldCredentials],
         html: `
           <manifold-credentials
-            resource-name="test"
+            resource-label="test"
           ></manifold-credentials>
         `,
       });

--- a/src/components/manifold-credentials/manifold-credentials.tsx
+++ b/src/components/manifold-credentials/manifold-credentials.tsx
@@ -11,20 +11,20 @@ export class ManifoldCredentials {
   @Prop() connection: Connection = connections.prod;
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() authToken?: string;
-  @Prop() resourceName: string = '';
+  @Prop() resourceLabel: string = '';
   @Prop({ mutable: true }) resourceId?: string = '';
   @State() loading?: boolean = false;
   @State() credentials?: Marketplace.Credential[];
 
-  @Watch('resourceName') nameChange(newName: string) {
+  @Watch('resourceLabel') labelChange(newLabel: string) {
     if (!this.resourceId) {
-      this.fetchResourceId(newName);
+      this.fetchResourceId(newLabel);
     }
   }
 
   componentWillLoad() {
-    if (this.resourceName && !this.resourceId) {
-      this.fetchResourceId(this.resourceName);
+    if (this.resourceLabel && !this.resourceId) {
+      this.fetchResourceId(this.resourceLabel);
     }
   }
 
@@ -43,15 +43,15 @@ export class ManifoldCredentials {
     this.loading = false;
   };
 
-  async fetchResourceId(resourceName: string) {
+  async fetchResourceId(resourceLabel: string) {
     const resourceResp = await fetch(
-      `${this.connection.marketplace}/resources/?me&label=${resourceName}`,
+      `${this.connection.marketplace}/resources/?me&label=${resourceLabel}`,
       withAuth(this.authToken)
     );
     const resources: Marketplace.Resource[] = await resourceResp.json();
 
     if (!Array.isArray(resources) || !resources.length) {
-      console.error(`${resourceName} product not found`);
+      console.error(`${resourceLabel} product not found`);
       return;
     }
 
@@ -66,7 +66,7 @@ export class ManifoldCredentials {
     return (
       <manifold-resource-credentials-view
         loading={this.loading}
-        resourceName={this.resourceName}
+        resourceLabel={this.resourceLabel}
         credentials={this.credentials}
         onCredentialsRequested={this.credentialsRequested}
       />

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
@@ -8,46 +8,46 @@ import { ManifoldDataDeprovisionButton } from './manifold-data-deprovision-butto
 
 describe('<manifold-data-provision-button>', () => {
   it('fetches the resource id on load if not set', () => {
-    const resourceName = 'test-resource';
+    const resourceLabel = 'test-resource';
 
     const provisionButton = new ManifoldDataDeprovisionButton();
     provisionButton.fetchResourceId = jest.fn();
-    provisionButton.resourceName = resourceName;
+    provisionButton.resourceLabel = resourceLabel;
     provisionButton.componentWillLoad();
-    expect(provisionButton.fetchResourceId).toHaveBeenCalledWith(resourceName);
+    expect(provisionButton.fetchResourceId).toHaveBeenCalledWith(resourceLabel);
   });
 
   it('does not fetch the resource id on load if set', () => {
-    const resourceName = 'test-resource';
+    const resourceLabel = 'test-resource';
 
     const provisionButton = new ManifoldDataDeprovisionButton();
     provisionButton.fetchResourceId = jest.fn();
-    provisionButton.resourceName = resourceName;
-    provisionButton.resourceId = resourceName;
+    provisionButton.resourceLabel = resourceLabel;
+    provisionButton.resourceId = resourceLabel;
     provisionButton.componentWillLoad();
     expect(provisionButton.fetchResourceId).not.toHaveBeenCalled();
   });
 
   it('fetches resource id on change if not set', () => {
-    const resourceName = 'new-resource';
+    const resourceLabel = 'new-resource';
 
     const provisionButton = new ManifoldDataDeprovisionButton();
     provisionButton.fetchResourceId = jest.fn();
-    provisionButton.resourceName = 'old-resource';
+    provisionButton.resourceLabel = 'old-resource';
 
-    provisionButton.nameChange(resourceName);
-    expect(provisionButton.fetchResourceId).toHaveBeenCalledWith(resourceName);
+    provisionButton.labelChange(resourceLabel);
+    expect(provisionButton.fetchResourceId).toHaveBeenCalledWith(resourceLabel);
   });
 
   it('does not resource id on change if set', () => {
-    const resourceName = 'new-resource';
+    const resourceLabel = 'new-resource';
 
     const provisionButton = new ManifoldDataDeprovisionButton();
     provisionButton.fetchResourceId = jest.fn();
-    provisionButton.resourceName = 'old-resource';
+    provisionButton.resourceLabel = 'old-resource';
     provisionButton.resourceId = '1234';
 
-    provisionButton.nameChange(resourceName);
+    provisionButton.labelChange(resourceLabel);
     expect(provisionButton.fetchResourceId).not.toHaveBeenCalled();
   });
 
@@ -57,9 +57,9 @@ describe('<manifold-data-provision-button>', () => {
     });
 
     it('will fetch the resource id', async () => {
-      const resourceName = 'new-resource';
+      const resourceLabel = 'new-resource';
 
-      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${resourceName}`, [
+      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`, [
         Resource,
       ]);
 
@@ -67,13 +67,13 @@ describe('<manifold-data-provision-button>', () => {
         components: [ManifoldDataDeprovisionButton],
         html: `
           <manifold-data-deprovision-button
-            resource-name="${resourceName}"
+            resource-label="${resourceLabel}"
           >Deprovision</manifold-data-deprovision-button>
         `,
       });
 
       expect(
-        fetchMock.called(`${connections.prod.marketplace}/resources/?me&label=${resourceName}`)
+        fetchMock.called(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`)
       ).toBe(true);
 
       const root = page.rootInstance as ManifoldDataDeprovisionButton;
@@ -81,21 +81,21 @@ describe('<manifold-data-provision-button>', () => {
     });
 
     it('will do nothing on a fetch error', async () => {
-      const resourceName = 'new-resource';
+      const resourceLabel = 'new-resource';
 
-      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&name=${resourceName}`, []);
+      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&name=${resourceLabel}`, []);
 
       const page = await newSpecPage({
         components: [ManifoldDataDeprovisionButton],
         html: `
           <manifold-data-deprovision-button
-            resource-name="${resourceName}"
+            resource-label="${resourceLabel}"
           >Deprovision</manifold-data-deprovision-button>
         `,
       });
 
       expect(
-        fetchMock.called(`${connections.prod.marketplace}/resources/?me&label=${resourceName}`)
+        fetchMock.called(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`)
       ).toBe(true);
 
       const root = page.rootInstance as ManifoldDataDeprovisionButton;
@@ -119,7 +119,7 @@ describe('<manifold-data-provision-button>', () => {
         components: [ManifoldDataDeprovisionButton],
         html: `
           <manifold-data-deprovision-button
-            resource-name="test"
+            resource-label="test"
           >Deprovision</manifold-data-deprovision-button>
         `,
       });
@@ -132,7 +132,7 @@ describe('<manifold-data-provision-button>', () => {
       expect(fetchMock.called(`${connections.prod.gateway}/id/resource/${Resource.id}`)).toBe(true);
       expect(instance.successEvent.emit).toHaveBeenCalledWith({
         message: 'test successfully deprovisioned',
-        resourceName: 'test',
+        resourceLabel: 'test',
         resourceId: Resource.id,
       });
     });
@@ -149,7 +149,7 @@ describe('<manifold-data-provision-button>', () => {
         components: [ManifoldDataDeprovisionButton],
         html: `
           <manifold-data-deprovision-button
-            resource-name="test"
+            resource-label="test"
           >Provision</manifold-data-deprovision-button>
         `,
       });
@@ -162,7 +162,7 @@ describe('<manifold-data-provision-button>', () => {
       expect(fetchMock.called(`${connections.prod.gateway}/id/resource/${Resource.id}`)).toBe(true);
       expect(instance.errorEvent.emit).toHaveBeenCalledWith({
         message: 'ohnoes',
-        resourceName: 'test',
+        resourceLabel: 'test',
         resourceId: Resource.id,
       });
     });

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
@@ -9,17 +9,20 @@ import { Marketplace } from '../../types/marketplace';
 
 interface SuccessMessage {
   message: string;
-  resourceName: string;
+  resourceLabel: string;
   resourceId: string;
 }
 
 interface ErrorMessage {
   message: string;
-  resourceName: string;
+  resourceLabel: string;
   resourceId: string;
 }
 
-@Component({ tag: 'manifold-data-deprovision-button' })
+@Component({
+  tag: 'manifold-data-deprovision-button',
+  shadow: true,
+})
 export class ManifoldDataDeprovisionButton {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
@@ -27,7 +30,7 @@ export class ManifoldDataDeprovisionButton {
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() authToken?: string;
   /** The label of the resource to deprovision */
-  @Prop() resourceName?: string;
+  @Prop() resourceLabel?: string;
   @Prop({ mutable: true }) resourceId?: string = '';
   @Prop() loading?: boolean = false;
   @Event({ eventName: 'manifold-deprovisionButton-click', bubbles: true })
@@ -36,15 +39,15 @@ export class ManifoldDataDeprovisionButton {
   @Event({ eventName: 'manifold-provisionButton-success', bubbles: true })
   successEvent: EventEmitter;
 
-  @Watch('resourceName') nameChange(newName: string) {
+  @Watch('resourceLabel') labelChange(newLabel: string) {
     if (!this.resourceId) {
-      this.fetchResourceId(newName);
+      this.fetchResourceId(newLabel);
     }
   }
 
   componentWillLoad() {
-    if (this.resourceName && !this.resourceId) {
-      this.fetchResourceId(this.resourceName);
+    if (this.resourceLabel && !this.resourceId) {
+      this.fetchResourceId(this.resourceLabel);
     }
   }
 
@@ -57,7 +60,7 @@ export class ManifoldDataDeprovisionButton {
     // We use Gateway b/c it’s much easier to provision w/o generating a base32 ID
     this.clickEvent.emit({
       resourceId: this.resourceId,
-      resourceName: this.resourceName || '',
+      resourceLabel: this.resourceLabel || '',
     });
 
     const response = await fetch(
@@ -70,8 +73,8 @@ export class ManifoldDataDeprovisionButton {
     // If successful, this will return 200 and stop here
     if (response.status >= 200 && response.status < 300) {
       const success: SuccessMessage = {
-        message: `${this.resourceName} successfully deprovisioned`,
-        resourceName: this.resourceName || '',
+        message: `${this.resourceLabel} successfully deprovisioned`,
+        resourceLabel: this.resourceLabel || '',
         resourceId: this.resourceId,
       };
       this.successEvent.emit(success);
@@ -82,22 +85,22 @@ export class ManifoldDataDeprovisionButton {
       const message = Array.isArray(body) ? body[0].message : body.message;
       const error: ErrorMessage = {
         message,
-        resourceName: this.resourceName || '',
+        resourceLabel: this.resourceLabel || '',
         resourceId: this.resourceId,
       };
       this.errorEvent.emit(error);
     }
   }
 
-  async fetchResourceId(resourceName: string) {
+  async fetchResourceId(resourceLabel: string) {
     const resourceResp = await fetch(
-      `${this.connection.marketplace}/resources/?me&label=${resourceName}`,
+      `${this.connection.marketplace}/resources/?me&label=${resourceLabel}`,
       withAuth(this.authToken)
     );
     const resources: Marketplace.Resource[] = await resourceResp.json();
 
     if (!Array.isArray(resources) || !resources.length) {
-      console.error(`${resourceName} product not found`);
+      console.error(`${resourceLabel} product not found`);
       return;
     }
 

--- a/src/components/manifold-data-manage-button/manifold-data-manage-button.spec.ts
+++ b/src/components/manifold-data-manage-button/manifold-data-manage-button.spec.ts
@@ -6,7 +6,7 @@ describe('<manifold-data-manage-button>', () => {
 
     const manageButton = new ManifoldDataManageButton();
     manageButton.fetchResourceId = jest.fn();
-    manageButton.resourceName = resourceName;
+    manageButton.resourceLabel = resourceName;
     manageButton.componentWillLoad();
     expect(manageButton.fetchResourceId).toHaveBeenCalledWith(resourceName);
   });
@@ -16,7 +16,7 @@ describe('<manifold-data-manage-button>', () => {
 
     const manageButton = new ManifoldDataManageButton();
     manageButton.fetchResourceId = jest.fn();
-    manageButton.resourceName = 'old-resource';
+    manageButton.resourceLabel = 'old-resource';
     manageButton.resourceChange(newResource);
     expect(manageButton.fetchResourceId).toHaveBeenCalledWith(newResource);
   });

--- a/src/components/manifold-data-manage-button/manifold-data-manage-button.tsx
+++ b/src/components/manifold-data-manage-button/manifold-data-manage-button.tsx
@@ -9,12 +9,16 @@ import { Connection, connections } from '../../utils/connections';
 
 interface SuccessMessage {
   features: Gateway.FeatureMap;
+  resourceLabel: string;
+  resourceId: string;
   planName: string;
   message: string;
 }
 
 interface ErrorMessage {
   features: Gateway.FeatureMap;
+  resourceLabel: string;
+  resourceId: string;
   message: string;
 }
 
@@ -26,7 +30,7 @@ export class ManifoldDataManageButton {
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() authToken?: string;
   /** Name of resource */
-  @Prop() resourceName?: string;
+  @Prop() resourceLabel?: string;
   @Prop() features?: Gateway.FeatureMap = {};
   @Prop() planId?: string = '';
   @Prop({ mutable: true }) productId?: string = '';
@@ -37,17 +41,17 @@ export class ManifoldDataManageButton {
   @Event({ eventName: 'manifold-manageButton-error', bubbles: true }) errorEvent: EventEmitter;
   @Event({ eventName: 'manifold-manageButton-success', bubbles: true })
   successEvent: EventEmitter;
-  @Watch('resourceName') resourceChange(newResource: string) {
+  @Watch('resourceLabel') resourceChange(newResource: string) {
     this.fetchResourceId(newResource);
   }
 
   componentWillLoad() {
-    if (this.resourceName) this.fetchResourceId(this.resourceName);
+    if (this.resourceLabel) this.fetchResourceId(this.resourceLabel);
   }
 
-  async fetchResourceId(resourceName: string) {
+  async fetchResourceId(resourceLabel: string) {
     const { gateway } = this.connection;
-    const response = await fetch(`${gateway}/resources/me/${resourceName}`, withAuth());
+    const response = await fetch(`${gateway}/resources/me/${resourceLabel}`, withAuth());
     const resource: Gateway.Resource = await response.json();
     if (resource.id) this.resourceId = resource.id;
   }
@@ -58,7 +62,11 @@ export class ManifoldDataManageButton {
       return;
     }
 
-    this.clickEvent.emit({ planId: this.planId });
+    this.clickEvent.emit({
+      planId: this.planId,
+      resourceLabel: this.resourceLabel,
+      resourceId: this.resourceId,
+    });
     const req: Gateway.ResourceUpdateRequest = { plan_id: this.planId };
 
     if (Object.keys(this.features).length) req.features = this.features;
@@ -78,7 +86,9 @@ export class ManifoldDataManageButton {
     if (response.status >= 200 && response.status < 300) {
       const planName = body.plan && body.plan.name;
       const success: SuccessMessage = {
-        message: `${this.resourceName} successfully updated to ${planName}`,
+        message: `${this.resourceLabel} successfully updated to ${planName}`,
+        resourceLabel: this.resourceLabel || '',
+        resourceId: this.resourceId,
         planName,
         features: body.features,
       };
@@ -87,6 +97,8 @@ export class ManifoldDataManageButton {
       // Sometimes messages are an array, sometimes they aren’t. Different strokes!
       const message = Array.isArray(body) ? body[0].message : body.message;
       const error: ErrorMessage = {
+        resourceLabel: this.resourceLabel || '',
+        resourceId: this.resourceId,
         message,
         features: this.features,
       };

--- a/src/components/manifold-data-product-logo/manifold-data-product-logo.spec.ts
+++ b/src/components/manifold-data-product-logo/manifold-data-product-logo.spec.ts
@@ -22,13 +22,13 @@ describe('<manifold-data-product-logo>', () => {
   });
 
   it('fetches resource on load', () => {
-    const resourceName = 'my-resource';
+    const resourceLabel = 'my-resource';
 
     const productLogo = new ManifoldDataProductLogo();
     productLogo.fetchResource = jest.fn();
-    productLogo.resourceName = resourceName;
+    productLogo.resourceLabel = resourceLabel;
     productLogo.componentWillLoad();
-    expect(productLogo.fetchResource).toHaveBeenCalledWith(resourceName);
+    expect(productLogo.fetchResource).toHaveBeenCalledWith(resourceLabel);
   });
 
   it('fetches resource on change', () => {
@@ -36,7 +36,7 @@ describe('<manifold-data-product-logo>', () => {
 
     const productLogo = new ManifoldDataProductLogo();
     productLogo.fetchResource = jest.fn();
-    productLogo.resourceName = 'old-resource';
+    productLogo.resourceLabel = 'old-resource';
     productLogo.resourceChange(newResource);
     expect(productLogo.fetchResource).toHaveBeenCalledWith(newResource);
   });

--- a/src/components/manifold-data-product-logo/manifold-data-product-logo.tsx
+++ b/src/components/manifold-data-product-logo/manifold-data-product-logo.tsx
@@ -17,18 +17,18 @@ export class ManifoldDataProductLogo {
   /** URL-friendly slug (e.g. `"jawsdb-mysql"`) */
   @Prop() productLabel?: string;
   /** Look up product name from resource */
-  @Prop() resourceName?: string;
+  @Prop() resourceLabel?: string;
   @State() product?: Catalog.Product;
   @Watch('productLabel') productChange(newProduct: string) {
     this.fetchProduct(newProduct);
   }
-  @Watch('resourceName') resourceChange(newResource: string) {
+  @Watch('resourceLabel') resourceChange(newResource: string) {
     this.fetchResource(newResource);
   }
 
   componentWillLoad() {
     if (this.productLabel) this.fetchProduct(this.productLabel);
-    if (this.resourceName) this.fetchResource(this.resourceName);
+    if (this.resourceLabel) this.fetchResource(this.resourceLabel);
   }
 
   fetchProduct = async (productLabel: string) => {
@@ -39,10 +39,10 @@ export class ManifoldDataProductLogo {
     this.product = products[0]; // eslint-disable-line prefer-destructuring
   };
 
-  fetchResource = async (resourceName: string) => {
+  fetchResource = async (resourceLabel: string) => {
     this.product = undefined;
     const { catalog, gateway } = this.connection;
-    const response = await fetch(`${gateway}/resources/me/${resourceName}`, withAuth(this.authToken));
+    const response = await fetch(`${gateway}/resources/me/${resourceLabel}`, withAuth(this.authToken));
     const resource: Gateway.Resource = await response.json();
     const productId = resource.product && resource.product.id;
     const productResp = await fetch(`${catalog}/products/${productId}`, withAuth(this.authToken));

--- a/src/components/manifold-data-product-name/manifold-data-product-name.spec.ts
+++ b/src/components/manifold-data-product-name/manifold-data-product-name.spec.ts
@@ -22,13 +22,13 @@ describe('<manifold-data-product-name>', () => {
   });
 
   it('fetches resource on load', () => {
-    const resourceName = 'my-resource';
+    const resourceLabel = 'my-resource';
 
     const productName = new ManifoldDataProductName();
     productName.fetchResource = jest.fn();
-    productName.resourceName = resourceName;
+    productName.resourceLabel = resourceLabel;
     productName.componentWillLoad();
-    expect(productName.fetchResource).toHaveBeenCalledWith(resourceName);
+    expect(productName.fetchResource).toHaveBeenCalledWith(resourceLabel);
   });
 
   it('fetches resource on change', () => {
@@ -36,7 +36,7 @@ describe('<manifold-data-product-name>', () => {
 
     const productName = new ManifoldDataProductName();
     productName.fetchResource = jest.fn();
-    productName.resourceName = 'old-resource';
+    productName.resourceLabel = 'old-resource';
     productName.resourceChange(newResource);
     expect(productName.fetchResource).toHaveBeenCalledWith(newResource);
   });

--- a/src/components/manifold-data-product-name/manifold-data-product-name.tsx
+++ b/src/components/manifold-data-product-name/manifold-data-product-name.tsx
@@ -15,18 +15,18 @@ export class ManifoldDataProductName {
   /** URL-friendly slug (e.g. `"jawsdb-mysql"`) */
   @Prop() productLabel?: string;
   /** Look up product name from resource */
-  @Prop() resourceName?: string;
+  @Prop() resourceLabel?: string;
   @State() productName?: string;
   @Watch('productLabel') productChange(newProduct: string) {
     this.fetchProduct(newProduct);
   }
-  @Watch('resourceName') resourceChange(newResource: string) {
+  @Watch('resourceLabel') resourceChange(newResource: string) {
     this.fetchResource(newResource);
   }
 
   componentWillLoad() {
     if (this.productLabel) this.fetchProduct(this.productLabel);
-    if (this.resourceName) this.fetchResource(this.resourceName);
+    if (this.resourceLabel) this.fetchResource(this.resourceLabel);
   }
 
   fetchProduct = async (productLabel: string) => {

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.spec.ts
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.spec.ts
@@ -199,7 +199,7 @@ describe('<manifold-data-provision-button>', () => {
           <manifold-data-provision-button
             product-label="test"
             owner-id="1234"
-            resource-name="test"
+            resource-label="test"
           >Provision</manifold-data-provision-button>
         `,
       });
@@ -214,7 +214,7 @@ describe('<manifold-data-provision-button>', () => {
         createdAt: GatewayResource.created_at,
         message: 'test successfully provisioned',
         resourceId: GatewayResource.id,
-        resourceName: GatewayResource.label,
+        resourceLabel: GatewayResource.label,
       });
     });
 
@@ -232,7 +232,7 @@ describe('<manifold-data-provision-button>', () => {
           <manifold-data-provision-button
             product-label="test"
             owner-id="1234"
-            resource-name="test"
+            resource-label="test"
           >Provision</manifold-data-provision-button>
         `,
       });
@@ -245,7 +245,7 @@ describe('<manifold-data-provision-button>', () => {
       expect(fetchMock.called(`${connections.prod.gateway}/resource/`)).toBe(true);
       expect(instance.errorEvent.emit).toHaveBeenCalledWith({
         message: 'ohnoes',
-        resourceName: 'test',
+        resourceLabel: 'test',
       });
     });
 
@@ -258,7 +258,7 @@ describe('<manifold-data-provision-button>', () => {
           <manifold-data-provision-button
             product-label="test"
             owner-id="1234"
-            resource-name="t"
+            resource-label="t"
           >Provision</manifold-data-provision-button>
         `,
       });
@@ -271,17 +271,17 @@ describe('<manifold-data-provision-button>', () => {
       expect(fetchMock.called(`${connections.prod.gateway}/resource/`)).toBe(false);
       expect(instance.invalidEvent.emit).toHaveBeenCalledWith({
         message: 'Must be at least 3 characters.',
-        resourceName: 't',
+        resourceLabel: 't',
       });
 
-      instance.resourceName = 'Test';
+      instance.resourceLabel = 'Test';
       await instance.provision();
 
       expect(fetchMock.called(`${connections.prod.gateway}/resource/`)).toBe(false);
       expect(instance.invalidEvent.emit).toHaveBeenCalledWith({
         message:
           'Must start with a lowercase letter, and use only lowercase, numbers, and hyphens.',
-        resourceName: 'Test',
+        resourceLabel: 'Test',
       });
     });
   });

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
@@ -11,14 +11,14 @@ import { Catalog } from '../../types/catalog';
 
 interface SuccessMessage {
   createdAt: string;
-  resourceName: string;
+  resourceLabel: string;
   resourceId: string;
   message: string;
 }
 
 interface ErrorMessage {
   message: string;
-  resourceName: string;
+  resourceLabel: string;
 }
 
 @Component({ tag: 'manifold-data-provision-button' })
@@ -34,8 +34,8 @@ export class ManifoldDataProvisionButton {
   @Prop() planLabel?: string;
   /** Region to provision (complete name), omit for all region */
   @Prop() regionName?: string;
-  /** The name of the resource to provision */
-  @Prop() resourceName?: string;
+  /** The label of the resource to provision */
+  @Prop() resourceLabel?: string;
   @Prop({ mutable: true }) ownerId?: string = '';
   @State() regionId?: string = globalRegion.id;
   @State() planId?: string = '';
@@ -68,32 +68,34 @@ export class ManifoldDataProvisionButton {
       console.error('Property “ownerId” is missing');
       return;
     }
-    if (!this.resourceName) {
-      console.error('Property “resourceName” is missing');
+    if (!this.resourceLabel) {
+      console.error('Property “resourceLabel” is missing');
       return;
     }
 
-    if (this.resourceName.length < 3) {
+    if (this.resourceLabel.length < 3) {
       this.invalidEvent.emit({
         message: 'Must be at least 3 characters.',
-        resourceName: this.resourceName,
+        resourceLabel: this.resourceLabel,
       });
       return;
     }
-    if (!this.validate(this.resourceName)) {
+    if (!this.validate(this.resourceLabel)) {
       this.invalidEvent.emit({
         message:
           'Must start with a lowercase letter, and use only lowercase, numbers, and hyphens.',
-        resourceName: this.resourceName,
+        resourceLabel: this.resourceLabel,
       });
       return;
     }
 
     // We use Gateway b/c it’s much easier to provision w/o generating a base32 ID
-    this.clickEvent.emit({ resourceName: this.resourceName });
+    this.clickEvent.emit({
+      resourceLabel: this.resourceLabel,
+    });
 
     const req: Gateway.ResourceCreateRequest = {
-      label: this.resourceName,
+      label: this.resourceLabel,
       owner: {
         id: this.ownerId,
         type: 'user',
@@ -120,9 +122,9 @@ export class ManifoldDataProvisionButton {
     if (response.status >= 200 && response.status < 300) {
       const success: SuccessMessage = {
         createdAt: body.created_at,
-        message: `${this.resourceName} successfully provisioned`,
+        message: `${this.resourceLabel} successfully provisioned`,
         resourceId: body.id,
-        resourceName: body.label,
+        resourceLabel: body.label,
       };
       this.successEvent.emit(success);
     } else {
@@ -130,7 +132,7 @@ export class ManifoldDataProvisionButton {
       const message = Array.isArray(body) ? body[0].message : body.message;
       const error: ErrorMessage = {
         message,
-        resourceName: this.resourceName,
+        resourceLabel: this.resourceLabel,
       };
       this.errorEvent.emit(error);
     }

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
@@ -8,46 +8,46 @@ import { ManifoldDataRenameButton } from './manifold-data-rename-button';
 
 describe('<manifold-data-rename-button>', () => {
   it('fetches the resource id on load if not set', () => {
-    const resourceName = 'test-resource';
+    const resourceLabel = 'test-resource';
 
     const provisionButton = new ManifoldDataRenameButton();
     provisionButton.fetchResourceId = jest.fn();
-    provisionButton.resourceName = resourceName;
+    provisionButton.resourceLabel = resourceLabel;
     provisionButton.componentWillLoad();
-    expect(provisionButton.fetchResourceId).toHaveBeenCalledWith(resourceName);
+    expect(provisionButton.fetchResourceId).toHaveBeenCalledWith(resourceLabel);
   });
 
   it('does not fetch the resource id on load if set', () => {
-    const resourceName = 'test-resource';
+    const resourceLabel = 'test-resource';
 
     const provisionButton = new ManifoldDataRenameButton();
     provisionButton.fetchResourceId = jest.fn();
-    provisionButton.resourceName = resourceName;
-    provisionButton.resourceId = resourceName;
+    provisionButton.resourceLabel = resourceLabel;
+    provisionButton.resourceId = resourceLabel;
     provisionButton.componentWillLoad();
     expect(provisionButton.fetchResourceId).not.toHaveBeenCalled();
   });
 
   it('fetches resource id on change if not set', () => {
-    const resourceName = 'new-resource';
+    const resourceLabel = 'new-resource';
 
     const provisionButton = new ManifoldDataRenameButton();
     provisionButton.fetchResourceId = jest.fn();
-    provisionButton.resourceName = 'old-resource';
+    provisionButton.resourceLabel = 'old-resource';
 
-    provisionButton.nameChange(resourceName);
-    expect(provisionButton.fetchResourceId).toHaveBeenCalledWith(resourceName);
+    provisionButton.labelChange(resourceLabel);
+    expect(provisionButton.fetchResourceId).toHaveBeenCalledWith(resourceLabel);
   });
 
   it('does not resource id on change if set', () => {
-    const resourceName = 'new-resource';
+    const resourceLabel = 'new-resource';
 
     const provisionButton = new ManifoldDataRenameButton();
     provisionButton.fetchResourceId = jest.fn();
-    provisionButton.resourceName = 'old-resource';
+    provisionButton.resourceLabel = 'old-resource';
     provisionButton.resourceId = '1234';
 
-    provisionButton.nameChange(resourceName);
+    provisionButton.labelChange(resourceLabel);
     expect(provisionButton.fetchResourceId).not.toHaveBeenCalled();
   });
 
@@ -57,9 +57,9 @@ describe('<manifold-data-rename-button>', () => {
     });
 
     it('will fetch the resource id', async () => {
-      const resourceName = 'new-resource';
+      const resourceLabel = 'new-resource';
 
-      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${resourceName}`, [
+      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`, [
         Resource,
       ]);
 
@@ -67,13 +67,13 @@ describe('<manifold-data-rename-button>', () => {
         components: [ManifoldDataRenameButton],
         html: `
           <manifold-data-rename-button
-            resource-name="${resourceName}"
+            resource-label="${resourceLabel}"
           >Rename</manifold-data-rename-button>
         `,
       });
 
       expect(
-        fetchMock.called(`${connections.prod.marketplace}/resources/?me&label=${resourceName}`)
+        fetchMock.called(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`)
       ).toBe(true);
 
       const root = page.rootInstance as ManifoldDataRenameButton;
@@ -81,21 +81,21 @@ describe('<manifold-data-rename-button>', () => {
     });
 
     it('will do nothing on a fetch error', async () => {
-      const resourceName = 'new-resource';
+      const resourceLabel = 'new-resource';
 
-      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&name=${resourceName}`, []);
+      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&name=${resourceLabel}`, []);
 
       const page = await newSpecPage({
         components: [ManifoldDataRenameButton],
         html: `
           <manifold-data-rename-button
-            resource-name="${resourceName}"
+            resource-label="${resourceLabel}"
           >Rename</manifold-data-rename-button>
         `,
       });
 
       expect(
-        fetchMock.called(`${connections.prod.marketplace}/resources/?me&label=${resourceName}`)
+        fetchMock.called(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`)
       ).toBe(true);
 
       const root = page.rootInstance as ManifoldDataRenameButton;
@@ -109,18 +109,18 @@ describe('<manifold-data-rename-button>', () => {
     });
 
     beforeEach(() => {
-      fetchMock.mock(/.*\/resources\/.*/, [Resource]);
+      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${Resource.body.label}`, [Resource]);
     });
 
     it('will trigger a dom event on successful rename', async () => {
-      fetchMock.mock(`${connections.prod.marketplace}/resource/${Resource.id}`, Resource);
+      fetchMock.mock(`${connections.prod.marketplace}/resources/${Resource.id}`, Resource);
 
       const page = await newSpecPage({
         components: [ManifoldDataRenameButton],
         html: `
           <manifold-data-rename-button
-            resource-name="test"
-            new-name="test2"
+            resource-label="${Resource.body.label}"
+            new-label="test2"
           >Rename</manifold-data-rename-button>
         `,
       });
@@ -130,17 +130,17 @@ describe('<manifold-data-rename-button>', () => {
 
       await instance.rename();
 
-      expect(fetchMock.called(`${connections.prod.marketplace}/resource/${Resource.id}`)).toBe(true);
+      expect(fetchMock.called(`${connections.prod.marketplace}/resources/${Resource.id}`)).toBe(true);
       expect(instance.successEvent.emit).toHaveBeenCalledWith({
-        message: `test successfully renamed`,
-        resourceName: 'test',
-        newName: 'test2',
+        message: `${Resource.body.label} successfully renamed`,
+        resourceLabel: Resource.body.label,
+        newLabel: 'test2',
         resourceId: Resource.id,
       });
     });
 
     it('will trigger a dom event on failed rename', async () => {
-      fetchMock.mock(`${connections.prod.marketplace}/resource/${Resource.id}`, {
+      fetchMock.mock(`${connections.prod.marketplace}/resources/${Resource.id}`, {
         status: 500,
         body: {
           message: 'ohnoes',
@@ -151,8 +151,8 @@ describe('<manifold-data-rename-button>', () => {
         components: [ManifoldDataRenameButton],
         html: `
           <manifold-data-rename-button
-            resource-name="test"
-            new-name="test2"
+            resource-label="${Resource.body.label}"
+            new-label="test2"
           >Provision</manifold-data-rename-button>
         `,
       });
@@ -162,11 +162,11 @@ describe('<manifold-data-rename-button>', () => {
 
       await instance.rename();
 
-      expect(fetchMock.called(`${connections.prod.marketplace}/resource/${Resource.id}`)).toBe(true);
+      expect(fetchMock.called(`${connections.prod.marketplace}/resources/${Resource.id}`)).toBe(true);
       expect(instance.errorEvent.emit).toHaveBeenCalledWith({
         message: 'ohnoes',
-        resourceName: 'test',
-        newName: 'test2',
+        resourceLabel: Resource.body.label,
+        newLabel: 'test2',
         resourceId: Resource.id,
       });
     });

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
@@ -8,33 +8,36 @@ import { Marketplace } from '../../types/marketplace';
 /* eslint-disable no-console */
 
 interface ClickMessage {
-  newName: string;
-  resourceName: string;
+  newLabel: string;
+  resourceLabel: string;
   resourceId: string;
 }
 
 interface InvalidMessage {
   message: string;
-  newName: string;
-  resourceName: string;
+  newLabel: string;
+  resourceLabel: string;
   resourceId: string;
 }
 
 interface SuccessMessage {
   message: string;
-  newName: string;
-  resourceName: string;
+  newLabel: string;
+  resourceLabel: string;
   resourceId: string;
 }
 
 interface ErrorMessage {
   message: string;
-  newName: string;
-  resourceName: string;
+  newLabel: string;
+  resourceLabel: string;
   resourceId: string;
 }
 
-@Component({ tag: 'manifold-data-rename-button' })
+@Component({
+  tag: 'manifold-data-rename-button',
+  shadow: true,
+})
 export class ManifoldDataRenameButton {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
@@ -42,9 +45,9 @@ export class ManifoldDataRenameButton {
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() authToken?: string;
   /** The label of the resource to rename */
-  @Prop() resourceName?: string;
-  /** The new name to give to the resource */
-  @Prop() newName: string = '';
+  @Prop() resourceLabel?: string;
+  /** The new label to give to the resource */
+  @Prop() newLabel: string = '';
   /** The id of the resource to rename, will be fetched if not set */
   @Prop({ mutable: true }) resourceId?: string = '';
   @Prop() loading?: boolean = false;
@@ -56,15 +59,15 @@ export class ManifoldDataRenameButton {
   @Event({ eventName: 'manifold-renameButton-success', bubbles: true })
   successEvent: EventEmitter;
 
-  @Watch('resourceName') nameChange(newName: string) {
+  @Watch('resourceLabel') labelChange(newLabel: string) {
     if (!this.resourceId) {
-      this.fetchResourceId(newName);
+      this.fetchResourceId(newLabel);
     }
   }
 
   componentWillLoad() {
-    if (this.resourceName && !this.resourceId) {
-      this.fetchResourceId(this.resourceName);
+    if (this.resourceLabel && !this.resourceId) {
+      this.fetchResourceId(this.resourceLabel);
     }
   }
 
@@ -74,22 +77,22 @@ export class ManifoldDataRenameButton {
       return;
     }
 
-    if (this.newName.length < 3) {
+    if (this.newLabel.length < 3) {
       const message: InvalidMessage = {
         message: 'Must be at least 3 characters.',
-        resourceName: this.resourceName || '',
-        newName: this.newName,
+        resourceLabel: this.resourceLabel || '',
+        newLabel: this.newLabel,
         resourceId: this.resourceId,
       };
       this.invalidEvent.emit(message);
       return;
     }
-    if (!this.validate(this.newName)) {
+    if (!this.validate(this.newLabel)) {
       const message: InvalidMessage = {
         message:
           'Must start with a lowercase letter, and use only lowercase, numbers, and hyphens.',
-        resourceName: this.resourceName || '',
-        newName: this.newName,
+        resourceLabel: this.resourceLabel || '',
+        newLabel: this.newLabel,
         resourceId: this.resourceId,
       };
       this.invalidEvent.emit(message);
@@ -97,20 +100,20 @@ export class ManifoldDataRenameButton {
     }
 
     const clickMessage: ClickMessage = {
-      resourceName: this.resourceName || '',
-      newName: this.newName,
+      resourceLabel: this.resourceLabel || '',
+      newLabel: this.newLabel,
       resourceId: this.resourceId,
     };
     this.clickEvent.emit(clickMessage);
 
     const body: Marketplace.PublicUpdateResource = {
       body: {
-        name: this.newName,
-        label: this.newName,
+        name: this.newLabel,
+        label: this.newLabel,
       },
     };
     const response = await fetch(
-      `${this.connection.marketplace}/resource/${this.resourceId}`,
+      `${this.connection.marketplace}/resources/${this.resourceId}`,
       withAuth(this.authToken, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
@@ -121,9 +124,9 @@ export class ManifoldDataRenameButton {
     // If successful, this will return 200 and stop here
     if (response.status >= 200 && response.status < 300) {
       const success: SuccessMessage = {
-        message: `${this.resourceName} successfully renamed`,
-        resourceName: this.resourceName || '',
-        newName: this.newName,
+        message: `${this.resourceLabel} successfully renamed`,
+        resourceLabel: this.resourceLabel || '',
+        newLabel: this.newLabel,
         resourceId: this.resourceId,
       };
       this.successEvent.emit(success);
@@ -134,23 +137,23 @@ export class ManifoldDataRenameButton {
       const message = Array.isArray(result) ? result[0].message : result.message;
       const error: ErrorMessage = {
         message,
-        resourceName: this.resourceName || '',
-        newName: this.newName,
+        resourceLabel: this.resourceLabel || '',
+        newLabel: this.newLabel,
         resourceId: this.resourceId,
       };
       this.errorEvent.emit(error);
     }
   }
 
-  async fetchResourceId(resourceName: string) {
+  async fetchResourceId(resourceLabel: string) {
     const resourceResp = await fetch(
-      `${this.connection.marketplace}/resources/?me&label=${resourceName}`,
+      `${this.connection.marketplace}/resources/?me&label=${resourceLabel}`,
       withAuth(this.authToken)
     );
     const resources: Marketplace.Resource[] = await resourceResp.json();
 
     if (!Array.isArray(resources) || !resources.length) {
-      console.error(`${resourceName} product not found`);
+      console.error(`${resourceLabel} product not found`);
       return;
     }
 

--- a/src/components/manifold-data-resource-list/manifold-data-resource-list.tsx
+++ b/src/components/manifold-data-resource-list/manifold-data-resource-list.tsx
@@ -7,6 +7,7 @@ import { Connection, connections } from '../../utils/connections';
 interface EventDetail {
   ownerId?: string;
   resourceId: string;
+  resourceLabel: string;
   resourceName: string;
 }
 
@@ -60,7 +61,8 @@ export class ManifoldDataResourceList {
       e.preventDefault();
       const detail: EventDetail = {
         resourceId: resource.id,
-        resourceName: resource.body.label,
+        resourceLabel: resource.body.label,
+        resourceName: resource.body.name,
         ownerId: resource.body.owner_id,
       };
       this.clickEvent.emit(detail);
@@ -68,7 +70,9 @@ export class ManifoldDataResourceList {
   }
 
   formatLink(resource: Marketplace.Resource) {
-    if (!this.resourceLinkFormat) return undefined;
+    if (!this.resourceLinkFormat) {
+      return undefined;
+    }
     return this.resourceLinkFormat.replace(/:resource/gi, resource.body.label);
   }
 
@@ -89,7 +93,7 @@ export class ManifoldDataResourceList {
         {this.resources.map(resource => (
           <li>
             <a href={this.formatLink(resource)} onClick={e => this.handleClick(resource, e)}>
-              {resource.body.label}
+              {resource.body.name}
             </a>
           </li>
         ))}

--- a/src/components/manifold-plan-details/manifold-plan-details.tsx
+++ b/src/components/manifold-plan-details/manifold-plan-details.tsx
@@ -226,7 +226,12 @@ export class ManifoldPlanDetails {
       const { expanded_features, name: planName } = this.plan.body;
 
       return (
-        <section class={this.scrollLocked ? 'scroll' : ''} itemscope itemtype="https://schema.org/IndividualProduct">
+        <section
+          class="wrapper"
+          data-scroll-locked={this.scrollLocked}
+          itemscope
+          itemtype="https://schema.org/IndividualProduct"
+        >
           <div class="card">
             <header class="header">
               <div class="logo">
@@ -257,7 +262,7 @@ export class ManifoldPlanDetails {
     }
     // 💀
     return (
-      <section class={this.scrollLocked ? 'scroll' : ''}>
+      <section class="wrapper" data-scroll-locked={this.scrollLocked}>
         <div class="card">
           <header class="header">
             <div class="logo">

--- a/src/components/manifold-plan-details/manifold-plan-details.tsx
+++ b/src/components/manifold-plan-details/manifold-plan-details.tsx
@@ -22,6 +22,7 @@ interface EventDetail {
 })
 export class ManifoldPlanDetails {
   @Prop() isExistingResource?: boolean = false;
+  @Prop() scrollLocked?: boolean = false;
   @Prop() plan?: Catalog.ExpandedPlan;
   @Prop() product?: Catalog.Product;
   @Prop() regions?: string[];
@@ -225,7 +226,7 @@ export class ManifoldPlanDetails {
       const { expanded_features, name: planName } = this.plan.body;
 
       return (
-        <section class="scroll" itemscope itemtype="https://schema.org/IndividualProduct">
+        <section class={this.scrollLocked ? 'scroll' : ''} itemscope itemtype="https://schema.org/IndividualProduct">
           <div class="card">
             <header class="header">
               <div class="logo">
@@ -256,7 +257,7 @@ export class ManifoldPlanDetails {
     }
     // 💀
     return (
-      <section class="scroll">
+      <section class={this.scrollLocked ? 'scroll' : ''}>
         <div class="card">
           <header class="header">
             <div class="logo">

--- a/src/components/manifold-plan-details/plan-details.css
+++ b/src/components/manifold-plan-details/plan-details.css
@@ -27,6 +27,13 @@
   font-family: var(--manifold-font-family);
 }
 
+.wrapper {
+  &[data-scroll-locked] {
+    position: sticky;
+    top: 1.5rem;
+  }
+}
+
 .card {
   padding-top: var(--padding);
   padding-right: var(--padding);
@@ -95,11 +102,6 @@
   font-size: var(--manifold-font-d2);
   letter-spacing: 0.0625em;
   text-transform: uppercase;
-}
-
-.scroll {
-  position: sticky;
-  top: 1.5rem;
 }
 
 .features {

--- a/src/components/manifold-plan-selector/manifold-plan-selector.spec.ts
+++ b/src/components/manifold-plan-selector/manifold-plan-selector.spec.ts
@@ -22,13 +22,13 @@ describe('<manifold-plan-selector>', () => {
   });
 
   it('fetches resource on load by resource name, if given', () => {
-    const resourceName = 'my-resource';
+    const resourceLabel = 'my-resource';
 
     const planSelector = new ManifoldPlanSelector();
     planSelector.fetchResource = jest.fn();
-    planSelector.resourceName = resourceName;
+    planSelector.resourceLabel = resourceLabel;
     planSelector.componentWillLoad();
-    expect(planSelector.fetchResource).toHaveBeenCalledWith(resourceName);
+    expect(planSelector.fetchResource).toHaveBeenCalledWith(resourceLabel);
   });
 
   it('fetches resource on change by resource name, if given', () => {
@@ -36,7 +36,7 @@ describe('<manifold-plan-selector>', () => {
 
     const planSelector = new ManifoldPlanSelector();
     planSelector.fetchResource = jest.fn();
-    planSelector.resourceName = 'old-resource';
+    planSelector.resourceLabel = 'old-resource';
     planSelector.resourceChange(newResource);
     expect(planSelector.fetchResource).toHaveBeenCalledWith(newResource);
   });

--- a/src/components/manifold-plan-selector/manifold-plan-selector.tsx
+++ b/src/components/manifold-plan-selector/manifold-plan-selector.tsx
@@ -17,7 +17,7 @@ export class ManifoldPlanSelector {
   /** Specify region order */
   @Prop() regions?: string;
   /** Is this tied to an existing resource? */
-  @Prop() resourceName?: string;
+  @Prop() resourceLabel?: string;
   @State() product?: Catalog.Product;
   @State() plans?: Catalog.Plan[];
   @State() resource?: Gateway.Resource;
@@ -25,7 +25,7 @@ export class ManifoldPlanSelector {
   @Watch('productLabel') productChange(newProduct: string) {
     this.fetchProductByLabel(newProduct);
   }
-  @Watch('resourceName') resourceChange(newResource: string) {
+  @Watch('resourceLabel') resourceChange(newResource: string) {
     this.fetchResource(newResource);
   }
   @Watch('regions') regionsChange(newRegions: string) {
@@ -35,8 +35,8 @@ export class ManifoldPlanSelector {
   componentWillLoad() {
     if (this.productLabel) {
       this.fetchProductByLabel(this.productLabel);
-    } else if (this.resourceName) {
-      this.fetchResource(this.resourceName);
+    } else if (this.resourceLabel) {
+      this.fetchResource(this.resourceLabel);
     }
   }
 
@@ -58,11 +58,11 @@ export class ManifoldPlanSelector {
     this.plans = [...plans].sort((a, b) => a.body.cost - b.body.cost);
   }
 
-  async fetchResource(resourceName: string) {
+  async fetchResource(resourceLabel: string) {
     this.resource = undefined;
     this.product = undefined;
     const { catalog, gateway } = this.connection;
-    const response = await fetch(`${gateway}/resources/me/${resourceName}`, withAuth(this.authToken));
+    const response = await fetch(`${gateway}/resources/me/${resourceLabel}`, withAuth(this.authToken));
     const resource: Gateway.Resource = await response.json();
     this.resource = resource;
     if (!resource.product) return;

--- a/src/components/manifold-plan/manifold-plan.tsx
+++ b/src/components/manifold-plan/manifold-plan.tsx
@@ -56,6 +56,7 @@ export class ManifoldPlan {
   render() {
     return (
       <manifold-plan-details
+        scrollLocked={false}
         plan={this.plan}
         product={this.product}
       />

--- a/src/components/manifold-resource-card-view/manifold-resource-card-view.e2e.ts
+++ b/src/components/manifold-resource-card-view/manifold-resource-card-view.e2e.ts
@@ -2,17 +2,27 @@ import { newE2EPage } from '@stencil/core/testing';
 
 /* eslint-disable no-param-reassign */
 
-const name = 'my-resource';
+const label = 'my-resource';
+const name = 'my resource';
 const logo = 'https://cdn.manifold.co/providers/jawsdb/logos/80ca8b9113cf76fd.png';
 
 describe('<manifold-resource-card>', () => {
-  it('displays label', async () => {
+  it('displays name', async () => {
     const page = await newE2EPage({
-      html: `<manifold-resource-card-view label="${name}" resource-id="test" />`,
+      html: `<manifold-resource-card-view label="${label}" name="${name}" resource-id="test" />`,
     });
     const el = await page.find('manifold-resource-card-view >>> [itemprop="name"]');
 
     expect(el.innerText).toBe(name);
+  });
+
+  it('displays label', async () => {
+    const page = await newE2EPage({
+      html: `<manifold-resource-card-view label="${label}" resource-id="test" />`,
+    });
+    const el = await page.find('manifold-resource-card-view >>> [itemprop="name"]');
+
+    expect(el.innerText).toBe(label);
   });
 
   it('displays logo', async () => {

--- a/src/components/manifold-resource-card-view/manifold-resource-card-view.spec.ts
+++ b/src/components/manifold-resource-card-view/manifold-resource-card-view.spec.ts
@@ -6,6 +6,7 @@ describe('<manifold-resource-card>', () => {
   it('dispatches click event', () => {
     const serviceCard = new ManifoldResourceCardView();
     serviceCard.label = Resource.body.label;
+    serviceCard.name = Resource.body.name;
     serviceCard.resourceId = Resource.id;
     serviceCard.logo = Product.body.logo_url;
     serviceCard.resourceStatus = 'available';
@@ -16,6 +17,7 @@ describe('<manifold-resource-card>', () => {
     serviceCard.onClick(new Event('click'));
     expect(mock.emit).toHaveBeenCalledWith({
       resourceId: Resource.id,
+      resourceName: Resource.body.name,
       resourceLabel: Resource.body.label,
     });
   });

--- a/src/components/manifold-resource-card-view/manifold-resource-card-view.tsx
+++ b/src/components/manifold-resource-card-view/manifold-resource-card-view.tsx
@@ -9,6 +9,7 @@ import { Gateway } from '../../types/gateway';
 interface EventDetail {
   resourceId?: string;
   resourceLabel?: string;
+  resourceName?: string;
 }
 
 const AVAILABLE = 'available';
@@ -28,6 +29,7 @@ export class ManifoldResourceCardView {
   @Prop() authToken?: string;
 
   @Prop() label?: string;
+  @Prop() name?: string;
   @Prop() logo?: string;
   @Prop() resourceId?: string;
   @Prop() resourceStatus?: string;
@@ -89,6 +91,7 @@ export class ManifoldResourceCardView {
       const detail: EventDetail = {
         resourceId: this.resourceId,
         resourceLabel: this.label,
+        resourceName: this.name,
       };
       this.resourceClick.emit(detail);
     }
@@ -107,7 +110,7 @@ export class ManifoldResourceCardView {
         onClick={this.onClick}
       >
         <h3 class="name" itemprop="name">
-          {this.label}
+          {this.name || this.label}
         </h3>
         <div class="status-box">
           <div class="status" data-status={this.status}>

--- a/src/components/manifold-resource-card/manifold-resource-card.tsx
+++ b/src/components/manifold-resource-card/manifold-resource-card.tsx
@@ -66,6 +66,7 @@ export class ManifoldResourceCard {
     return this.resource ? (
       <manifold-resource-card-view
         label={this.resource.label}
+        name={this.resource.name}
         logo={this.resource.product && this.resource.product.logo_url}
         resourceId={this.resource.id}
         resourceStatus={this.resource.state}

--- a/src/components/manifold-resource-container/manifold-resource-container.spec.ts
+++ b/src/components/manifold-resource-container/manifold-resource-container.spec.ts
@@ -2,13 +2,13 @@ import { ManifoldResourceContainer } from './manifold-resource-container';
 
 describe('<manifold-resource-credentials>', () => {
   it('fetches resource on load', () => {
-    const resourceName = 'my-resource';
+    const resourceLabel = 'my-resource';
 
     const resourceCreds = new ManifoldResourceContainer();
     resourceCreds.fetchResource = jest.fn();
-    resourceCreds.resourceName = resourceName;
+    resourceCreds.resourceLabel = resourceLabel;
     resourceCreds.componentWillLoad();
-    expect(resourceCreds.fetchResource).toHaveBeenCalledWith(resourceName);
+    expect(resourceCreds.fetchResource).toHaveBeenCalledWith(resourceLabel);
   });
 
   it('fetches resource  on change', () => {
@@ -16,7 +16,7 @@ describe('<manifold-resource-credentials>', () => {
 
     const resourceCreds = new ManifoldResourceContainer();
     resourceCreds.fetchResource = jest.fn();
-    resourceCreds.resourceName = 'old-resource';
+    resourceCreds.resourceLabel = 'old-resource';
     resourceCreds.resourceChange(newResource);
     expect(resourceCreds.fetchResource).toHaveBeenCalledWith(newResource);
   });

--- a/src/components/manifold-resource-container/manifold-resource-container.tsx
+++ b/src/components/manifold-resource-container/manifold-resource-container.tsx
@@ -12,24 +12,24 @@ export class ManifoldResourceContainer {
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() authToken?: string;
   /** Which resource does this belong to? */
-  @Prop() resourceName?: string;
+  @Prop() resourceLabel?: string;
   @State() resource?: Gateway.Resource;
   @State() loading: boolean = false;
 
-  @Watch('resourceName') resourceChange(newName: string) {
+  @Watch('resourceLabel') resourceChange(newName: string) {
     this.fetchResource(newName);
   }
 
   componentWillLoad() {
-    if (this.resourceName) {
-      this.fetchResource(this.resourceName);
+    if (this.resourceLabel) {
+      this.fetchResource(this.resourceLabel);
     }
   }
 
-  fetchResource = async (resourceName: string) => {
+  fetchResource = async (resourceLabel: string) => {
     this.loading = true;
     const { gateway } = this.connection;
-    const response = await fetch(`${gateway}/resources/me/${resourceName}`, withAuth(this.authToken));
+    const response = await fetch(`${gateway}/resources/me/${resourceLabel}`, withAuth(this.authToken));
     this.resource = await response.json();
     this.loading = false;
   };

--- a/src/components/manifold-resource-credentials/manifold-resource-credentials.tsx
+++ b/src/components/manifold-resource-credentials/manifold-resource-credentials.tsx
@@ -9,7 +9,7 @@ export class ManifoldResourceCredentials {
       <ResourceTunnel.Consumer>
         {(state: ResourceState) => (
           <manifold-credentials
-            resourceName={state.data && state.data.label}
+            resourceLabel={state.data && state.data.label}
             resourceId={state.data && state.data.id}
           />
         )}

--- a/src/components/manifold-resource-deprovision/manifold-resource-deprovision.tsx
+++ b/src/components/manifold-resource-deprovision/manifold-resource-deprovision.tsx
@@ -1,24 +1,29 @@
-import { h, Component } from '@stencil/core';
+import { h, Component, Prop } from '@stencil/core';
 
-import ResourceTunnel, { ResourceState } from '../../data/resource';
+import ResourceTunnel from '../../data/resource';
+import { Gateway } from '../../types/gateway';
 
-@Component({ tag: 'manifold-resource-deprovision' })
+@Component({
+  tag: 'manifold-resource-deprovision',
+  shadow: true,
+})
 export class ManifoldResourceDeprovision {
+  @Prop() data?: Gateway.Resource;
+  @Prop() loading: boolean = true;
+
   render() {
     return (
-      <ResourceTunnel.Consumer>
-        {(state: ResourceState) => (
-          <manifold-data-deprovision-button
-            resourceId={state.data && state.data.id}
-            resourceName={state.data && state.data.label}
-            loading={state.loading}
-          >
-            <manifold-forward-slot>
-              <slot />
-            </manifold-forward-slot>
-          </manifold-data-deprovision-button>
-        )}
-      </ResourceTunnel.Consumer>
+      <manifold-data-deprovision-button
+        resourceId={this.data && this.data.id}
+        resourceLabel={this.data && this.data.label}
+        loading={this.loading}
+      >
+        <manifold-forward-slot>
+          <slot />
+        </manifold-forward-slot>
+      </manifold-data-deprovision-button>
     );
   }
 }
+
+ResourceTunnel.injectProps(ManifoldResourceDeprovision, ['data', 'loading']);

--- a/src/components/manifold-resource-list/manifold-resource-list.spec.ts
+++ b/src/components/manifold-resource-list/manifold-resource-list.spec.ts
@@ -54,6 +54,7 @@ describe('<manifold-resource-list>', () => {
     expect(resourceList.resources).toEqual([
       {
         id: Resource.id,
+        name: Resource.body.name,
         label: Resource.body.label,
         logo: Product.body.logo_url,
         status: 'provision',

--- a/src/components/manifold-resource-list/manifold-resource-list.tsx
+++ b/src/components/manifold-resource-list/manifold-resource-list.tsx
@@ -10,6 +10,7 @@ import { Connection, connections } from '../../utils/connections';
 interface FoundResource {
   id: string;
   label: string;
+  name: string;
   logo?: string;
   status: string;
 }
@@ -147,6 +148,7 @@ export class ManifoldResourceList {
           return {
             id: resource.id,
             label: resource.body.label,
+            name: resource.body.name,
             logo: product && product.body.logo_url,
             status: operation ? ManifoldResourceList.opStateToStatus(operation) : 'available',
           };
@@ -169,6 +171,7 @@ export class ManifoldResourceList {
         {this.resources.map(resource => (
           <manifold-resource-card-view
             label={resource.label}
+            name={resource.name}
             logo={resource.logo}
             resource-id={resource.id}
             resource-status={resource.status}

--- a/src/components/manifold-resource-plan/manifold-resource-plan.tsx
+++ b/src/components/manifold-resource-plan/manifold-resource-plan.tsx
@@ -15,6 +15,7 @@ export class ManifoldResourcePlan {
           state.data.plan &&
           state.data.product.provider ? (
             <manifold-plan-details
+              scrollLocked={false}
               plan={convertPlan(
                 state.data.plan,
                 state.data.product.id || '',

--- a/src/components/manifold-resource-rename/manifold-resource-rename.tsx
+++ b/src/components/manifold-resource-rename/manifold-resource-rename.tsx
@@ -1,24 +1,30 @@
-import { h, Component } from '@stencil/core';
+import { h, Component, Prop } from '@stencil/core';
 
-import ResourceTunnel, { ResourceState } from '../../data/resource';
+import ResourceTunnel from '../../data/resource';
+import { Gateway } from '../../types/gateway';
 
-@Component({ tag: 'manifold-resource-rename' })
+@Component({
+  tag: 'manifold-resource-rename',
+  shadow: true,
+})
 export class ManifoldResourceRename {
+  @Prop() data?: Gateway.Resource;
+  @Prop() loading: boolean = true;
+
   render() {
     return (
-      <ResourceTunnel.Consumer>
-        {(state: ResourceState) => (
-          <manifold-data-rename-button
-            resourceId={state.data && state.data.id}
-            resourceName={state.data && state.data.label}
-            loading={state.loading}
-          >
-            <manifold-forward-slot>
-              <slot />
-            </manifold-forward-slot>
-          </manifold-data-rename-button>
-        )}
-      </ResourceTunnel.Consumer>
+      <manifold-data-rename-button
+        resourceId={this.data && this.data.id}
+        resourceLabel={this.data && this.data.label}
+        loading={this.loading}
+      >
+        <manifold-forward-slot>
+          <slot />
+        </manifold-forward-slot>
+      </manifold-data-rename-button>
     );
   }
 }
+
+ResourceTunnel.injectProps(ManifoldResourceRename, ['data', 'loading']);
+

--- a/stories/manifold-data-deprovision-button.stories.js
+++ b/stories/manifold-data-deprovision-button.stories.js
@@ -6,7 +6,7 @@ storiesOf('Provision Button [Data]', module)
   .add(
     'default',
     () => `
-      <manifold-data-provision-button resource-name="my-resource">
+      <manifold-data-provision-button resource-label="my-resource">
         Deprovision resource
       </manifold-data-provision-button>
     `

--- a/stories/manifold-data-manage-button.stories.js
+++ b/stories/manifold-data-manage-button.stories.js
@@ -6,5 +6,5 @@ storiesOf('Manage Button 🔒 [Data]', module)
   .add(
     'default',
     () =>
-      '<manifold-data-manage-button resource-name="my-resource">💾 Save</manifold-data-manage-button>'
+      '<manifold-data-manage-button resource-label="my-resource">💾 Save</manifold-data-manage-button>'
   );

--- a/stories/manifold-data-provision-button.stories.js
+++ b/stories/manifold-data-provision-button.stories.js
@@ -8,7 +8,7 @@ storiesOf('Provision Button [Data]', module)
     () => `
       <label for="my-provision-button">Resource Name</label>
       <input id="my-provision-button" value="my-resource">my-resource</input>
-      <manifold-data-provision-button resource-name="my-resource">
+      <manifold-data-provision-button resource-label="my-resource">
         🚀 Provision Business plan on Prefab.cloud
       </manifold-data-provision-button>
     `

--- a/stories/manifold-data-rename-button.stories.js
+++ b/stories/manifold-data-rename-button.stories.js
@@ -1,12 +1,12 @@
 import { storiesOf } from '@storybook/html';
 import markdown from '../docs/docs/data/manifold-data-rename-button.md';
 
-storiesOf('Rename Button 🔒', module)
+storiesOf('Rename Button 🔒 [Data]', module)
   .addParameters({ readme: { sidebar: markdown } })
   .add(
     'default',
     () => `
-      <manifold-data-rename-button resource-name="my-resource" resource-id="1234">
+      <manifold-data-rename-button resource-label="my-resource" resource-id="1234">
         Save
       </manifold-data-rename-button>
     `

--- a/stories/manifold-resource-card.stories.js
+++ b/stories/manifold-resource-card.stories.js
@@ -5,13 +5,13 @@ storiesOf('Resource card 🔒 ', module)
   .addParameters({ readme: { sidebar: markdown } })
   .add(
     'View resource',
-    () => '<manifold-resource-card-view label="my-resource" logo="https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png" resource-id="1234" resource-status="available"/>'
+    () => '<manifold-resource-card-view name="My resource" label="my-resource" logo="https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png" resource-id="1234" resource-status="available"/>'
   )
   .add(
     'Loading resource',
-    () => '<manifold-resource-card-view label="my-resource" logo="https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png" loading="" resource-status="unknown"/>'
+    () => '<manifold-resource-card-view name="My resource" label="my-resource" logo="https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png" loading="" resource-status="unknown"/>'
   )
   .add(
     'Resource with link',
-    () => '<manifold-resource-card-view label="my-resource" logo="https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png" resource-id="1234" resource-status="unknown" resource-link-format="/resources/:resource" />'
+    () => '<manifold-resource-card-view name="My resource" label="my-resource" logo="https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png" resource-id="1234" resource-status="unknown" resource-link-format="/resources/:resource" />'
   );

--- a/stories/manifold-resource-credentials.stories.js
+++ b/stories/manifold-resource-credentials.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/html';
-import markdown from '../docs/docs/components/manifold-resource-credentials.md';
+import markdown from '../docs/docs/components/manifold-credentials.md';
 
 const credentialsView = `
 <manifold-resource-container resource-name="cms-stage">


### PR DESCRIPTION
Work is related to manifoldco/engineering#8729

## Reason for change
Everywhere in our docs we are using resource label for the slug we can use to fetch and resource name for the display name. In UI, resource name was the slug and the display name. That distinction has now been fixed and we should have a more clear standard when it comes to names and labels.

This PR also adds a new documentation page for how to create a fully connected resource details view with the components I have been creating.

## Testing
Test with storybook and the docs