### PR TITLE
Converting product page to graphql

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -16,6 +16,10 @@ import {
   Connection,
 } from './utils/connections';
 import {
+  Product,
+  Provider,
+} from './types/graphql';
+import {
   Marketplace,
 } from './types/marketplace';
 import {
@@ -426,11 +430,11 @@ export namespace Components {
     'productLabel'?: string;
   }
   interface ManifoldProductDetails {
-    'product'?: Catalog.Product;
+    'product'?: Product;
   }
   interface ManifoldProductPage {
-    'product'?: Catalog.Product;
-    'provider'?: Catalog.Provider;
+    'product'?: Product;
+    'provider'?: Provider;
   }
   interface ManifoldRegionSelector {
     'allowedRegions': string[];
@@ -1435,11 +1439,11 @@ declare namespace LocalJSX {
     'productLabel'?: string;
   }
   interface ManifoldProductDetails extends JSXBase.HTMLAttributes<HTMLManifoldProductDetailsElement> {
-    'product'?: Catalog.Product;
+    'product'?: Product;
   }
   interface ManifoldProductPage extends JSXBase.HTMLAttributes<HTMLManifoldProductPageElement> {
-    'product'?: Catalog.Product;
-    'provider'?: Catalog.Provider;
+    'product'?: Product;
+    'provider'?: Provider;
   }
   interface ManifoldRegionSelector extends JSXBase.HTMLAttributes<HTMLManifoldRegionSelectorElement> {
     'allowedRegions'?: string[];

--- a/src/components/manifold-product-details/manifold-product-details.tsx
+++ b/src/components/manifold-product-details/manifold-product-details.tsx
@@ -44,7 +44,7 @@ export class ManifoldProductDetails {
           </span>
         </h1>
         <ul class="value-prop-list" itemprop="description">
-          {value_props.map(({ body, header }) => (
+          {valueProps.map(({ body, header }) => (
             <li class="value-prop" key={header}>
               <h3>
                 <manifold-skeleton-text>{header}</manifold-skeleton-text>

--- a/src/components/manifold-product-details/manifold-product-details.tsx
+++ b/src/components/manifold-product-details/manifold-product-details.tsx
@@ -1,5 +1,5 @@
 import { h, Component, Prop } from '@stencil/core';
-import { Catalog } from '../../types/catalog';
+import { Product } from '../../types/graphql';
 import skeletonProduct from '../../data/product';
 
 @Component({
@@ -8,12 +8,10 @@ import skeletonProduct from '../../data/product';
   shadow: true,
 })
 export class ManifoldProductDetails {
-  @Prop() product?: Catalog.Product;
+  @Prop() product?: Product;
 
   render() {
-    const {
-      body: { tagline, value_props, images = [] },
-    } = this.product || skeletonProduct;
+    const { tagline, valueProps, screenshots = [] } = this.product || skeletonProduct;
 
     if (this.product) {
       return (
@@ -22,15 +20,15 @@ export class ManifoldProductDetails {
             <span class="tagline">{tagline}</span>
           </h1>
           <ul class="value-prop-list" itemprop="description">
-            {value_props.map(({ body, header }) => (
+            {valueProps.map(({ body, header }) => (
               <li class="value-prop" key={header}>
                 <h3>{header}</h3>
                 <p>{body}</p>
               </li>
             ))}
           </ul>
-          {images.length > 0 && (
-            <manifold-image-gallery images={images}>Screenshots</manifold-image-gallery>
+          {screenshots.length > 0 && (
+            <manifold-image-gallery images={screenshots}>Screenshots</manifold-image-gallery>
           )}
         </div>
       );

--- a/src/components/manifold-product-page/manifold-product-page.tsx
+++ b/src/components/manifold-product-page/manifold-product-page.tsx
@@ -1,31 +1,8 @@
-import { h, Component, Prop, Watch } from '@stencil/core';
-import { gql } from '@manifoldco/gql-zero';
+import { h, Component, Prop } from '@stencil/core';
 import { arrow_up_right, book, life_buoy } from '@manifoldco/icons';
-import graphqlFetch from '../../utils/graphqlFetch';
 import { Product, Provider } from '../../types/graphql';
 import skeletonProduct from '../../data/product';
-import Tunnel from '../../data/connection';
-// import { withAuth } from '../../utils/auth';
 import { categoryIcon } from '../../utils/marketplace';
-import { Connection, connections } from '../../utils/connections';
-
-const query = gql`
-  query PRODUCT_PAGE($productId: String!) {
-    product(id: $productId) {
-      displayName
-      documentationUrl
-      supportEmail
-      label
-      logoUrl
-      categories {
-        label
-      }
-      provider {
-        displayName
-      }
-    }
-  }
-`;
 
 @Component({
   tag: 'manifold-product-page',
@@ -34,42 +11,17 @@ const query = gql`
 })
 export class ManifoldProductPage {
   @Prop() product?: Product;
-  @Prop() productId?: string;
   @Prop() provider?: Provider;
-  @Prop() connection?: Connection = connections.prod;
-  @Prop() authToken?: string;
-  @Watch('productId') productChange(newProduct: string) {
-    this.fetchProdProv(newProduct);
+
+  get providerName() {
+    if (!this.product || !this.provider) {
+      return undefined;
+    }
+    return (
+      (this.provider.displayName !== this.product.displayName && this.provider.displayName) ||
+      undefined
+    );
   }
-
-  // get providerName() {
-  //   if (!this.product || !this.provider) return undefined;
-  //   return (
-  //     (this.provider.body.name !== this.product.body.name && this.provider.body.name) || undefined
-  //   );
-  // }
-
-  componentWillLoad() {
-    if (this.productId) {
-      this.fetchProdProv(this.productId);
-    }
-  }
-
-  fetchProdProv = async (productId: string) => {
-    if (!this.connection) {
-      return;
-    }
-
-    this.product = undefined;
-    this.provider = undefined;
-    const variables = { productId };
-    const { data, error } = await graphqlFetch({ query, variables });
-    if (error) {
-      console.error(error);
-    }
-    this.product = data.product;
-    this.provider = data.product.provider;
-  };
 
   render() {
     if (this.product) {
@@ -96,9 +48,7 @@ export class ManifoldProductPage {
                     {displayName}
                   </h2>
                   <p class="provider-name">
-                    {this.provider && this.provider.displayName && (
-                      <span itemprop="brand">from {this.provider.displayName}</span>
-                    )}
+                    {this.providerName && <span itemprop="brand">from {this.providerName}</span>}
                   </p>
                 </div>
                 <div class="sidebar-cta">
@@ -181,5 +131,3 @@ export class ManifoldProductPage {
     );
   }
 }
-
-Tunnel.injectProps(ManifoldProductPage, ['connection', 'authToken']);

--- a/src/components/manifold-product-page/manifold-product-page.tsx
+++ b/src/components/manifold-product-page/manifold-product-page.tsx
@@ -2,10 +2,10 @@ import { h, Component, Prop, Watch } from '@stencil/core';
 import { gql } from '@manifoldco/gql-zero';
 import { arrow_up_right, book, life_buoy } from '@manifoldco/icons';
 import graphqlFetch from '../../utils/graphqlFetch';
-import { Product, Provider } from '../../types/graphql'; 
+import { Product, Provider } from '../../types/graphql';
 import skeletonProduct from '../../data/product';
 import Tunnel from '../../data/connection';
-import { withAuth } from '../../utils/auth';
+// import { withAuth } from '../../utils/auth';
 import { categoryIcon } from '../../utils/marketplace';
 import { Connection, connections } from '../../utils/connections';
 
@@ -42,9 +42,6 @@ export class ManifoldProductPage {
     this.fetchProdProv(newProduct);
   }
 
-  //provider name
-  //product documentation_url, support_url, name, label, logo_url, tags
-
   // get providerName() {
   //   if (!this.product || !this.provider) return undefined;
   //   return (
@@ -53,7 +50,9 @@ export class ManifoldProductPage {
   // }
 
   componentWillLoad() {
-    if (this.productId) this.fetchProdProv(this.productId);
+    if (this.productId) {
+      this.fetchProdProv(this.productId);
+    }
   }
 
   fetchProdProv = async (productId: string) => {
@@ -70,11 +69,18 @@ export class ManifoldProductPage {
     }
     this.product = data.product;
     this.provider = data.product.provider;
-  }
+  };
 
   render() {
     if (this.product) {
-      const { documentationUrl, supportEmail, displayName, label, logoUrl, categories } = this.product;
+      const {
+        documentationUrl,
+        supportEmail,
+        displayName,
+        label,
+        logoUrl,
+        categories,
+      } = this.product;
       const gradient = `var(--manifold-g-${label}, var(--manifold-g-default))`;
 
       return (
@@ -90,7 +96,9 @@ export class ManifoldProductPage {
                     {displayName}
                   </h2>
                   <p class="provider-name">
-                    {this.provider.displayName && <span itemprop="brand">from {this.provider.displayName}</span>}
+                    {this.provider && this.provider.displayName && (
+                      <span itemprop="brand">from {this.provider.displayName}</span>
+                    )}
                   </p>
                 </div>
                 <div class="sidebar-cta">

--- a/src/components/manifold-product-page/manifold-product-page.tsx
+++ b/src/components/manifold-product-page/manifold-product-page.tsx
@@ -1,8 +1,31 @@
-import { h, Component, Prop } from '@stencil/core';
+import { h, Component, Prop, Watch } from '@stencil/core';
+import { gql } from '@manifoldco/gql-zero';
 import { arrow_up_right, book, life_buoy } from '@manifoldco/icons';
-import { Catalog } from '../../types/catalog';
+import graphqlFetch from '../../utils/graphqlFetch';
+import { Product, Provider } from '../../types/graphql'; 
 import skeletonProduct from '../../data/product';
+import Tunnel from '../../data/connection';
+import { withAuth } from '../../utils/auth';
 import { categoryIcon } from '../../utils/marketplace';
+import { Connection, connections } from '../../utils/connections';
+
+const query = gql`
+  query PRODUCT_PAGE($productId: String!) {
+    product(id: $productId) {
+      displayName
+      documentationUrl
+      supportEmail
+      label
+      logoUrl
+      categories {
+        label
+      }
+      provider {
+        displayName
+      }
+    }
+  }
+`;
 
 @Component({
   tag: 'manifold-product-page',
@@ -10,21 +33,48 @@ import { categoryIcon } from '../../utils/marketplace';
   shadow: true,
 })
 export class ManifoldProductPage {
-  @Prop() product?: Catalog.Product;
-  @Prop() provider?: Catalog.Provider;
+  @Prop() product?: Product;
+  @Prop() productId?: string;
+  @Prop() provider?: Provider;
+  @Prop() connection?: Connection = connections.prod;
+  @Prop() authToken?: string;
+  @Watch('productId') productChange(newProduct: string) {
+    this.fetchProdProv(newProduct);
+  }
 
-  get providerName() {
-    if (!this.product || !this.provider) {
-      return undefined;
+  //provider name
+  //product documentation_url, support_url, name, label, logo_url, tags
+
+  // get providerName() {
+  //   if (!this.product || !this.provider) return undefined;
+  //   return (
+  //     (this.provider.body.name !== this.product.body.name && this.provider.body.name) || undefined
+  //   );
+  // }
+
+  componentWillLoad() {
+    if (this.productId) this.fetchProdProv(this.productId);
+  }
+
+  fetchProdProv = async (productId: string) => {
+    if (!this.connection) {
+      return;
     }
-    return (
-      (this.provider.body.name !== this.product.body.name && this.provider.body.name) || undefined
-    );
+
+    this.product = undefined;
+    this.provider = undefined;
+    const variables = { productId };
+    const { data, error } = await graphqlFetch({ query, variables });
+    if (error) {
+      console.error(error);
+    }
+    this.product = data.product;
+    this.provider = data.product.provider;
   }
 
   render() {
     if (this.product) {
-      const { documentation_url, support_email, name, label, logo_url, tags } = this.product.body;
+      const { documentationUrl, supportEmail, displayName, label, logoUrl, categories } = this.product;
       const gradient = `var(--manifold-g-${label}, var(--manifold-g-default))`;
 
       return (
@@ -34,31 +84,31 @@ export class ManifoldProductPage {
               <div class="sidebar-inner">
                 <div class="sidebar-card" style={{ '--background-gradient': gradient }}>
                   <div class="product-logo">
-                    <img src={logo_url} alt={name} itemprop="logo" />
+                    <img src={logoUrl} alt={displayName} itemprop="logo" />
                   </div>
                   <h2 class="product-name" itemprop="name">
-                    {name}
+                    {displayName}
                   </h2>
                   <p class="provider-name">
-                    {this.providerName && <span itemprop="brand">from {this.providerName}</span>}
+                    {this.provider.displayName && <span itemprop="brand">from {this.provider.displayName}</span>}
                   </p>
                 </div>
                 <div class="sidebar-cta">
                   <slot name="cta" />
                 </div>
-                {tags && (
+                {categories && (
                   <div class="sidebar-section">
                     <h4>Category</h4>
-                    {tags.map(tag => (
+                    {categories.map(category => (
                       <div
                         class="category"
-                        style={{ '--categoryColor': `var(--manifold-c-${tag})` }}
+                        style={{ '--categoryColor': `var(--manifold-c-${category})` }}
                       >
                         <manifold-icon
-                          icon={categoryIcon[tag] || categoryIcon.uncategorized}
+                          icon={categoryIcon[category.label] || categoryIcon.uncategorized}
                           margin-right
                         />
-                        {tag}
+                        {category}
                       </div>
                     ))}
                   </div>
@@ -66,14 +116,14 @@ export class ManifoldProductPage {
                 <div class="sidebar-section">
                   <h4>Links</h4>
                   <div class="provider-link">
-                    <a href={documentation_url} target="_blank" rel="noopener noreferrer">
+                    <a href={documentationUrl} target="_blank" rel="noopener noreferrer">
                       <manifold-icon icon={book} margin-right />
                       Docs
                       <manifold-icon class="external-link-icon" icon={arrow_up_right} margin-left />
                     </a>
                   </div>
                   <div class="provider-link">
-                    <a href={`mailto:${support_email}`} target="_blank" rel="noopener noreferrer">
+                    <a href={`mailto:${supportEmail}`} target="_blank" rel="noopener noreferrer">
                       <manifold-icon icon={life_buoy} margin-right />
                       Support
                       <manifold-icon class="external-link-icon" icon={arrow_up_right} margin-left />
@@ -123,3 +173,5 @@ export class ManifoldProductPage {
     );
   }
 }
+
+Tunnel.injectProps(ManifoldProductPage, ['connection', 'authToken']);


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

***BREAKING:*** Chloe realized in writing this PR that since the data handling is happening in `<manifold-product>` the graphql should probably be there as well, of course! So I guess converting the product-page means converting the other components that are connected to it/wrapping it first..does that seem true? I want to post this for review just so people can give me feedback on my attempt though, and I'll see if doing it in the product component makes more sense. :)

## Reason for change
Adding a graphql query and new fetch statement to the `<manifold-product-page>`. Got a little confused on how to know where the variables for the query are coming from, unrelated to graphql but just as far as data handling goes (I assume it should get passed in as a prop?).

## Testing
Storybook renders the `product-page` inside of `product` which uses fetch and catalog to pass data to the `product-page`, so testing there isn't accurate to this component. Might mean we need a new story, or to add graphql to `product`, or might very well mean I misunderstood how the data in this component was supposed to work.