### PR TITLE
Fix the deprovision and rename button click

### DIFF
--- a/docs/docs/resource-details.md
+++ b/docs/docs/resource-details.md
@@ -67,6 +67,28 @@ be stylized or be given children.
 </manifold-resource-container>
 ```
 
+### Events
+
+For validation, error, and success messages, it will emit custom events.
+
+```js
+document.addEventListener('manifold-deprovisionButton-click', ({ detail: { resourceLabel } }) =>
+  console.info(`⌛ Derovisioning ${resourceLabel} …`)
+);
+document.addEventListener(
+  'manifold-deprovisionButton-success',
+  ({ detail: { resourceLabel } }) =>alert(`${resourceLabel} deprovisioned successfully!`)
+);
+document.addEventListener('manifold-deprovisionButton-error', ({ detail }) => console.log(detail));
+// {message: "bad_request: bad_request: No plan_id provided", resourceid: "1234", resourceLabel: "my-resource"}
+```
+
+| Name                               |                       Returns                        | Description                                                                                                                 |
+| :--------------------------------- | :--------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------- |
+| `manifold-deprovisionButton-click`   |                    `resourceLabel`                 | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
+| `manifold-deprovisionButton-success` |     `message`, `resourceId`, `resourceLabel`       | Successful deprovision. Returns a resource ID and resource Label.                                                                              |
+| `manifold-deprovisionButton-error`   |     `message`, `resourceId`, `resourceLabel`       | Erred provision, along with information on what went wrong.     
+
 ## The resource rename Button
 
 The [`manifold-data-rename-button`](/data/rename-button) component can be used inside the container without any attribute by
@@ -79,6 +101,31 @@ be stylized or be given children.
   <manifold-resource-rename>Rename</manifold-resource-rename>
 </manifold-resource-container>
 ```
+
+### Events
+
+For validation, error, and success messages, it will emit custom events.
+
+```js
+document.addEventListener('manifold-renameButton-click', ({ detail: { resourceLabel, newLabel } }) =>
+  console.info(`⌛ Renaming ${resourceLabel} to ${newLabel} …`)
+);
+document.addEventListener(
+  'manifold-renameButton-success',
+  ({ detail: { resourceLabel, newLabel } }) => alert(`${resourceLabel} renamed to ${newLabel} successfully!`)
+);
+document.addEventListener('manifold-renameButton-error', ({ detail }) => console.log(detail));
+// {message: "bad_request: bad_request: No plan_id provided", resourceid: "1234", resourceLabel: "my-resource", newLabel: "new-name"}
+document.addEventListener('manifold-renameButton-invalid', ({ detail }) => console.log(detail));
+// {message: "bad_request: bad_request: No plan_id provided", resourceid: "1234", resourceLabel: "my-resource", newLabel: "new-name"}
+```
+
+| Name                            |                       Returns                            | Description                                                                                                                 |
+| :-------------------------------| :------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------- |
+| `manifold-renameButton-click`   |       `resourceId`, `resourceLabel`, `newLabel`          | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
+| `manifold-renameButton-success` |   `message`, `resourceId`, `resourceLabel`, `newLabel`   | Successful renaming. Returns a resource ID and resource Label as well as a message and the new name for the resource.       |
+| `manifold-renameButton-error`   |   `message`, `resourceId`, `resourceLabel`, `newLabel`   | Erred rename, along with information on what went wrong.                                                                    |
+| `manifold-renameButton-error`   |   `message`, `resourceId`, `resourceLabel`, `newLabel`   | Invalid renaming, along with information on what went wrong. 
 
 ## The resource product details
 

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1081,7 +1081,7 @@ declare namespace LocalJSX {
     'loading'?: boolean;
     'onManifold-deprovisionButton-click'?: (event: CustomEvent<any>) => void;
     'onManifold-deprovisionButton-error'?: (event: CustomEvent<any>) => void;
-    'onManifold-provisionButton-success'?: (event: CustomEvent<any>) => void;
+    'onManifold-deprovisionButton-success'?: (event: CustomEvent<any>) => void;
     'resourceId'?: string;
     /**
     * The label of the resource to deprovision
@@ -1505,6 +1505,9 @@ declare namespace LocalJSX {
   interface ManifoldResourceDeprovision extends JSXBase.HTMLAttributes<HTMLManifoldResourceDeprovisionElement> {
     'data'?: Gateway.Resource;
     'loading'?: boolean;
+    'onManifold-deprovisionButton-click'?: (event: CustomEvent<any>) => void;
+    'onManifold-deprovisionButton-error'?: (event: CustomEvent<any>) => void;
+    'onManifold-deprovisionButton-success'?: (event: CustomEvent<any>) => void;
   }
   interface ManifoldResourceDetails extends JSXBase.HTMLAttributes<HTMLManifoldResourceDetailsElement> {}
   interface ManifoldResourceDetailsView extends JSXBase.HTMLAttributes<HTMLManifoldResourceDetailsViewElement> {
@@ -1543,6 +1546,10 @@ declare namespace LocalJSX {
     * The new label to give to the resource
     */
     'newLabel'?: string;
+    'onManifold-renameButton-click'?: (event: CustomEvent<any>) => void;
+    'onManifold-renameButton-error'?: (event: CustomEvent<any>) => void;
+    'onManifold-renameButton-invalid'?: (event: CustomEvent<any>) => void;
+    'onManifold-renameButton-success'?: (event: CustomEvent<any>) => void;
   }
   interface ManifoldResourceStatus extends JSXBase.HTMLAttributes<HTMLManifoldResourceStatusElement> {
     'size'?: 'small' | 'medium';

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -527,6 +527,10 @@ export namespace Components {
   interface ManifoldResourceRename {
     'data'?: Gateway.Resource;
     'loading': boolean;
+    /**
+    * The new label to give to the resource
+    */
+    'newLabel': string;
   }
   interface ManifoldResourceStatus {
     'size'?: 'small' | 'medium';
@@ -1535,6 +1539,10 @@ declare namespace LocalJSX {
   interface ManifoldResourceRename extends JSXBase.HTMLAttributes<HTMLManifoldResourceRenameElement> {
     'data'?: Gateway.Resource;
     'loading'?: boolean;
+    /**
+    * The new label to give to the resource
+    */
+    'newLabel'?: string;
   }
   interface ManifoldResourceStatus extends JSXBase.HTMLAttributes<HTMLManifoldResourceStatusElement> {
     'size'?: 'small' | 'medium';

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
@@ -125,12 +125,12 @@ describe('<manifold-data-provision-button>', () => {
       });
 
       const instance = page.rootInstance as ManifoldDataDeprovisionButton;
-      instance.successEvent.emit = jest.fn();
+      instance.success.emit = jest.fn();
 
       await instance.deprovision();
 
       expect(fetchMock.called(`${connections.prod.gateway}/id/resource/${Resource.id}`)).toBe(true);
-      expect(instance.successEvent.emit).toHaveBeenCalledWith({
+      expect(instance.success.emit).toHaveBeenCalledWith({
         message: 'test successfully deprovisioned',
         resourceLabel: 'test',
         resourceId: Resource.id,
@@ -155,12 +155,12 @@ describe('<manifold-data-provision-button>', () => {
       });
 
       const instance = page.rootInstance as ManifoldDataDeprovisionButton;
-      instance.errorEvent.emit = jest.fn();
+      instance.error.emit = jest.fn();
 
       await instance.deprovision();
 
       expect(fetchMock.called(`${connections.prod.gateway}/id/resource/${Resource.id}`)).toBe(true);
-      expect(instance.errorEvent.emit).toHaveBeenCalledWith({
+      expect(instance.error.emit).toHaveBeenCalledWith({
         message: 'ohnoes',
         resourceLabel: 'test',
         resourceId: Resource.id,

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
@@ -166,5 +166,45 @@ describe('<manifold-data-provision-button>', () => {
         resourceId: Resource.id,
       });
     });
+
+    it('will do nothing if still loading', async () => {
+      fetchMock.mock(`${connections.prod.gateway}/id/resource/${Resource.id}`, 200);
+
+      const page = await newSpecPage({
+        components: [ManifoldDataDeprovisionButton],
+        html: `
+          <manifold-data-deprovision-button
+            resource-label="test"
+          >Provision</manifold-data-deprovision-button>
+        `,
+      });
+
+      const instance = page.rootInstance as ManifoldDataDeprovisionButton;
+      instance.loading = true;
+
+      await instance.deprovision();
+
+      expect(fetchMock.called(`${connections.prod.gateway}/id/resource/${Resource.id}`)).toBe(false);
+    });
+
+    it('will do nothing if no resourceId is provided', async () => {
+      fetchMock.mock(`${connections.prod.gateway}/id/resource/${Resource.id}`, 200);
+
+      const page = await newSpecPage({
+        components: [ManifoldDataDeprovisionButton],
+        html: `
+          <manifold-data-deprovision-button
+            resource-label="test"
+          >Provision</manifold-data-deprovision-button>
+        `,
+      });
+
+      const instance = page.rootInstance as ManifoldDataDeprovisionButton;
+      instance.resourceId = undefined;
+
+      await instance.deprovision();
+
+      expect(fetchMock.called(`${connections.prod.gateway}/id/resource/${Resource.id}`)).toBe(false);
+    });
   });
 });

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
@@ -30,11 +30,9 @@ export class ManifoldDataDeprovisionButton {
   @Prop() resourceLabel?: string;
   @Prop({ mutable: true }) resourceId?: string = '';
   @Prop() loading?: boolean = false;
-  @Event({ eventName: 'manifold-deprovisionButton-click', bubbles: true })
-  clickEvent: EventEmitter;
-  @Event({ eventName: 'manifold-deprovisionButton-error', bubbles: true }) errorEvent: EventEmitter;
-  @Event({ eventName: 'manifold-provisionButton-success', bubbles: true })
-  successEvent: EventEmitter;
+  @Event({ eventName: 'manifold-deprovisionButton-click', bubbles: true }) click: EventEmitter;
+  @Event({ eventName: 'manifold-deprovisionButton-error', bubbles: true }) error: EventEmitter;
+  @Event({ eventName: 'manifold-deprovisionButton-success', bubbles: true }) success: EventEmitter;
 
   @Watch('resourceLabel') labelChange(newLabel: string) {
     if (!this.resourceId) {
@@ -59,7 +57,7 @@ export class ManifoldDataDeprovisionButton {
     }
 
     // We use Gateway b/c it’s much easier to provision w/o generating a base32 ID
-    this.clickEvent.emit({
+    this.click.emit({
       resourceId: this.resourceId,
       resourceLabel: this.resourceLabel || '',
     });
@@ -78,7 +76,7 @@ export class ManifoldDataDeprovisionButton {
         resourceLabel: this.resourceLabel || '',
         resourceId: this.resourceId,
       };
-      this.successEvent.emit(success);
+      this.success.emit(success);
     } else {
       const body = await response.json();
 
@@ -89,7 +87,7 @@ export class ManifoldDataDeprovisionButton {
         resourceLabel: this.resourceLabel || '',
         resourceId: this.resourceId,
       };
-      this.errorEvent.emit(error);
+      this.error.emit(error);
     }
   }
 

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
@@ -49,7 +49,11 @@ export class ManifoldDataDeprovisionButton {
   }
 
   async deprovision() {
-    if (!this.resourceId || !this.connection) {
+    if (!this.connection || this.loading) {
+      return;
+    }
+
+    if (!this.resourceId) {
       console.error('Property “resourceId” is missing');
       return;
     }
@@ -108,18 +112,11 @@ export class ManifoldDataDeprovisionButton {
     this.resourceId = resources[0].id;
   }
 
-  handleClick() {
-    if (!this.resourceId && !this.loading) {
-      return;
-    }
-    this.deprovision();
-  }
-
   render() {
     return (
       <button
         type="submit"
-        onClick={this.handleClick}
+        onClick={() => this.deprovision()}
         disabled={!this.resourceId && !this.loading}
       >
         <slot />

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
@@ -126,12 +126,12 @@ describe('<manifold-data-rename-button>', () => {
       });
 
       const instance = page.rootInstance as ManifoldDataRenameButton;
-      instance.successEvent.emit = jest.fn();
+      instance.success.emit = jest.fn();
 
       await instance.rename();
 
       expect(fetchMock.called(`${connections.prod.marketplace}/resources/${Resource.id}`)).toBe(true);
-      expect(instance.successEvent.emit).toHaveBeenCalledWith({
+      expect(instance.success.emit).toHaveBeenCalledWith({
         message: `${Resource.body.label} successfully renamed`,
         resourceLabel: Resource.body.label,
         newLabel: 'test2',
@@ -158,12 +158,12 @@ describe('<manifold-data-rename-button>', () => {
       });
 
       const instance = page.rootInstance as ManifoldDataRenameButton;
-      instance.errorEvent.emit = jest.fn();
+      instance.error.emit = jest.fn();
 
       await instance.rename();
 
       expect(fetchMock.called(`${connections.prod.marketplace}/resources/${Resource.id}`)).toBe(true);
-      expect(instance.errorEvent.emit).toHaveBeenCalledWith({
+      expect(instance.error.emit).toHaveBeenCalledWith({
         message: 'ohnoes',
         resourceLabel: Resource.body.label,
         newLabel: 'test2',

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
@@ -170,5 +170,45 @@ describe('<manifold-data-rename-button>', () => {
         resourceId: Resource.id,
       });
     });
+
+    it('will do nothing if still loading', async () => {
+      fetchMock.mock(`${connections.prod.gateway}/id/resource/${Resource.id}`, 200);
+
+      const page = await newSpecPage({
+        components: [ManifoldDataRenameButton],
+        html: `
+          <manifold-data-rename-button
+            resource-label="test"
+          >Provision</manifold-data-rename-button>
+        `,
+      });
+
+      const instance = page.rootInstance as ManifoldDataRenameButton;
+      instance.loading = true;
+
+      await instance.rename();
+
+      expect(fetchMock.called(`${connections.prod.gateway}/id/resource/${Resource.id}`)).toBe(false);
+    });
+
+    it('will do nothing if no resourceId is provided', async () => {
+      fetchMock.mock(`${connections.prod.gateway}/id/resource/${Resource.id}`, 200);
+
+      const page = await newSpecPage({
+        components: [ManifoldDataRenameButton],
+        html: `
+          <manifold-data-rename-button
+            resource-label="test"
+          >Provision</manifold-data-rename-button>
+        `,
+      });
+
+      const instance = page.rootInstance as ManifoldDataRenameButton;
+      instance.resourceId = undefined;
+
+      await instance.rename();
+
+      expect(fetchMock.called(`${connections.prod.gateway}/id/resource/${Resource.id}`)).toBe(false);
+    });
   });
 });

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
@@ -69,7 +69,7 @@ export class ManifoldDataRenameButton {
   }
 
   async rename() {
-    if (!this.connection) {
+    if (!this.connection || this.loading) {
       return;
     }
 
@@ -169,18 +169,11 @@ export class ManifoldDataRenameButton {
     return /^[a-z][a-z0-9]*/.test(input);
   }
 
-  handleClick() {
-    if (!this.resourceId && !this.loading) {
-      return;
-    }
-    this.rename();
-  }
-
   render() {
     return (
       <button
         type="submit"
-        onClick={this.handleClick}
+        onClick={() => this.rename()}
         disabled={!this.resourceId && !this.loading}
       >
         <slot />

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
@@ -48,13 +48,10 @@ export class ManifoldDataRenameButton {
   /** The id of the resource to rename, will be fetched if not set */
   @Prop({ mutable: true }) resourceId?: string = '';
   @Prop() loading?: boolean = false;
-  @Event({ eventName: 'manifold-renameButton-click', bubbles: true })
-  clickEvent: EventEmitter;
-  @Event({ eventName: 'manifold-renameButton-invalid', bubbles: true })
-  invalidEvent: EventEmitter;
-  @Event({ eventName: 'manifold-renameButton-error', bubbles: true }) errorEvent: EventEmitter;
-  @Event({ eventName: 'manifold-renameButton-success', bubbles: true })
-  successEvent: EventEmitter;
+  @Event({ eventName: 'manifold-renameButton-click', bubbles: true }) click: EventEmitter;
+  @Event({ eventName: 'manifold-renameButton-invalid', bubbles: true }) invalid: EventEmitter;
+  @Event({ eventName: 'manifold-renameButton-error', bubbles: true }) error: EventEmitter;
+  @Event({ eventName: 'manifold-renameButton-success', bubbles: true }) success: EventEmitter;
 
   @Watch('resourceLabel') labelChange(newLabel: string) {
     if (!this.resourceId) {
@@ -85,7 +82,7 @@ export class ManifoldDataRenameButton {
         newLabel: this.newLabel,
         resourceId: this.resourceId,
       };
-      this.invalidEvent.emit(message);
+      this.invalid.emit(message);
       return;
     }
     if (!this.validate(this.newLabel)) {
@@ -96,7 +93,7 @@ export class ManifoldDataRenameButton {
         newLabel: this.newLabel,
         resourceId: this.resourceId,
       };
-      this.invalidEvent.emit(message);
+      this.invalid.emit(message);
       return;
     }
 
@@ -105,7 +102,7 @@ export class ManifoldDataRenameButton {
       newLabel: this.newLabel,
       resourceId: this.resourceId,
     };
-    this.clickEvent.emit(clickMessage);
+    this.click.emit(clickMessage);
 
     const body: Marketplace.PublicUpdateResource = {
       body: {
@@ -130,7 +127,7 @@ export class ManifoldDataRenameButton {
         newLabel: this.newLabel,
         resourceId: this.resourceId,
       };
-      this.successEvent.emit(success);
+      this.success.emit(success);
     } else {
       const result = await response.json();
 
@@ -142,7 +139,7 @@ export class ManifoldDataRenameButton {
         newLabel: this.newLabel,
         resourceId: this.resourceId,
       };
-      this.errorEvent.emit(error);
+      this.error.emit(error);
     }
   }
 

--- a/src/components/manifold-resource-deprovision/manifold-resource-deprovision.tsx
+++ b/src/components/manifold-resource-deprovision/manifold-resource-deprovision.tsx
@@ -1,4 +1,4 @@
-import { h, Component, Prop } from '@stencil/core';
+import { h, Component, Prop, Event, EventEmitter } from '@stencil/core';
 
 import ResourceTunnel from '../../data/resource';
 import { Gateway } from '../../types/gateway';
@@ -7,6 +7,9 @@ import { Gateway } from '../../types/gateway';
 export class ManifoldResourceDeprovision {
   @Prop() data?: Gateway.Resource;
   @Prop() loading: boolean = true;
+  @Event({ eventName: 'manifold-deprovisionButton-click', bubbles: true }) click: EventEmitter;
+  @Event({ eventName: 'manifold-deprovisionButton-error', bubbles: true }) error: EventEmitter;
+  @Event({ eventName: 'manifold-deprovisionButton-success', bubbles: true }) success: EventEmitter;
 
   render() {
     return (
@@ -14,6 +17,9 @@ export class ManifoldResourceDeprovision {
         resourceId={this.data && this.data.id}
         resourceLabel={this.data && this.data.label}
         loading={this.loading}
+        onManifold-deprovisionButton-click={this.click.emit}
+        onManifold-deprovisionButton-error={this.error.emit}
+        onManifold-deprovisionButton-success={this.success.emit}
       >
         <manifold-forward-slot>
           <slot />

--- a/src/components/manifold-resource-rename/manifold-resource-rename.tsx
+++ b/src/components/manifold-resource-rename/manifold-resource-rename.tsx
@@ -1,4 +1,4 @@
-import { h, Component, Prop } from '@stencil/core';
+import { h, Component, Prop, Event, EventEmitter } from '@stencil/core';
 
 import ResourceTunnel from '../../data/resource';
 import { Gateway } from '../../types/gateway';
@@ -9,6 +9,10 @@ export class ManifoldResourceRename {
   @Prop() loading: boolean = true;
   /** The new label to give to the resource */
   @Prop() newLabel: string = '';
+  @Event({ eventName: 'manifold-renameButton-click', bubbles: true }) click: EventEmitter;
+  @Event({ eventName: 'manifold-renameButton-invalid', bubbles: true }) invalid: EventEmitter;
+  @Event({ eventName: 'manifold-renameButton-error', bubbles: true }) error: EventEmitter;
+  @Event({ eventName: 'manifold-renameButton-success', bubbles: true }) success: EventEmitter;
 
   render() {
     return (
@@ -17,6 +21,10 @@ export class ManifoldResourceRename {
         resourceLabel={this.data && this.data.label}
         loading={this.loading}
         newLabel={this.newLabel}
+        onManifold-renameButton-click={this.click.emit}
+        onManifold-renameButton-invalid={this.invalid.emit}
+        onManifold-renameButton-error={this.error.emit}
+        onManifold-renameButton-success={this.success.emit}
       >
         <manifold-forward-slot>
           <slot />

--- a/src/components/manifold-resource-rename/manifold-resource-rename.tsx
+++ b/src/components/manifold-resource-rename/manifold-resource-rename.tsx
@@ -7,6 +7,8 @@ import { Gateway } from '../../types/gateway';
 export class ManifoldResourceRename {
   @Prop() data?: Gateway.Resource;
   @Prop() loading: boolean = true;
+  /** The new label to give to the resource */
+  @Prop() newLabel: string = '';
 
   render() {
     return (
@@ -14,6 +16,7 @@ export class ManifoldResourceRename {
         resourceId={this.data && this.data.id}
         resourceLabel={this.data && this.data.label}
         loading={this.loading}
+        newLabel={this.newLabel}
       >
         <manifold-forward-slot>
           <slot />


### PR DESCRIPTION
## Reason for change
When used outside stencil, the `handleClick` method didn't have the right `this` bound, this fix will make sure it works and the cases added are tested.

## Testing
Test with storybook.
