### PR TITLE
Storybook on Now

### DIFF
--- a/.nowignore
+++ b/.nowignore
@@ -1,0 +1,10 @@
+.cache
+.stencil
+*.spec.ts
+*.e2e.ts
+coverage
+dist
+node_modules
+pkg
+public
+storybook-static

--- a/now.json
+++ b/now.json
@@ -1,0 +1,12 @@
+{
+  "name": "ui",
+  "scope": "manifold",
+  "version": 2,
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@now/static-build",
+      "config": { "distDir": "storybook-static" }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "lint": "npm run lint:js && npm run lint:css && cd docs && npm run lint",
     "lint:css": "stylelint 'src/**/*.css'",
     "lint:js": "eslint --ext .js,.ts,.tsx src",
+    "now-build": "npm run build-storybook",
     "postinstall": "cd docs && npm i",
     "prepare": "stencil build",
     "publish": "node scripts/publish",


### PR DESCRIPTION
## Reason for change
It was helpful for design to have some preview link for Storybook to look at. We had it on Netlify, but that broke because of a bug in their system, and their support staff didn’t care to help us fix it.

This puts Storybook on ZEIT Now for internal usage, mostly for design.

## Testing
https://ui.manifold.now.sh/
