### PR TITLE
properly handle region change event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the provision button requiring the label to be set, preventing or automatic label generation from working.
 - Fixed name for `manifold-service-view` to be `manifold-service-card-view` to match documentation.
 - Added missing support for theme variable `--manifold-tag-free-text-color`.
+- Fixed region selector so that it properly emits a `manifold-planSelector-change` event when the region changes.
 
 ### Changed
 - Added graphqlFetch to `manifold-connection`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 - Deprecated `resource-label` attibute on `manifold-data-product-logo`. Use `manifold-data-resource-logo` component instead.
+- Deprecated `region-name` prop in favour of `region-id` for `manifold-data-provision-button`.
 
 ### Added
 - Added a SSO data button and the resource wrapper for ssoing into a resource's product dashboard.

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 - Deprecated `resource-label` attibute on `manifold-data-product-logo`. Use `manifold-data-resource-logo` component instead.
+- Deprecated `region-name` prop in favour of `region-id` for `manifold-data-provision-button`.
 
 ### Fixed
 - Fixed the provision button requiring the label to be set, preventing or automatic label generation from working.

--- a/docs/docs/data/manifold-data-provision-button.md
+++ b/docs/docs/data/manifold-data-provision-button.md
@@ -12,6 +12,9 @@ example: |
 <manifold-toast alert-type="warning">
   <div><code>resource-name</code> has been deprecated in favor of <code>resource-label</code> starting in version 0.4.0.</div>
 </manifold-toast>
+<manifold-toast alert-type="warning">
+  <div><code>region-name</code> has been deprecated in favor of <code>region-id</code> starting in version 0.5.1.</div>
+</manifold-toast>
 
 # 🔒 Provision Button
 
@@ -27,12 +30,12 @@ selector](#manifold-plan-selector) component. You could do that like so:
 const userId = ''; // Note: must be set
 const resourceLabel = ''; // Can be obtained from your own input
 
-function updateButton({ detail: { features, planLabel, productLabel, regionName } }) {
+function updateButton({ detail: { features, planLabel, productLabel, regionId } }) {
   const provisionButton = document.querySelector('manifold-data-provision-button');
   provisionButton.features = features;
   provisionButton.planLabel = planLabel;
   provisionButton.productLabel = productLabel;
-  provisionButton.regionName = regionName;
+  provisionButton.regionId = regionId;
   provisionButton.resourceLabel = resourceLabel;
 
   provisionButton.ownerId = userId;
@@ -75,12 +78,12 @@ document.addEventListener('manifold-provisionButton-invalid', ({ detail }) => co
 // {resourceLabel: "MyResourceName", message: "Must start with a lowercase letter, and use only lowercase, numbers, and hyphens."}
 ```
 
-| Name                               |                       Returns                         | Description                                                                                                                 |
-| :--------------------------------- | :--------------------------------------------------:  | :-------------------------------------------------------------------------------------------------------------------------- |
-| `manifold-provisionButton-click`   |                    `resourceLabel`                    | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
+| Name                               | Returns                                               | Description                                                                                                                 |
+|------------------------------------|-------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| `manifold-provisionButton-click`   | `resourceLabel`                                       | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
 | `manifold-provisionButton-success` | `message`, `resourceLabel`, `resourceId`, `createdAt` | Successful provision. Returns name, along with a resource ID                                                                |
-| `manifold-provisionButton-error`   |              `message`, `resourceLabel`               | Erred provision, along with information on what went wrong.                                                                 |
-| `manifold-provisionButton-invalid` |              `message`, `resourceLabel`               | Fires if the resource name isn’t named properly.                                                                            |
+| `manifold-provisionButton-error`   | `message`, `resourceLabel`                            | Erred provision, along with information on what went wrong.                                                                 |
+| `manifold-provisionButton-invalid` | `message`, `resourceLabel`                            | Fires if the resource name isn’t named properly.                                                                            |
 
 ## Styling
 

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -35,6 +35,7 @@ export namespace Components {
     'selectedResource'?: Gateway.Resource;
   }
   interface ManifoldAuthToken {
+    'oauthUrl'?: string;
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
@@ -1110,6 +1111,7 @@ declare namespace LocalJSX {
     'selectedResource'?: Gateway.Resource;
   }
   interface ManifoldAuthToken extends JSXBase.HTMLAttributes<HTMLManifoldAuthTokenElement> {
+    'oauthUrl'?: string;
     'onManifoldOauthTokenChange'?: (event: CustomEvent<any>) => void;
     /**
     * _(hidden)_ Passed by `<manifold-connection>`

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
@@ -32,12 +32,11 @@ export class ManifoldDataProvisionButton {
   @Prop() productLabel?: string;
   /** Plan to provision (slug) */
   @Prop() planLabel?: string;
-  /** Region to provision (complete name), omit for all region */
-  @Prop() regionName?: string;
   /** The label of the resource to provision */
   @Prop() resourceLabel?: string;
   @Prop({ mutable: true }) ownerId?: string = '';
-  @State() regionId?: string = globalRegion.id;
+  /** Region to provision (ID) */
+  @Prop() regionId?: string = globalRegion.id;
   @State() planId?: string = '';
   @State() productId?: string = '';
   @Event({ eventName: 'manifold-provisionButton-click', bubbles: true })

--- a/src/components/manifold-plan-details/manifold-plan-details.tsx
+++ b/src/components/manifold-plan-details/manifold-plan-details.tsx
@@ -99,7 +99,7 @@ export class ManifoldPlanDetails {
     }
   }
 
-  handleChangeRegion(e: CustomEvent) {
+  handleChangeRegion = (e: CustomEvent) => {
     if (!e.detail || !e.detail.value) {
       return;
     }
@@ -115,7 +115,7 @@ export class ManifoldPlanDetails {
       };
       this.planUpdate.emit(detail);
     }
-  }
+  };
 
   setFeaturesFromPlan(plan: Catalog.ExpandedPlan) {
     if (plan.body.expanded_features) {


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

- The classic problem of `this` not referring to what you'd expect. :shakes-fist:

## Testing
<!-- For someone unfamiliar with the issue, how should this be tested? -->

- go to plan selector
- add an event listener to the document
```js
document.addEventListener('manifold-planSelector-change', (e) => {
  console.log(e.detail);
});
```
- change the region
- see the console log
