### PR TITLE
Add bundlesize check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
       script: PREVIOUS_SHA=$(git rev-parse master) npm run happo-ci-travis
     - stage: test
       name: '📦 bundlesize'
-      script: npm run build && npx bundlesize
+      script: npm run profile
     - stage: publish
       name: Publish to npm
       script: npm run publish

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ jobs:
     - stage: test
       name: '🔭 Run visual regression tests'
       script: PREVIOUS_SHA=$(git rev-parse master) npm run happo-ci-travis
+    - stage: test
+      name: '📦 bundlesize'
+      script: npm run build && npx bundlesize
     - stage: publish
       name: Publish to npm
       script: npm run publish

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -5425,7 +5425,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5443,11 +5444,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5460,15 +5463,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5571,7 +5577,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5581,6 +5588,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5593,17 +5601,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5620,6 +5631,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5692,7 +5704,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5702,6 +5715,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5777,7 +5791,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5807,6 +5822,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5824,6 +5840,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5862,11 +5879,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -7470,12 +7489,14 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "optional": true
         },
         "slice-ansi": {
           "version": "1.0.0",
@@ -7501,6 +7522,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "optional": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -8437,7 +8459,8 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -8460,6 +8483,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "optional": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "now-build": "npm run build-storybook",
     "postinstall": "cd docs && npm i",
     "prepare": "stencil build",
+    "profile": "stencil build && npx bundlesize",
     "publish": "node scripts/publish",
     "storybook": "start-storybook -p 6006",
     "test": "stencil test --spec --e2e",

--- a/package.json
+++ b/package.json
@@ -63,8 +63,13 @@
       "compression": "none"
     },
     {
-      "path": "./dist/esm/*.js",
+      "path": "./dist/esm/manifold-!(mock)*.js",
       "maxSize": "32 kB",
+      "compression": "none"
+    },
+    {
+      "path": "./dist/esm/chunk-*.js",
+      "maxSize": "66 kB",
       "compression": "none"
     }
   ],

--- a/package.json
+++ b/package.json
@@ -55,6 +55,18 @@
     "test:debug": "node --inspect-brk node_modules/.bin/stencil test --spec --e2e --runInBand",
     "test:watch": "stencil test --spec --e2e --watchAll"
   },
+  "bundlesize": [
+    {
+      "path": "./dist/esm/loader.mjs",
+      "maxSize": "15 kB",
+      "compression": "none"
+    },
+    {
+      "path": "./dist/esm/*.js",
+      "maxSize": "32 kB",
+      "compression": "none"
+    }
+  ],
   "dependencies": {
     "@manifoldco/gql-zero": "^0.2.0",
     "@manifoldco/shadowcat": "^0.1.5",

--- a/src/readme.md
+++ b/src/readme.md
@@ -8,7 +8,7 @@ npm run dev
 This will start Storybook at `localhost:6060`. Storybook is the preferred way
 to work on styles and testing.
 
-__Note:__ When testing the `<manifold-auth-token>` component in Storybook, a fresh token (`manifold_api_token`, available from local storage after a successful login to Dashboard) needs to be manually added to local storage in Storybook. If you don't see the resources you expect after doing this, first check the console and network calls to see if `identity` is returning a 401 Unauthorized response. If this is the case, it's possible your token has expired and you need to set a fresh one in local storage.
+**Note:** When testing the `<manifold-auth-token>` component in Storybook, a fresh token (`manifold_api_token`, available from local storage after a successful login to Dashboard) needs to be manually added to local storage in Storybook. If you don't see the resources you expect after doing this, first check the console and network calls to see if `identity` is returning a 401 Unauthorized response. If this is the case, it's possible your token has expired and you need to set a fresh one in local storage.
 
 Copy these specs from [our specs][specs] into here:
 
@@ -44,7 +44,7 @@ You can do this by clicking `Details` on a failed Happo check and using the `Rev
 
 A passing Happo check means that the test detected no visual changes.
 
-__Note:__ Some diffs may be detected based on animations happening in the components. This may be resolved in the future, but as of writing these diffs require human approval.
+**Note:** Some diffs may be detected based on animations happening in the components. This may be resolved in the future, but as of writing these diffs require human approval.
 
 ### Writing Happo Tests
 
@@ -147,26 +147,16 @@ _Note: when adding a new `*.md` file in `/docs/docs`, it will automatically
 hot reload, however it will break if you don’t add a `path` in
 [frontmatter][frontmatter]._
 
-## 🚀 Publishing to npm
+## 🚀 Deploying
 
 To publish to npm, tag it in Git with a valid [npm-semver][npm-semver].
 
-### Stable release
-
-If you’re releasing a stable release after it’s been fully tested, create a
-semver [Git tag][git-tag], starting with `v`:
-
-```
-v1.0.0
-```
-
-This will be accessible for download at `npm i --save @manifoldco/ui`.
-
 ### Unstable release
 
-If you’re testing a release candidate, or something experimental, add a
-hyphen (`-`) followed by a named flag, and end with `.` + digit. Here are
-some examples:
+**Tagging a release version with a hyphen (`-`)** will publish a test release.
+Use this for both release candidates as well as experimental releases.
+Releasing in this way is highly-encouraged, and poses no risk to our
+partners.
 
 ```
 v1.0.0-rc.0      # first release candidate
@@ -176,6 +166,19 @@ v1.1.0-alpha.0   # buggy version, published for testing
 
 Unlike stable releases, these won’t be downloaded unless someone specifically
 requests the flag (e.g.: `npm i --save @manifoldco/ui@rc` or `npm i --save @manifoldco/ui@alpha`).
+
+### Stable release
+
+**⚠️ Don’t publish a stable version without publishing a release candidate first (above)!**
+
+If you’re releasing a stable release after it’s been fully tested, create a
+semver [Git tag][git-tag], starting with `v`:
+
+```
+v1.0.0
+```
+
+This will be accessible for download at `npm i --save @manifoldco/ui`.
 
 [git-tag]: https://help.github.com/en/articles/working-with-tags
 [npm-semver]: https://docs.npmjs.com/misc/semver


### PR DESCRIPTION
## Reason for change
I originally explored using bundlesize on UI, and decided against it because it seemed to code-split very well. However, we’ve now discovered some new ways our bundle size could expand without noticing, so this adds 2 checks in place:

- [ ] our entry bundle is super light (`esm/loader.mjs`)
- [ ] each individual component doesn’t exceed `32 kB` without warning
- [ ] other parts of Stencil don’t get bigger without notifying us

## Testing
Tests should pass
