### PR TITLE
Fix the provision button requiring a label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed the provision button requiring the label to be set, preventing or automatic label generation from working.
+
 ### Changed
 - Changed the deprovision and rename button to not include a shadow dom root, they can now be styled from external stylesheets.
 

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed the provision button requiring the label to be set, preventing or automatic label generation from working.
+
 ### Changed
 - Changed the deprovision and rename button to not include a shadow dom root, they can now be styled from external stylesheets.
 

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
@@ -18,7 +18,7 @@ interface SuccessMessage {
 
 interface ErrorMessage {
   message: string;
-  resourceLabel: string;
+  resourceLabel?: string;
 }
 
 @Component({ tag: 'manifold-data-provision-button' })
@@ -72,19 +72,15 @@ export class ManifoldDataProvisionButton {
       console.error('Property “ownerId” is missing');
       return;
     }
-    if (!this.resourceLabel) {
-      console.error('Property “resourceLabel” is missing');
-      return;
-    }
 
-    if (this.resourceLabel.length < 3) {
+    if (this.resourceLabel && this.resourceLabel.length < 3) {
       this.invalidEvent.emit({
         message: 'Must be at least 3 characters.',
         resourceLabel: this.resourceLabel,
       });
       return;
     }
-    if (!this.validate(this.resourceLabel)) {
+    if (this.resourceLabel && !this.validate(this.resourceLabel)) {
       this.invalidEvent.emit({
         message:
           'Must start with a lowercase letter, and use only lowercase, numbers, and hyphens.',


### PR DESCRIPTION
## Reason for change
The provisioning system on our backend does not need a label, if it is omitted, a random label will be generated. The past code was requiring the label which made it impossible to have the automatic system work as intended.
