### PR TITLE
Use shadowcat for oauth 

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -951,6 +951,11 @@
         "yargs": "^9.0.0"
       }
     },
+    "@manifoldco/gql-zero": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@manifoldco/gql-zero/-/gql-zero-0.2.0.tgz",
+      "integrity": "sha512-s0nPkp5PUzvqK8SaIQEMw5AYArC4slq+YQ9xL9lG8QImMO1NIWfnrvwJRVAO+Ns5dmeZeAdXACX+1g2k27I0Yg=="
+    },
     "@manifoldco/icons": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@manifoldco/icons/-/icons-0.0.3.tgz",
@@ -959,6 +964,7 @@
     "@manifoldco/ui": {
       "version": "file:..",
       "requires": {
+        "@manifoldco/gql-zero": "^0.2.0",
         "@stencil/state-tunnel": "^1.0.1"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1694,9 +1694,9 @@
       "dev": true
     },
     "@manifoldco/shadowcat": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@manifoldco/shadowcat/-/shadowcat-0.0.2.tgz",
-      "integrity": "sha512-amKxLHY/NLlqFKup7tRdUNAD2ZVwNmPBea167y/dbKpRXjZZjFRbkBmJXUuLvaHRfOngpKH3Q+TeBw9NLBjPoQ==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@manifoldco/shadowcat/-/shadowcat-0.1.3.tgz",
+      "integrity": "sha512-UU12ANMq/C9clGbXTnq9/S4rCCbk75Ug4OlskjjDF7KDjiJrnLuvmB1DlqK9KYdmGA7Fss+xXSWBsYX6t35qpw==",
       "dev": true
     },
     "@mrmlnc/readdir-enhanced": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1693,6 +1693,12 @@
       "integrity": "sha512-mmi4h29UcJyGYF5Fx0wZoZVuTDS1x21paYFJzWbvpHKi4FrpEuqI5IkR3KRLvFgL+zb8G2O8GUX5pdXehR9EYw==",
       "dev": true
     },
+    "@manifoldco/shadowcat": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@manifoldco/shadowcat/-/shadowcat-0.0.2.tgz",
+      "integrity": "sha512-amKxLHY/NLlqFKup7tRdUNAD2ZVwNmPBea167y/dbKpRXjZZjFRbkBmJXUuLvaHRfOngpKH3Q+TeBw9NLBjPoQ==",
+      "dev": true
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -7481,21 +7487,21 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
@@ -7513,14 +7519,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "optional": true,
@@ -7538,28 +7544,28 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
@@ -7583,21 +7589,21 @@
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
@@ -7607,14 +7613,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
@@ -7646,7 +7652,7 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
@@ -7663,7 +7669,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
@@ -7673,7 +7679,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
@@ -7684,21 +7690,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "optional": true,
@@ -7708,14 +7714,14 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "optional": true,
@@ -7725,7 +7731,7 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true,
           "optional": true
@@ -7753,7 +7759,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "optional": true,
@@ -7801,7 +7807,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
@@ -7830,7 +7836,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
@@ -7843,21 +7849,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "optional": true,
@@ -7867,21 +7873,21 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
@@ -7892,14 +7898,14 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
@@ -7919,7 +7925,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
@@ -7928,7 +7934,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -7961,14 +7967,14 @@
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
@@ -7982,21 +7988,21 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "optional": true,
@@ -8008,7 +8014,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
@@ -8018,7 +8024,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "optional": true,
@@ -8028,7 +8034,7 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
@@ -8051,7 +8057,7 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
@@ -8068,7 +8074,7 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true,
           "optional": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1694,9 +1694,9 @@
       "dev": true
     },
     "@manifoldco/shadowcat": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@manifoldco/shadowcat/-/shadowcat-0.1.3.tgz",
-      "integrity": "sha512-UU12ANMq/C9clGbXTnq9/S4rCCbk75Ug4OlskjjDF7KDjiJrnLuvmB1DlqK9KYdmGA7Fss+xXSWBsYX6t35qpw==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@manifoldco/shadowcat/-/shadowcat-0.1.5.tgz",
+      "integrity": "sha512-d+UIi9vyUjExBVXFtnrqUpF1agupnqTrA4AVPCqADpGs6/XawKiAU7bJyKuW51k+AQHSZLygB1G1C7EFHW89AA==",
       "dev": true
     },
     "@mrmlnc/readdir-enhanced": {
@@ -7487,21 +7487,21 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
@@ -7519,14 +7519,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "optional": true,
@@ -7544,28 +7544,28 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
@@ -7589,21 +7589,21 @@
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
@@ -7613,14 +7613,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
@@ -7652,7 +7652,7 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
@@ -7669,7 +7669,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
@@ -7679,7 +7679,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
@@ -7690,21 +7690,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "optional": true,
@@ -7714,14 +7714,14 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "optional": true,
@@ -7731,7 +7731,7 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true,
           "optional": true
@@ -7759,7 +7759,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "optional": true,
@@ -7807,7 +7807,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
@@ -7836,7 +7836,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
@@ -7849,21 +7849,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "optional": true,
@@ -7873,21 +7873,21 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
@@ -7898,14 +7898,14 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
@@ -7925,7 +7925,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
@@ -7934,7 +7934,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -7967,14 +7967,14 @@
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
@@ -7988,21 +7988,21 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "optional": true,
@@ -8014,7 +8014,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
@@ -8024,7 +8024,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "optional": true,
@@ -8034,7 +8034,7 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
@@ -8057,7 +8057,7 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
@@ -8074,7 +8074,7 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true,
           "optional": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -7487,21 +7487,21 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
@@ -7519,14 +7519,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "optional": true,
@@ -7544,28 +7544,28 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
@@ -7589,21 +7589,21 @@
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
@@ -7613,14 +7613,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
@@ -7652,7 +7652,7 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
@@ -7669,7 +7669,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
@@ -7679,7 +7679,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
@@ -7690,21 +7690,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "optional": true,
@@ -7714,14 +7714,14 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "optional": true,
@@ -7731,7 +7731,7 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true,
           "optional": true
@@ -7759,7 +7759,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "optional": true,
@@ -7807,7 +7807,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
@@ -7836,7 +7836,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
@@ -7849,21 +7849,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "optional": true,
@@ -7873,21 +7873,21 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
@@ -7898,14 +7898,14 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
@@ -7925,7 +7925,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
@@ -7934,7 +7934,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -7967,14 +7967,14 @@
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
@@ -7988,21 +7988,21 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "optional": true,
@@ -8014,7 +8014,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
@@ -8024,7 +8024,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "optional": true,
@@ -8034,7 +8034,7 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
@@ -8057,7 +8057,7 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
@@ -8074,7 +8074,7 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true,
           "optional": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -7487,21 +7487,21 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
@@ -7519,14 +7519,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "optional": true,
@@ -7544,28 +7544,28 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
@@ -7589,21 +7589,21 @@
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
@@ -7613,14 +7613,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
@@ -7652,7 +7652,7 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
@@ -7669,7 +7669,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
@@ -7679,7 +7679,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
@@ -7690,21 +7690,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "optional": true,
@@ -7714,14 +7714,14 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "optional": true,
@@ -7731,7 +7731,7 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true,
           "optional": true
@@ -7759,7 +7759,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "optional": true,
@@ -7807,7 +7807,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
@@ -7836,7 +7836,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
@@ -7849,21 +7849,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "optional": true,
@@ -7873,21 +7873,21 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
@@ -7898,14 +7898,14 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
@@ -7925,7 +7925,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "",
+              "resolved": false,
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
@@ -7934,7 +7934,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -7967,14 +7967,14 @@
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
@@ -7988,21 +7988,21 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "optional": true,
@@ -8014,7 +8014,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
@@ -8024,7 +8024,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "optional": true,
@@ -8034,7 +8034,7 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
@@ -8057,7 +8057,7 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
@@ -8074,7 +8074,7 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "",
+          "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true,
           "optional": true

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@graphql-codegen/typescript-operations": "^1.3.1",
     "@manifoldco/eslint-plugin-stencil": "^0.2.1",
     "@manifoldco/icons": "0.0.3",
+    "@manifoldco/shadowcat": "0.0.2",
     "@reach/observe-rect": "^1.0.3",
     "@stencil/core": "^1.1.7",
     "@stencil/postcss": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@graphql-codegen/typescript-operations": "^1.3.1",
     "@manifoldco/eslint-plugin-stencil": "^0.2.1",
     "@manifoldco/icons": "0.0.3",
-    "@manifoldco/shadowcat": "^0.1.3",
+    "@manifoldco/shadowcat": "^0.1.5",
     "@reach/observe-rect": "^1.0.3",
     "@stencil/core": "^1.1.7",
     "@stencil/postcss": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@graphql-codegen/typescript-operations": "^1.3.1",
     "@manifoldco/eslint-plugin-stencil": "^0.2.1",
     "@manifoldco/icons": "0.0.3",
-    "@manifoldco/shadowcat": "0.0.2",
+    "@manifoldco/shadowcat": "^0.1.3",
     "@reach/observe-rect": "^1.0.3",
     "@stencil/core": "^1.1.7",
     "@stencil/postcss": "^1.0.1",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -34,7 +34,7 @@ export namespace Components {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'setAuthToken'?: (s: string) => void;
+    'setAuthToken': (s: string) => void;
     'token'?: string;
   }
   interface ManifoldBadge {}
@@ -1019,6 +1019,7 @@ declare namespace LocalJSX {
     'selectedResource'?: Gateway.Resource;
   }
   interface ManifoldAuthToken extends JSXBase.HTMLAttributes<HTMLManifoldAuthTokenElement> {
+    'onManifoldOauthTokenChange'?: (event: CustomEvent<any>) => void;
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */

--- a/src/components/manifold-auth-token/manifold-auth-token.spec.ts
+++ b/src/components/manifold-auth-token/manifold-auth-token.spec.ts
@@ -2,7 +2,10 @@ import { ManifoldAuthToken } from './manifold-auth-token';
 
 describe('<manifold-auth-token>', () => {
   it('calls the set auth token on load', () => {
-    const token = 'test';
+    const expiry = new Date();
+    expiry.setDate(expiry.getDate() + 1);
+    const encodedExpiry = Buffer.from(expiry.toUTCString()).toString('base64');
+    const token = `test.${encodedExpiry}`;
 
     const provisionButton = new ManifoldAuthToken();
     provisionButton.setAuthToken = jest.fn();

--- a/src/components/manifold-auth-token/manifold-auth-token.spec.ts
+++ b/src/components/manifold-auth-token/manifold-auth-token.spec.ts
@@ -1,19 +1,40 @@
 import { ManifoldAuthToken } from './manifold-auth-token';
 
 describe('<manifold-auth-token>', () => {
-  it('calls the set auth token on load', () => {
+  describe('when the token is not expired', () => {
     const expiry = new Date();
     expiry.setDate(expiry.getDate() + 1);
     const encodedExpiry = Buffer.from(expiry.toUTCString()).toString('base64');
-    const token = `test.${encodedExpiry}`;
 
-    const provisionButton = new ManifoldAuthToken();
-    provisionButton.setAuthToken = jest.fn();
+    it('calls the set auth token on load', () => {
+      const token = `test.${encodedExpiry}`;
 
-    provisionButton.token = token;
-    provisionButton.componentWillLoad();
+      const provisionButton = new ManifoldAuthToken();
+      provisionButton.setAuthToken = jest.fn();
 
-    expect(provisionButton.setAuthToken).toHaveBeenCalledWith(token);
+      provisionButton.token = token;
+      provisionButton.componentWillLoad();
+
+      expect(provisionButton.setAuthToken).toHaveBeenCalledWith(token);
+    });
+  });
+
+  describe('when the token is expired', () => {
+    const expiry = new Date();
+    expiry.setDate(expiry.getDate() - 1);
+    const encodedExpiry = Buffer.from(expiry.toUTCString()).toString('base64');
+
+    it('calls the set auth token on load', () => {
+      const token = `test.${encodedExpiry}`;
+
+      const provisionButton = new ManifoldAuthToken();
+      provisionButton.setAuthToken = jest.fn();
+
+      provisionButton.token = token;
+      provisionButton.componentWillLoad();
+
+      expect(provisionButton.setAuthToken).not.toHaveBeenCalled();
+    });
   });
 
   it('calls the set auth token on change', () => {

--- a/src/components/manifold-auth-token/manifold-auth-token.spec.ts
+++ b/src/components/manifold-auth-token/manifold-auth-token.spec.ts
@@ -24,7 +24,7 @@ describe('<manifold-auth-token>', () => {
     expiry.setDate(expiry.getDate() - 1);
     const encodedExpiry = Buffer.from(expiry.toUTCString()).toString('base64');
 
-    it('calls the set auth token on load', () => {
+    it('does not call the set auth token on load', () => {
       const token = `test.${encodedExpiry}`;
 
       const provisionButton = new ManifoldAuthToken();

--- a/src/components/manifold-auth-token/manifold-auth-token.spec.ts
+++ b/src/components/manifold-auth-token/manifold-auth-token.spec.ts
@@ -4,7 +4,8 @@ describe('<manifold-auth-token>', () => {
   describe('when the token is not expired', () => {
     const expiry = new Date();
     expiry.setDate(expiry.getDate() + 1);
-    const encodedExpiry = Buffer.from(expiry.toUTCString()).toString('base64');
+    const unixTime = Math.floor(expiry.getTime() / 1000);
+    const encodedExpiry = Buffer.from(unixTime.toString()).toString('base64');
 
     it('calls the set auth token on load', () => {
       const token = `test.${encodedExpiry}`;

--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -1,19 +1,25 @@
-import { h, Component, Prop, Watch } from '@stencil/core';
+import { h, Component, Prop, Watch, Event } from '@stencil/core';
 import Tunnel from '../../data/connection';
+import { EventEmitter } from 'events';
 
 @Component({ tag: 'manifold-auth-token' })
 export class ManifoldAuthToken {
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() setAuthToken?: (s: string) => void;
+  @Prop() setAuthToken: (s: string) => void = () => {};
   /* Authorisation header token that can be used to authenticate the user in manifold */
-  @Prop() token?: string;
+  @Prop({ mutable: true }) token?: string;
+  @Event() manifoldOauthTokenChange: EventEmitter;
 
   @Watch('token') tokenChange(newToken: string) {
-    return this.setAuthToken && this.setAuthToken(newToken);
+    this.setAuthToken(newToken);
+
+    if ((!this.token && newToken) || (this.token && !newToken)) {
+      this.manifoldOauthTokenChange.emit(newToken);
+    }
   }
 
   componentWillLoad() {
-    if (this.setAuthToken && this.token) {
+    if (this.token) {
       this.setAuthToken(this.token);
     }
   }

--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -1,5 +1,4 @@
 import { h, Component, Prop, Watch, Event, EventEmitter } from '@stencil/core';
-import '@manifoldco/shadowcat';
 import { AuthToken } from '@manifoldco/shadowcat';
 import Tunnel from '../../data/connection';
 import { isExpired } from '../../utils/auth';

--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -44,4 +44,4 @@ export class ManifoldAuthToken {
   }
 }
 
-Tunnel.injectProps(ManifoldAuthToken, ['setAuthToken', 'clearAuthToken']);
+Tunnel.injectProps(ManifoldAuthToken, ['setAuthToken']);

--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -1,4 +1,5 @@
 import { h, Component, Prop, Watch, Event, EventEmitter } from '@stencil/core';
+import '@manifoldco/shadowcat';
 import { AuthToken } from '@manifoldco/shadowcat';
 import Tunnel from '../../data/connection';
 import { isExpired } from '../../utils/auth';
@@ -26,8 +27,8 @@ export class ManifoldAuthToken {
 
   setInternalToken(e: CustomEvent) {
     const payload = e.detail as AuthToken;
-    if (!payload.error) {
-      const encodedExpiry = Buffer.from(payload.expiry || '').toString('base64');
+    if (!payload.error && payload.expiry) {
+      const encodedExpiry = Buffer.from(payload.expiry.toString()).toString('base64');
       this.token = `${payload.token}.${encodedExpiry}`;
     }
   }

--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -1,5 +1,4 @@
 import { h, Component, Prop, Watch } from '@stencil/core';
-// import '@manifoldco/shadowcat';
 import Tunnel from '../../data/connection';
 
 @Component({ tag: 'manifold-auth-token' })
@@ -18,7 +17,8 @@ export class ManifoldAuthToken {
       this.setAuthToken(this.token);
     }
   }
-  async componentDidLoad() {
+
+  componentDidLoad() {
     document.addEventListener('receiveManifoldToken', (e: CustomEvent) => {
       this.token = e.detail;
     });
@@ -27,10 +27,7 @@ export class ManifoldAuthToken {
   render() {
     return (
       <div>
-        <manifold-oauth
-          id="test"
-          oauthUrl="https://manifold-shadowcat-test-server.herokuapp.com/signin/oauth/web"
-        ></manifold-oauth>
+        <manifold-oauth oauthUrl="https://manifold-shadowcat-test-server.herokuapp.com/signin/oauth/web"></manifold-oauth>
         <input type="hidden" value={this.token ? 'true' : 'false'} />;
       </div>
     );

--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -1,6 +1,5 @@
-import { h, Component, Prop, Watch, Event } from '@stencil/core';
+import { h, Component, Prop, Watch, Event, EventEmitter } from '@stencil/core';
 import Tunnel from '../../data/connection';
-import { EventEmitter } from 'events';
 
 @Component({ tag: 'manifold-auth-token' })
 export class ManifoldAuthToken {

--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -11,10 +11,7 @@ export class ManifoldAuthToken {
 
   @Watch('token') tokenChange(newToken: string) {
     this.setAuthToken(newToken);
-
-    if ((!this.token && newToken) || (this.token && !newToken)) {
-      this.manifoldOauthTokenChange.emit(newToken);
-    }
+    this.manifoldOauthTokenChange.emit(newToken);
   }
 
   componentWillLoad() {

--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -18,16 +18,17 @@ export class ManifoldAuthToken {
     }
   }
 
-  componentDidLoad() {
-    document.addEventListener('receiveManifoldToken', (e: CustomEvent) => {
-      this.token = e.detail;
-    });
+  setInternalToken(e: CustomEvent) {
+    this.token = e.detail;
   }
 
   render() {
     return (
       <div>
-        <manifold-oauth oauthUrl="https://manifold-shadowcat-test-server.herokuapp.com/signin/oauth/web"></manifold-oauth>
+        <manifold-oauth
+          onReceiveManifoldToken={this.setInternalToken}
+          oauthUrl="https://manifold-shadowcat-test-server.herokuapp.com/signin/oauth/web"
+        ></manifold-oauth>
         <input type="hidden" value={this.token ? 'true' : 'false'} />;
       </div>
     );

--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -1,10 +1,9 @@
-import { h, Component, Prop, Element, Watch } from '@stencil/core';
-import { defineCustomElements } from '@manifoldco/shadowcat/dist/loader';
+import { h, Component, Prop, Watch } from '@stencil/core';
+// import '@manifoldco/shadowcat';
 import Tunnel from '../../data/connection';
 
 @Component({ tag: 'manifold-auth-token' })
 export class ManifoldAuthToken {
-  @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() setAuthToken?: (s: string) => void;
   /* Authorisation header token that can be used to authenticate the user in manifold */
@@ -15,45 +14,14 @@ export class ManifoldAuthToken {
   }
 
   componentWillLoad() {
-    defineCustomElements(window);
-
     if (this.setAuthToken && this.token) {
       this.setAuthToken(this.token);
     }
   }
-
-  componentDidLoad() {
-    function listener(el: Element | null) {
-      return new Promise<string>(resolve => {
-        if (el) {
-          el.addEventListener('receiveManifoldToken', (e: CustomEvent) => {
-            console.log('token received from iframe: ', e.detail);
-            resolve(e.detail);
-          });
-        }
-      });
-    }
-
-    async function setToken(el: Element | null) {
-      const newToken: string = await listener(el);
-      console.log('newToken:', newToken);
-      return newToken;
-    }
-
-    const oauth = document.querySelector('#test');
-    const newToken = setToken(oauth);
-
-    // this is setting the token to be a Promise<string> and I don't understand
-    // how to turn it into a string in the setToken() function
-    if (this.token) {
-      this.token = newToken;
-    }
-  }
-
-  componentWillUpdate() {
-    if (this.token) {
-      console.log('TOKEN WILL UPDATE: ', this.token);
-    }
+  async componentDidLoad() {
+    document.addEventListener('receiveManifoldToken', (e: CustomEvent) => {
+      this.token = e.detail;
+    });
   }
 
   render() {

--- a/src/components/manifold-connection/manifold-connection.tsx
+++ b/src/components/manifold-connection/manifold-connection.tsx
@@ -27,12 +27,21 @@ export class ManiTunnel {
     localStorage.setItem(TOKEN_KEY, token);
   };
 
+  get accessToken() {
+    if (this.authToken) {
+      const [token] = this.authToken.split('.');
+      return token;
+    }
+
+    return undefined;
+  }
+
   render() {
     return (
       <Tunnel.Provider
         state={{
           connection: connections[this.env],
-          authToken: this.authToken,
+          authToken: this.accessToken,
           setAuthToken: this.setAuthToken,
         }}
       >

--- a/src/components/manifold-connection/manifold-connection.tsx
+++ b/src/components/manifold-connection/manifold-connection.tsx
@@ -2,15 +2,25 @@ import { h, Component, Prop, State } from '@stencil/core';
 
 import Tunnel from '../../data/connection';
 import { connections } from '../../utils/connections';
+import { isExpired } from '../../utils/auth';
 
 const TOKEN_KEY = 'manifold_api_token';
+
+function getDefaultToken() {
+  const token = localStorage.getItem(TOKEN_KEY);
+  if (token && !isExpired(token)) {
+    return token;
+  }
+
+  return undefined;
+}
 
 @Component({ tag: 'manifold-connection' })
 export class ManiTunnel {
   /** _(optional)_ Specify `env="stage"` for staging */
   @Prop() env: 'stage' | 'prod' = 'prod';
 
-  @State() authToken?: string = localStorage.getItem(TOKEN_KEY) || undefined;
+  @State() authToken?: string = getDefaultToken();
 
   setAuthToken = (token: string) => {
     this.authToken = token;

--- a/src/components/manifold-connection/manifold-connection.tsx
+++ b/src/components/manifold-connection/manifold-connection.tsx
@@ -3,15 +3,18 @@ import { h, Component, Prop, State } from '@stencil/core';
 import Tunnel from '../../data/connection';
 import { connections } from '../../utils/connections';
 
+const TOKEN_KEY = 'manifold_api_token';
+
 @Component({ tag: 'manifold-connection' })
 export class ManiTunnel {
   /** _(optional)_ Specify `env="stage"` for staging */
   @Prop() env: 'stage' | 'prod' = 'prod';
 
-  @State() authToken?: string = localStorage.getItem('manifold_api_token') || undefined;
+  @State() authToken?: string = localStorage.getItem(TOKEN_KEY) || undefined;
 
   setAuthToken = (token: string) => {
     this.authToken = token;
+    localStorage.setItem(TOKEN_KEY, token);
   };
 
   render() {

--- a/src/global/app.ts
+++ b/src/global/app.ts
@@ -1,0 +1,1 @@
+import '@manifoldco/shadowcat';

--- a/src/global/app.ts
+++ b/src/global/app.ts
@@ -1,1 +1,0 @@
-import '@manifoldco/shadowcat';

--- a/src/readme.md
+++ b/src/readme.md
@@ -8,11 +8,7 @@ npm run dev
 This will start Storybook at `localhost:6060`. Storybook is the preferred way
 to work on styles and testing.
 
-__Note:__ When testing the `<manifold-auth-token>` component in Storybook, a fresh token (`manifold_api_token`, available from local storage after a successful login to Dashboard) needs to be manually added to local storage in Storybook. If you don't see the resources you expect after doing this, first check the console and network calls to see if `identity` is returning a 401 Unauthorized. If this is the case, it's possible your token has expired and you need to set a fresh one.
-
-During the `ui` transition from REST calls to GraphQL and PUMA, this component needs to be able to consume several types of tokens to account for the demo apps that already exist and the testing of tokens with expirations set. In this story we are currently adding a fake expiration to the api tokens so that the resources become visible, which is why the token may expire without the component being aware. This is purely a function of testing without access to the full PUMA flow and should be resolved after the transition.
-
----
+__Note:__ When testing the `<manifold-auth-token>` component in Storybook, a fresh token (`manifold_api_token`, available from local storage after a successful login to Dashboard) needs to be manually added to local storage in Storybook. If you don't see the resources you expect after doing this, first check the console and network calls to see if `identity` is returning a 401 Unauthorized response. If this is the case, it's possible your token has expired and you need to set a fresh one in local storage.
 
 Copy these specs from [our specs][specs] into here:
 

--- a/src/readme.md
+++ b/src/readme.md
@@ -8,6 +8,12 @@ npm run dev
 This will start Storybook at `localhost:6060`. Storybook is the preferred way
 to work on styles and testing.
 
+__Note:__ When testing the `<manifold-auth-token>` component in Storybook, a fresh token (`manifold_api_token`, available from local storage after a successful login to Dashboard) needs to be manually added to local storage in Storybook. If you don't see the resources you expect after doing this, first check the console and network calls to see if `identity` is returning a 401 Unauthorized. If this is the case, it's possible your token has expired and you need to set a fresh one.
+
+During the `ui` transition from REST calls to GraphQL and PUMA, this component needs to be able to consume several types of tokens to account for the demo apps that already exist and the testing of tokens with expirations set. In this story we are currently adding a fake expiration to the api tokens so that the resources become visible, which is why the token may expire without the component being aware. This is purely a function of testing without access to the full PUMA flow and should be resolved after the transition.
+
+---
+
 Copy these specs from [our specs][specs] into here:
 
 - `src/spec/catalog/v1.yaml`
@@ -42,7 +48,7 @@ You can do this by clicking `Details` on a failed Happo check and using the `Rev
 
 A passing Happo check means that the test detected no visual changes.
 
-_Note:_ Some diffs may be detected based on animations happening in the components. This may be resolved in the future, but as of writing these diffs require human approval.
+__Note:__ Some diffs may be detected based on animations happening in the components. This may be resolved in the future, but as of writing these diffs require human approval.
 
 ### Writing Happo Tests
 

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -4,14 +4,21 @@
  */
 
 export function withAuth(authToken?: string, options?: RequestInit): RequestInit | undefined {
-  if (!authToken) {
+  /* FIXME: This is being used as a fallback for our demo apps during the transition to
+   * oauth and GraphQL. The authToken being passed in will only be present if the app
+   * that renders our web components uses oauth. But we have demo apps that are keeping
+   * our old tokens in local storage in order for REST calls to work. This keeps them
+   * working.
+   */
+  const token = authToken || localStorage.getItem('manifold_api_token');
+  if (!token) {
     return options;
   }
   return {
     ...(options || {}),
     headers: {
       ...((options && options.headers) || {}),
-      authorization: `Bearer ${authToken}`,
+      authorization: `Bearer ${token}`,
     },
   };
 }

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -27,7 +27,8 @@ export function isExpired(token: string) {
   const [, expiry] = token.split('.');
 
   if (expiry) {
-    const d = new Date(Buffer.from(expiry, 'base64').toString());
+    const decodedExpiry = parseInt(Buffer.from(expiry, 'base64').toString(), 10);
+    const d = new Date(decodedExpiry * 1000);
     const now = new Date();
 
     if (d > now) {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -15,3 +15,18 @@ export function withAuth(authToken?: string, options?: RequestInit): RequestInit
     },
   };
 }
+
+export function isExpired(token: string) {
+  const [, expiry] = token.split('.');
+
+  if (expiry) {
+    const d = new Date(Buffer.from(expiry, 'base64').toString());
+    const now = new Date();
+
+    if (d > now) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/stories/manifold-auth-token.stories.js
+++ b/stories/manifold-auth-token.stories.js
@@ -1,17 +1,26 @@
 import { storiesOf } from '@storybook/html';
 import markdown from '../docs/docs/data/manifold-auth-token.md';
 
+function withVeryFakeExpiry(token) {
+  const expiry = new Date();
+  expiry.setDate(expiry.getDate() + 1);
+  const encodedExpiry = Buffer.from(expiry.toUTCString()).toString('base64');
+  return `${token}.${encodedExpiry}`;
+}
+
 storiesOf('Auth Token Provider [Data]', module)
   .addParameters({ readme: { sidebar: markdown } })
-  .addDecorator(storyFn => localStorage.manifold_api_token ?
-    storyFn()
-    : 'Set your token under `manifold_api_token` in localstorage then refresh to view this story')
+  .addDecorator(storyFn =>
+    localStorage.manifold_api_token
+      ? storyFn()
+      : 'Set a fresh token under `manifold_api_token` in localstorage then refresh to view this story'
+  )
   .add(
     'See your resources',
     () => `
       <manifold-connection>
         These resources are loaded from the server rather than mocks
-        <manifold-auth-token token="${localStorage.manifold_api_token}"/>
+        <manifold-auth-token token="${withVeryFakeExpiry(localStorage.manifold_api_token)}"/>
         <manifold-resource-list />
       </manifold-connection>
     `

--- a/stories/manifold-auth-token.stories.js
+++ b/stories/manifold-auth-token.stories.js
@@ -2,6 +2,13 @@ import { storiesOf } from '@storybook/html';
 import markdown from '../docs/docs/data/manifold-auth-token.md';
 
 function withVeryFakeExpiry(token) {
+  /* During the ui transition from REST calls to GraphQL and PUMA,
+  this component needs to be able to consume several types of tokens
+  to account for the demo apps that already exist and the testing of
+  tokens with expirations set. This fake expiry allows the resources to
+  become visible in testing, which means the actual token may expire 
+  without the component being aware - if so it will return a 401 and 
+  should be changed for a fresh one. */
   const expiry = new Date();
   expiry.setDate(expiry.getDate() + 1);
   const encodedExpiry = Buffer.from(expiry.toUTCString()).toString('base64');

--- a/stories/manifold-auth-token.stories.js
+++ b/stories/manifold-auth-token.stories.js
@@ -11,7 +11,8 @@ function withVeryFakeExpiry(token) {
   should be changed for a fresh one. */
   const expiry = new Date();
   expiry.setDate(expiry.getDate() + 1);
-  const encodedExpiry = Buffer.from(expiry.toUTCString()).toString('base64');
+  const unixTime = Math.floor(expiry.getTime() / 1000);
+  const encodedExpiry = Buffer.from(unixTime.toString()).toString('base64');
   return `${token}.${encodedExpiry}`;
 }
 


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change
Probably over-engineered this, but learned a ton about TypeScript and Stencil in the process!!! There are some linting errors here, but maybe new eyes on this will help us figure out a reasonable way to get the token from the iframe into the token Prop (and then update it when needed). Any way you know to do it is welcome to me.

These are the necessities of this component per @Minivera:
- On load, if it has a token, give that to the manifold-connection
- Start fetching a newer auth token
- When it receives a auth token, update connection and trigger the dom event for the platform to get the newer token
 
I did successfully add `manifoldco/shadowcat` to the `manifold-auth-token` component however. :)

## Testing
Ran this in Storybook and checked the console for the `this.token` value, which was hard.