### PR TITLE
Add a wait of 15 seconds for the token to exist during fetches

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,7 +57,7 @@ module.exports = {
     'object-curly-newline': 'off', // let Prettier decide,
     'curly': ['error', 'all'],
     'prettier/prettier': 'error',
-    'no-console': 'off',
+    'no-console': ['error', { allow: ['warn', 'error'] }],
     'func-names': 'off',
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,7 +55,9 @@ module.exports = {
     'lines-between-class-members': 'off', // class members don’t need that space!
     'max-len': 'off', // let Prettier decide
     'object-curly-newline': 'off', // let Prettier decide,
-    "curly": ["error", "all"],
+    'curly': ['error', 'all'],
     'prettier/prettier': 'error',
+    'no-console': 'off',
+    'func-names': 'off',
   },
 };

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -426,6 +426,7 @@ export namespace Components {
     'ariaLabel': string;
     'name': string;
     'preferredRegions'?: string[];
+    'regions'?: Catalog.Region[];
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
@@ -1459,6 +1460,7 @@ declare namespace LocalJSX {
     'name'?: string;
     'onUpdateValue'?: (event: CustomEvent<any>) => void;
     'preferredRegions'?: string[];
+    'regions'?: Catalog.Region[];
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -65,6 +65,10 @@ export namespace Components {
     * _(optional)_ Specify `env="stage"` for staging
     */
     'env': 'local' | 'stage' | 'prod';
+    /**
+    * _(optional)_ Wait time for the fetch calls before it times out
+    */
+    'waitTime': number;
   }
   interface ManifoldCostDisplay {
     'baseCost'?: number;
@@ -73,56 +77,51 @@ export namespace Components {
     'measuredFeatures': Catalog.ExpandedFeature[];
   }
   interface ManifoldCredentials {
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
     'resourceId'?: string;
     'resourceLabel': string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldDataDeprovisionButton {
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
     'loading'?: boolean;
     'resourceId'?: string;
     /**
     * The label of the resource to deprovision
     */
     'resourceLabel'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldDataHasResource {
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
     /**
     * Disable auto-updates?
     */
     'paused'?: boolean;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldDataManageButton {
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
     'features'?: Gateway.FeatureMap;
     'planId'?: string;
     'productId'?: string;
@@ -131,20 +130,21 @@ export namespace Components {
     * Name of resource
     */
     'resourceLabel'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldDataProductLogo {
     /**
     * _(optional)_ `alt` attribute
     */
     'alt'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
@@ -160,14 +160,6 @@ export namespace Components {
   }
   interface ManifoldDataProductName {
     /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
-    /**
     * URL-friendly slug (e.g. `"jawsdb-mysql"`)
     */
     'productLabel'?: string;
@@ -175,16 +167,17 @@ export namespace Components {
     * Look up product name from resource
     */
     'resourceLabel'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldDataProvisionButton {
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
@@ -206,16 +199,17 @@ export namespace Components {
     * The label of the resource to provision
     */
     'resourceLabel'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldDataRenameButton {
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
     'loading'?: boolean;
     /**
     * The new label to give to the resource
@@ -229,16 +223,17 @@ export namespace Components {
     * The label of the resource to rename
     */
     'resourceLabel'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldDataResourceList {
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
     /**
     * Disable auto-updates?
     */
@@ -251,6 +246,15 @@ export namespace Components {
     * Link format structure, with `:resource` placeholder
     */
     'resourceLinkFormat'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldDataResourceLogo {
     /**
@@ -258,27 +262,20 @@ export namespace Components {
     */
     'alt'?: string;
     /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
-    /**
     * Look up product logo from resource
     */
     'resourceLabel'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldDataSsoButton {
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
     'loading'?: boolean;
     /**
     * The id of the resource to rename, will be fetched if not set
@@ -288,6 +285,15 @@ export namespace Components {
     * The label of the resource to rename
     */
     'resourceLabel'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldForwardSlot {}
   interface ManifoldIcon {
@@ -325,14 +331,6 @@ export namespace Components {
   }
   interface ManifoldMarketplace {
     /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
-    /**
     * Comma-separated list of hidden products (labels)
     */
     'excludes'?: string;
@@ -364,6 +362,15 @@ export namespace Components {
     * Comma-separated list of shown products (labels)
     */
     'products'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
     /**
     * Template format structure, with `:product` placeholder
     */
@@ -397,14 +404,6 @@ export namespace Components {
   }
   interface ManifoldPlan {
     /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
-    /**
     * URL-friendly slug (e.g. `"kitefin"`)
     */
     'planLabel'?: string;
@@ -412,17 +411,30 @@ export namespace Components {
     * URL-friendly slug (e.g. `"jawsdb-mysql"`)
     */
     'productLabel'?: string;
-  }
-  interface ManifoldPlanCost {
-    'allFeatures': Catalog.ExpandedFeature[];
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'authToken'?: string;
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
+  }
+  interface ManifoldPlanCost {
+    'allFeatures': Catalog.ExpandedFeature[];
     'compact'?: boolean;
-    'connection'?: Connection;
     'customizable'?: boolean;
     'planId': string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
     'selectedFeatures': Gateway.FeatureMap;
   }
   interface ManifoldPlanDetails {
@@ -441,14 +453,6 @@ export namespace Components {
   }
   interface ManifoldPlanSelector {
     /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
-    /**
     * URL-friendly slug (e.g. `"jawsdb-mysql"`)
     */
     'productLabel'?: string;
@@ -460,20 +464,30 @@ export namespace Components {
     * Is this tied to an existing resource?
     */
     'resourceLabel'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldProduct {
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
     /**
     * _(optional)_ Hide the CTA on the left?
     */
     'productLabel'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldProductDetails {
     'product'?: Catalog.Product;
@@ -485,32 +499,35 @@ export namespace Components {
   interface ManifoldRegionSelector {
     'allowedRegions': string[];
     'ariaLabel': string;
+    'name': string;
+    'preferredRegions'?: string[];
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'authToken'?: string;
-    'connection'?: Connection;
-    'name': string;
-    'preferredRegions'?: string[];
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
     'value'?: string;
   }
   interface ManifoldResourceCard {
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    'connection'?: Connection;
     'label'?: string;
     'preserveEvent'?: boolean;
     'resourceId'?: string;
     'resourceLinkFormat'?: string;
-  }
-  interface ManifoldResourceCardView {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'authToken'?: string;
-    'connection'?: Connection;
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
+  }
+  interface ManifoldResourceCardView {
     'label'?: string;
     'loading'?: boolean;
     'logo'?: string;
@@ -519,20 +536,30 @@ export namespace Components {
     'resourceId'?: string;
     'resourceLinkFormat'?: string;
     'resourceStatus'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldResourceContainer {
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
     /**
     * Which resource does this belong to?
     */
     'resourceLabel'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldResourceCredentials {}
   interface ManifoldResourceCredentialsView {
@@ -550,14 +577,6 @@ export namespace Components {
   }
   interface ManifoldResourceList {
     /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
-    /**
     * Disable auto-updates?
     */
     'paused'?: boolean;
@@ -569,6 +588,15 @@ export namespace Components {
     * Link format structure, with `:resource` placeholder
     */
     'resourceLinkFormat'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldResourcePlan {}
   interface ManifoldResourceProduct {
@@ -603,17 +631,21 @@ export namespace Components {
     'required'?: boolean;
   }
   interface ManifoldServiceCard {
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    'connection'?: Connection;
     'isFeatured'?: boolean;
     'preserveEvent'?: boolean;
     'product'?: Catalog.Product;
     'productId'?: string;
     'productLabel'?: string;
     'productLinkFormat'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
     'skeleton'?: boolean;
   }
   interface ManifoldServiceCardView {
@@ -1148,6 +1180,10 @@ declare namespace LocalJSX {
     * _(optional)_ Specify `env="stage"` for staging
     */
     'env'?: 'local' | 'stage' | 'prod';
+    /**
+    * _(optional)_ Wait time for the fetch calls before it times out
+    */
+    'waitTime'?: number;
   }
   interface ManifoldCostDisplay extends JSXBase.HTMLAttributes<HTMLManifoldCostDisplayElement> {
     'baseCost'?: number;
@@ -1156,26 +1192,19 @@ declare namespace LocalJSX {
     'measuredFeatures'?: Catalog.ExpandedFeature[];
   }
   interface ManifoldCredentials extends JSXBase.HTMLAttributes<HTMLManifoldCredentialsElement> {
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
     'resourceId'?: string;
     'resourceLabel'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldDataDeprovisionButton extends JSXBase.HTMLAttributes<HTMLManifoldDataDeprovisionButtonElement> {
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
     'loading'?: boolean;
     'onManifold-deprovisionButton-click'?: (event: CustomEvent<any>) => void;
     'onManifold-deprovisionButton-error'?: (event: CustomEvent<any>) => void;
@@ -1185,30 +1214,32 @@ declare namespace LocalJSX {
     * The label of the resource to deprovision
     */
     'resourceLabel'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldDataHasResource extends JSXBase.HTMLAttributes<HTMLManifoldDataHasResourceElement> {
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
     /**
     * Disable auto-updates?
     */
     'paused'?: boolean;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldDataManageButton extends JSXBase.HTMLAttributes<HTMLManifoldDataManageButtonElement> {
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
     'features'?: Gateway.FeatureMap;
     'onManifold-manageButton-click'?: (event: CustomEvent<any>) => void;
     'onManifold-manageButton-error'?: (event: CustomEvent<any>) => void;
@@ -1220,20 +1251,21 @@ declare namespace LocalJSX {
     * Name of resource
     */
     'resourceLabel'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldDataProductLogo extends JSXBase.HTMLAttributes<HTMLManifoldDataProductLogoElement> {
     /**
     * _(optional)_ `alt` attribute
     */
     'alt'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
@@ -1249,14 +1281,6 @@ declare namespace LocalJSX {
   }
   interface ManifoldDataProductName extends JSXBase.HTMLAttributes<HTMLManifoldDataProductNameElement> {
     /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
-    /**
     * URL-friendly slug (e.g. `"jawsdb-mysql"`)
     */
     'productLabel'?: string;
@@ -1264,16 +1288,17 @@ declare namespace LocalJSX {
     * Look up product name from resource
     */
     'resourceLabel'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldDataProvisionButton extends JSXBase.HTMLAttributes<HTMLManifoldDataProvisionButtonElement> {
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
@@ -1299,16 +1324,17 @@ declare namespace LocalJSX {
     * The label of the resource to provision
     */
     'resourceLabel'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldDataRenameButton extends JSXBase.HTMLAttributes<HTMLManifoldDataRenameButtonElement> {
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
     'loading'?: boolean;
     /**
     * The new label to give to the resource
@@ -1326,16 +1352,17 @@ declare namespace LocalJSX {
     * The label of the resource to rename
     */
     'resourceLabel'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldDataResourceList extends JSXBase.HTMLAttributes<HTMLManifoldDataResourceListElement> {
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
     'onManifold-resourceList-click'?: (event: CustomEvent<any>) => void;
     /**
     * Disable auto-updates?
@@ -1349,6 +1376,15 @@ declare namespace LocalJSX {
     * Link format structure, with `:resource` placeholder
     */
     'resourceLinkFormat'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldDataResourceLogo extends JSXBase.HTMLAttributes<HTMLManifoldDataResourceLogoElement> {
     /**
@@ -1356,27 +1392,20 @@ declare namespace LocalJSX {
     */
     'alt'?: string;
     /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
-    /**
     * Look up product logo from resource
     */
     'resourceLabel'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldDataSsoButton extends JSXBase.HTMLAttributes<HTMLManifoldDataSsoButtonElement> {
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
     'loading'?: boolean;
     'onManifold-ssoButton-click'?: (event: CustomEvent<any>) => void;
     'onManifold-ssoButton-error'?: (event: CustomEvent<any>) => void;
@@ -1389,6 +1418,15 @@ declare namespace LocalJSX {
     * The label of the resource to rename
     */
     'resourceLabel'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldForwardSlot extends JSXBase.HTMLAttributes<HTMLManifoldForwardSlotElement> {}
   interface ManifoldIcon extends JSXBase.HTMLAttributes<HTMLManifoldIconElement> {
@@ -1427,14 +1465,6 @@ declare namespace LocalJSX {
   }
   interface ManifoldMarketplace extends JSXBase.HTMLAttributes<HTMLManifoldMarketplaceElement> {
     /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
-    /**
     * Comma-separated list of hidden products (labels)
     */
     'excludes'?: string;
@@ -1466,6 +1496,15 @@ declare namespace LocalJSX {
     * Comma-separated list of shown products (labels)
     */
     'products'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
     /**
     * Template format structure, with `:product` placeholder
     */
@@ -1500,14 +1539,6 @@ declare namespace LocalJSX {
   }
   interface ManifoldPlan extends JSXBase.HTMLAttributes<HTMLManifoldPlanElement> {
     /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
-    /**
     * URL-friendly slug (e.g. `"kitefin"`)
     */
     'planLabel'?: string;
@@ -1515,17 +1546,30 @@ declare namespace LocalJSX {
     * URL-friendly slug (e.g. `"jawsdb-mysql"`)
     */
     'productLabel'?: string;
-  }
-  interface ManifoldPlanCost extends JSXBase.HTMLAttributes<HTMLManifoldPlanCostElement> {
-    'allFeatures'?: Catalog.ExpandedFeature[];
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'authToken'?: string;
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
+  }
+  interface ManifoldPlanCost extends JSXBase.HTMLAttributes<HTMLManifoldPlanCostElement> {
+    'allFeatures'?: Catalog.ExpandedFeature[];
     'compact'?: boolean;
-    'connection'?: Connection;
     'customizable'?: boolean;
     'planId'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
     'selectedFeatures'?: Gateway.FeatureMap;
   }
   interface ManifoldPlanDetails extends JSXBase.HTMLAttributes<HTMLManifoldPlanDetailsElement> {
@@ -1546,14 +1590,6 @@ declare namespace LocalJSX {
   }
   interface ManifoldPlanSelector extends JSXBase.HTMLAttributes<HTMLManifoldPlanSelectorElement> {
     /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
-    /**
     * URL-friendly slug (e.g. `"jawsdb-mysql"`)
     */
     'productLabel'?: string;
@@ -1565,20 +1601,30 @@ declare namespace LocalJSX {
     * Is this tied to an existing resource?
     */
     'resourceLabel'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldProduct extends JSXBase.HTMLAttributes<HTMLManifoldProductElement> {
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
     /**
     * _(optional)_ Hide the CTA on the left?
     */
     'productLabel'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldProductDetails extends JSXBase.HTMLAttributes<HTMLManifoldProductDetailsElement> {
     'product'?: Catalog.Product;
@@ -1590,33 +1636,36 @@ declare namespace LocalJSX {
   interface ManifoldRegionSelector extends JSXBase.HTMLAttributes<HTMLManifoldRegionSelectorElement> {
     'allowedRegions'?: string[];
     'ariaLabel'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    'connection'?: Connection;
     'name'?: string;
     'onUpdateValue'?: (event: CustomEvent<any>) => void;
     'preferredRegions'?: string[];
-    'value'?: string;
-  }
-  interface ManifoldResourceCard extends JSXBase.HTMLAttributes<HTMLManifoldResourceCardElement> {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'authToken'?: string;
-    'connection'?: Connection;
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
+    'value'?: string;
+  }
+  interface ManifoldResourceCard extends JSXBase.HTMLAttributes<HTMLManifoldResourceCardElement> {
     'label'?: string;
     'preserveEvent'?: boolean;
     'resourceId'?: string;
     'resourceLinkFormat'?: string;
-  }
-  interface ManifoldResourceCardView extends JSXBase.HTMLAttributes<HTMLManifoldResourceCardViewElement> {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'authToken'?: string;
-    'connection'?: Connection;
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
+  }
+  interface ManifoldResourceCardView extends JSXBase.HTMLAttributes<HTMLManifoldResourceCardViewElement> {
     'label'?: string;
     'loading'?: boolean;
     'logo'?: string;
@@ -1626,20 +1675,30 @@ declare namespace LocalJSX {
     'resourceId'?: string;
     'resourceLinkFormat'?: string;
     'resourceStatus'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldResourceContainer extends JSXBase.HTMLAttributes<HTMLManifoldResourceContainerElement> {
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
     /**
     * Which resource does this belong to?
     */
     'resourceLabel'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldResourceCredentials extends JSXBase.HTMLAttributes<HTMLManifoldResourceCredentialsElement> {}
   interface ManifoldResourceCredentialsView extends JSXBase.HTMLAttributes<HTMLManifoldResourceCredentialsViewElement> {
@@ -1661,14 +1720,6 @@ declare namespace LocalJSX {
   }
   interface ManifoldResourceList extends JSXBase.HTMLAttributes<HTMLManifoldResourceListElement> {
     /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'connection'?: Connection;
-    /**
     * Disable auto-updates?
     */
     'paused'?: boolean;
@@ -1680,6 +1731,15 @@ declare namespace LocalJSX {
     * Link format structure, with `:resource` placeholder
     */
     'resourceLinkFormat'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
   }
   interface ManifoldResourcePlan extends JSXBase.HTMLAttributes<HTMLManifoldResourcePlanElement> {}
   interface ManifoldResourceProduct extends JSXBase.HTMLAttributes<HTMLManifoldResourceProductElement> {
@@ -1722,11 +1782,6 @@ declare namespace LocalJSX {
     'required'?: boolean;
   }
   interface ManifoldServiceCard extends JSXBase.HTMLAttributes<HTMLManifoldServiceCardElement> {
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'authToken'?: string;
-    'connection'?: Connection;
     'isFeatured'?: boolean;
     'onManifold-marketplace-click'?: (event: CustomEvent<any>) => void;
     'preserveEvent'?: boolean;
@@ -1734,6 +1789,15 @@ declare namespace LocalJSX {
     'productId'?: string;
     'productLabel'?: string;
     'productLinkFormat'?: string;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'restFetch'?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+    ) => Promise<T | Error>;
     'skeleton'?: boolean;
   }
   interface ManifoldServiceCardView extends JSXBase.HTMLAttributes<HTMLManifoldServiceCardViewElement> {

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -192,9 +192,9 @@ export namespace Components {
     */
     'productLabel'?: string;
     /**
-    * Region to provision (complete name), omit for all region
+    * Region to provision (ID)
     */
-    'regionName'?: string;
+    'regionId'?: string;
     /**
     * The label of the resource to provision
     */
@@ -1317,9 +1317,9 @@ declare namespace LocalJSX {
     */
     'productLabel'?: string;
     /**
-    * Region to provision (complete name), omit for all region
+    * Region to provision (ID)
     */
-    'regionName'?: string;
+    'regionId'?: string;
     /**
     * The label of the resource to provision
     */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -13,8 +13,8 @@ import {
   Gateway,
 } from './types/gateway';
 import {
-  Connection,
-} from './utils/connections';
+  RestFetch,
+} from './utils/restFetch';
 import {
   GraphqlRequestBody,
   GraphqlResponseBody,
@@ -82,12 +82,7 @@ export namespace Components {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldDataDeprovisionButton {
     'loading'?: boolean;
@@ -99,12 +94,7 @@ export namespace Components {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldDataHasResource {
     /**
@@ -114,12 +104,7 @@ export namespace Components {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldDataManageButton {
     'features'?: Gateway.FeatureMap;
@@ -133,12 +118,7 @@ export namespace Components {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldDataProductLogo {
     /**
@@ -170,12 +150,7 @@ export namespace Components {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldDataProvisionButton {
     /**
@@ -202,12 +177,7 @@ export namespace Components {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldDataRenameButton {
     'loading'?: boolean;
@@ -226,12 +196,7 @@ export namespace Components {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldDataResourceList {
     /**
@@ -249,12 +214,7 @@ export namespace Components {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldDataResourceLogo {
     /**
@@ -268,12 +228,7 @@ export namespace Components {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldDataSsoButton {
     'loading'?: boolean;
@@ -288,12 +243,7 @@ export namespace Components {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldForwardSlot {}
   interface ManifoldIcon {
@@ -365,12 +315,7 @@ export namespace Components {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
     /**
     * Template format structure, with `:product` placeholder
     */
@@ -414,12 +359,7 @@ export namespace Components {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldPlanCost {
     'allFeatures': Catalog.ExpandedFeature[];
@@ -429,12 +369,7 @@ export namespace Components {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
     'selectedFeatures': Gateway.FeatureMap;
   }
   interface ManifoldPlanDetails {
@@ -467,12 +402,7 @@ export namespace Components {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldProduct {
     /**
@@ -482,12 +412,7 @@ export namespace Components {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldProductDetails {
     'product'?: Catalog.Product;
@@ -504,12 +429,7 @@ export namespace Components {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
     'value'?: string;
   }
   interface ManifoldResourceCard {
@@ -520,12 +440,7 @@ export namespace Components {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldResourceCardView {
     'label'?: string;
@@ -539,12 +454,7 @@ export namespace Components {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldResourceContainer {
     /**
@@ -554,12 +464,7 @@ export namespace Components {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldResourceCredentials {}
   interface ManifoldResourceCredentialsView {
@@ -591,12 +496,7 @@ export namespace Components {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldResourcePlan {}
   interface ManifoldResourceProduct {
@@ -640,12 +540,7 @@ export namespace Components {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
     'skeleton'?: boolean;
   }
   interface ManifoldServiceCardView {
@@ -1197,12 +1092,7 @@ declare namespace LocalJSX {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldDataDeprovisionButton extends JSXBase.HTMLAttributes<HTMLManifoldDataDeprovisionButtonElement> {
     'loading'?: boolean;
@@ -1217,12 +1107,7 @@ declare namespace LocalJSX {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldDataHasResource extends JSXBase.HTMLAttributes<HTMLManifoldDataHasResourceElement> {
     /**
@@ -1232,12 +1117,7 @@ declare namespace LocalJSX {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldDataManageButton extends JSXBase.HTMLAttributes<HTMLManifoldDataManageButtonElement> {
     'features'?: Gateway.FeatureMap;
@@ -1254,12 +1134,7 @@ declare namespace LocalJSX {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldDataProductLogo extends JSXBase.HTMLAttributes<HTMLManifoldDataProductLogoElement> {
     /**
@@ -1291,12 +1166,7 @@ declare namespace LocalJSX {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldDataProvisionButton extends JSXBase.HTMLAttributes<HTMLManifoldDataProvisionButtonElement> {
     /**
@@ -1327,12 +1197,7 @@ declare namespace LocalJSX {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldDataRenameButton extends JSXBase.HTMLAttributes<HTMLManifoldDataRenameButtonElement> {
     'loading'?: boolean;
@@ -1355,12 +1220,7 @@ declare namespace LocalJSX {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldDataResourceList extends JSXBase.HTMLAttributes<HTMLManifoldDataResourceListElement> {
     'onManifold-resourceList-click'?: (event: CustomEvent<any>) => void;
@@ -1379,12 +1239,7 @@ declare namespace LocalJSX {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldDataResourceLogo extends JSXBase.HTMLAttributes<HTMLManifoldDataResourceLogoElement> {
     /**
@@ -1398,12 +1253,7 @@ declare namespace LocalJSX {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldDataSsoButton extends JSXBase.HTMLAttributes<HTMLManifoldDataSsoButtonElement> {
     'loading'?: boolean;
@@ -1421,12 +1271,7 @@ declare namespace LocalJSX {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldForwardSlot extends JSXBase.HTMLAttributes<HTMLManifoldForwardSlotElement> {}
   interface ManifoldIcon extends JSXBase.HTMLAttributes<HTMLManifoldIconElement> {
@@ -1499,12 +1344,7 @@ declare namespace LocalJSX {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
     /**
     * Template format structure, with `:product` placeholder
     */
@@ -1549,12 +1389,7 @@ declare namespace LocalJSX {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldPlanCost extends JSXBase.HTMLAttributes<HTMLManifoldPlanCostElement> {
     'allFeatures'?: Catalog.ExpandedFeature[];
@@ -1564,12 +1399,7 @@ declare namespace LocalJSX {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
     'selectedFeatures'?: Gateway.FeatureMap;
   }
   interface ManifoldPlanDetails extends JSXBase.HTMLAttributes<HTMLManifoldPlanDetailsElement> {
@@ -1604,12 +1434,7 @@ declare namespace LocalJSX {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldProduct extends JSXBase.HTMLAttributes<HTMLManifoldProductElement> {
     /**
@@ -1619,12 +1444,7 @@ declare namespace LocalJSX {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldProductDetails extends JSXBase.HTMLAttributes<HTMLManifoldProductDetailsElement> {
     'product'?: Catalog.Product;
@@ -1642,12 +1462,7 @@ declare namespace LocalJSX {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
     'value'?: string;
   }
   interface ManifoldResourceCard extends JSXBase.HTMLAttributes<HTMLManifoldResourceCardElement> {
@@ -1658,12 +1473,7 @@ declare namespace LocalJSX {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldResourceCardView extends JSXBase.HTMLAttributes<HTMLManifoldResourceCardViewElement> {
     'label'?: string;
@@ -1678,12 +1488,7 @@ declare namespace LocalJSX {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldResourceContainer extends JSXBase.HTMLAttributes<HTMLManifoldResourceContainerElement> {
     /**
@@ -1693,12 +1498,7 @@ declare namespace LocalJSX {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldResourceCredentials extends JSXBase.HTMLAttributes<HTMLManifoldResourceCredentialsElement> {}
   interface ManifoldResourceCredentialsView extends JSXBase.HTMLAttributes<HTMLManifoldResourceCredentialsViewElement> {
@@ -1734,12 +1534,7 @@ declare namespace LocalJSX {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
   }
   interface ManifoldResourcePlan extends JSXBase.HTMLAttributes<HTMLManifoldResourcePlanElement> {}
   interface ManifoldResourceProduct extends JSXBase.HTMLAttributes<HTMLManifoldResourceProductElement> {
@@ -1792,12 +1587,7 @@ declare namespace LocalJSX {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
-    'restFetch'?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-    ) => Promise<T | Error>;
+    'restFetch'?: RestFetch;
     'skeleton'?: boolean;
   }
   interface ManifoldServiceCardView extends JSXBase.HTMLAttributes<HTMLManifoldServiceCardViewElement> {

--- a/src/components/manifold-active-plan/manifold-active-plan-happo.ts
+++ b/src/components/manifold-active-plan/manifold-active-plan-happo.ts
@@ -1,11 +1,13 @@
 import product from '../../spec/mock/jawsdb/product.json';
 import plans from '../../spec/mock/jawsdb/plans.json';
+import regions from '../../spec/mock/jawsdb/regions.json';
 import fromJSON from '../../spec/mock/fromJSON';
 
 export const jawsDB = () => {
   const plan = document.createElement('manifold-active-plan');
   plan.plans = fromJSON(plans);
   plan.product = fromJSON(product);
+  plan.regions = fromJSON(regions);
 
   document.body.appendChild(plan);
 
@@ -16,6 +18,7 @@ export const planError = () => {
   const plan = document.createElement('manifold-active-plan');
   plan.plans = fromJSON(plans);
   plan.product = fromJSON(product);
+  plan.regions = fromJSON(regions);
   plan.selectedResource = {
     get region() {
       throw new Error('oops'); // strangely-specific render() error for this component

--- a/src/components/manifold-active-plan/manifold-active-plan-happo.ts
+++ b/src/components/manifold-active-plan/manifold-active-plan-happo.ts
@@ -3,22 +3,38 @@ import plans from '../../spec/mock/jawsdb/plans.json';
 import regions from '../../spec/mock/jawsdb/regions.json';
 import fromJSON from '../../spec/mock/fromJSON';
 
-export const jawsDB = () => {
+export const jawsDB = async () => {
   const plan = document.createElement('manifold-active-plan');
   plan.plans = fromJSON(plans);
   plan.product = fromJSON(product);
-  plan.regions = fromJSON(regions);
 
   document.body.appendChild(plan);
+
+  await plan.componentOnReady();
+
+  if (plan.shadowRoot) {
+    const details = plan.shadowRoot.querySelector('manifold-plan-details');
+
+    if (details && details.shadowRoot) {
+      const selector = details.shadowRoot.querySelector('manifold-region-selector');
+      if (selector) {
+        selector.regions = fromJSON(regions);
+
+        document.body.appendChild(plan);
+
+        return selector.componentOnReady();
+      }
+    }
+  }
 
   return plan.componentOnReady();
 };
 
-export const planError = () => {
+export const planError = async () => {
   const plan = document.createElement('manifold-active-plan');
   plan.plans = fromJSON(plans);
   plan.product = fromJSON(product);
-  plan.regions = fromJSON(regions);
+
   plan.selectedResource = {
     get region() {
       throw new Error('oops'); // strangely-specific render() error for this component
@@ -26,6 +42,23 @@ export const planError = () => {
   } as any;
 
   document.body.appendChild(plan);
+
+  await plan.componentOnReady();
+
+  if (plan.shadowRoot) {
+    const details = plan.shadowRoot.querySelector('manifold-plan-details');
+
+    if (details && details.shadowRoot) {
+      const selector = details.shadowRoot.querySelector('manifold-region-selector');
+      if (selector) {
+        selector.regions = fromJSON(regions);
+
+        document.body.appendChild(plan);
+
+        return selector.componentOnReady();
+      }
+    }
+  }
 
   return plan.componentOnReady();
 };

--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -1,4 +1,5 @@
 import { h, Component, Prop, Watch, Event, EventEmitter } from '@stencil/core';
+
 import { AuthToken } from '@manifoldco/shadowcat';
 import Tunnel from '../../data/connection';
 import { isExpired } from '../../utils/auth';

--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -29,7 +29,7 @@ export class ManifoldAuthToken {
     const payload = e.detail as AuthToken;
     if (!payload.error && payload.expiry) {
       const expiry = payload.expiry.toString();
-      this.token = `${payload.token}.${expiry}`;
+      this.token = `${payload.token}|${expiry}`;
     }
   };
 

--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -31,7 +31,7 @@ export class ManifoldAuthToken {
     const payload = e.detail as AuthToken;
     if (!payload.error && payload.expiry) {
       const expiry = payload.expiry.toString();
-      this.token = `${payload.token}|${expiry}`;
+      this.token = `${payload.token}.${expiry}`;
     }
   };
 

--- a/src/components/manifold-connection/manifold-connection.tsx
+++ b/src/components/manifold-connection/manifold-connection.tsx
@@ -38,7 +38,7 @@ export class ManiTunnel {
 
   get accessToken() {
     if (this.authToken) {
-      const [token] = this.authToken.split('|');
+      const [token] = this.authToken.split('.');
       return token;
     }
 

--- a/src/components/manifold-connection/manifold-connection.tsx
+++ b/src/components/manifold-connection/manifold-connection.tsx
@@ -32,11 +32,12 @@ export class ManiTunnel {
     localStorage.setItem(TOKEN_KEY, token);
   };
 
-  getAuthToken = () => (this.authToken && !isExpired(this.authToken) ? this.authToken : undefined);
+  getAuthToken = () =>
+    this.authToken && !isExpired(this.authToken) ? this.accessToken : undefined;
 
   get accessToken() {
     if (this.authToken) {
-      const [token] = this.authToken.split('.');
+      const [token] = this.authToken.split('|');
       return token;
     }
 

--- a/src/components/manifold-credentials/manifold-credentials.tsx
+++ b/src/components/manifold-credentials/manifold-credentials.tsx
@@ -2,17 +2,12 @@ import { h, Component, Prop, State, Watch } from '@stencil/core';
 
 import { Marketplace } from '../../types/marketplace';
 import ConnectionTunnel from '../../data/connection';
-import { Connection } from '../../utils/connections';
+import { RestFetch } from '../../utils/restFetch';
 
 @Component({ tag: 'manifold-credentials' })
 export class ManifoldCredentials {
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() restFetch?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-  ) => Promise<T | Error>;
+  @Prop() restFetch?: RestFetch;
   @Prop() resourceLabel: string = '';
   @Prop({ mutable: true }) resourceId?: string = '';
   @State() loading?: boolean = false;
@@ -36,10 +31,10 @@ export class ManifoldCredentials {
     }
 
     this.loading = true;
-    const response = await this.restFetch<Marketplace.Credential[]>(
-      'marketplace',
-      `/credentials/?resource_id=${this.resourceId}`
-    );
+    const response = await this.restFetch<Marketplace.Credential[]>({
+      service: 'marketplace',
+      endpoint: `/credentials/?resource_id=${this.resourceId}`,
+    });
 
     if (response instanceof Error) {
       console.error(response);
@@ -55,10 +50,10 @@ export class ManifoldCredentials {
       return;
     }
 
-    const response = await this.restFetch<Marketplace.Resource[]>(
-      'marketplace',
-      `/resources/?me&label=${resourceLabel}`
-    );
+    const response = await this.restFetch<Marketplace.Resource[]>({
+      service: 'marketplace',
+      endpoint: `/resources/?me&label=${resourceLabel}`,
+    });
 
     if (response instanceof Error) {
       console.error(response);

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
@@ -1,8 +1,8 @@
 import { h, Component, Prop, Element, Watch, Event, EventEmitter } from '@stencil/core';
 
 import Tunnel from '../../data/connection';
-import { Connection } from '../../utils/connections';
 import { Marketplace } from '../../types/marketplace';
+import { RestFetch } from '../../utils/restFetch';
 
 /* eslint-disable no-console */
 
@@ -22,12 +22,7 @@ interface ErrorMessage {
 export class ManifoldDataDeprovisionButton {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() restFetch?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-  ) => Promise<T | Error>;
+  @Prop() restFetch?: RestFetch;
   /** The label of the resource to deprovision */
   @Prop() resourceLabel?: string;
   @Prop({ mutable: true }) resourceId?: string = '';
@@ -64,12 +59,11 @@ export class ManifoldDataDeprovisionButton {
       resourceLabel: this.resourceLabel || '',
     });
 
-    const response = await this.restFetch(
-      'gateway',
-      `/id/resource/${this.resourceId}`,
-      {},
-      { method: 'DELETE' }
-    );
+    const response = await this.restFetch({
+      service: 'gateway',
+      endpoint: `/id/resource/${this.resourceId}`,
+      options: { method: 'DELETE' },
+    });
 
     if (response instanceof Error) {
       const error: ErrorMessage = {
@@ -94,10 +88,10 @@ export class ManifoldDataDeprovisionButton {
       return;
     }
 
-    const response = await this.restFetch<Marketplace.Resource[]>(
-      'marketplace',
-      `/resources/?me&label=${resourceLabel}`
-    );
+    const response = await this.restFetch<Marketplace.Resource[]>({
+      service: 'marketplace',
+      endpoint: `/resources/?me&label=${resourceLabel}`,
+    });
 
     if (response instanceof Error) {
       console.error(response);

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
@@ -1,8 +1,7 @@
 import { h, Component, Prop, Element, Watch, Event, EventEmitter } from '@stencil/core';
 
 import Tunnel from '../../data/connection';
-import { withAuth } from '../../utils/auth';
-import { Connection, connections } from '../../utils/connections';
+import { Connection } from '../../utils/connections';
 import { Marketplace } from '../../types/marketplace';
 
 /* eslint-disable no-console */
@@ -23,9 +22,12 @@ interface ErrorMessage {
 export class ManifoldDataDeprovisionButton {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() connection?: Connection = connections.prod;
-  /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() authToken?: string;
+  @Prop() restFetch?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+  ) => Promise<T | Error>;
   /** The label of the resource to deprovision */
   @Prop() resourceLabel?: string;
   @Prop({ mutable: true }) resourceId?: string = '';
@@ -47,7 +49,7 @@ export class ManifoldDataDeprovisionButton {
   }
 
   async deprovision() {
-    if (!this.connection || this.loading) {
+    if (!this.restFetch || this.loading) {
       return;
     }
 
@@ -62,45 +64,46 @@ export class ManifoldDataDeprovisionButton {
       resourceLabel: this.resourceLabel || '',
     });
 
-    const response = await fetch(
-      `${this.connection.gateway}/id/resource/${this.resourceId}`,
-      withAuth(this.authToken, {
-        method: 'DELETE',
-      })
+    const response = await this.restFetch(
+      'gateway',
+      `/id/resource/${this.resourceId}`,
+      {},
+      { method: 'DELETE' }
     );
 
-    // If successful, this will return 200 and stop here
-    if (response.status >= 200 && response.status < 300) {
-      const success: SuccessMessage = {
-        message: `${this.resourceLabel} successfully deprovisioned`,
-        resourceLabel: this.resourceLabel || '',
-        resourceId: this.resourceId,
-      };
-      this.success.emit(success);
-    } else {
-      const body = await response.json();
-
-      // Sometimes messages are an array, sometimes they aren’t. Different strokes!
-      const message = Array.isArray(body) ? body[0].message : body.message;
+    if (response instanceof Error) {
       const error: ErrorMessage = {
-        message,
+        message: response.message,
         resourceLabel: this.resourceLabel || '',
         resourceId: this.resourceId,
       };
       this.error.emit(error);
-    }
-  }
-
-  async fetchResourceId(resourceLabel: string) {
-    if (!this.connection) {
       return;
     }
 
-    const resourceResp = await fetch(
-      `${this.connection.marketplace}/resources/?me&label=${resourceLabel}`,
-      withAuth(this.authToken)
+    const success: SuccessMessage = {
+      message: `${this.resourceLabel} successfully deprovisioned`,
+      resourceLabel: this.resourceLabel || '',
+      resourceId: this.resourceId,
+    };
+    this.success.emit(success);
+  }
+
+  async fetchResourceId(resourceLabel: string) {
+    if (!this.restFetch) {
+      return;
+    }
+
+    const response = await this.restFetch<Marketplace.Resource[]>(
+      'marketplace',
+      `/resources/?me&label=${resourceLabel}`
     );
-    const resources: Marketplace.Resource[] = await resourceResp.json();
+
+    if (response instanceof Error) {
+      console.error(response);
+      return;
+    }
+    const resources: Marketplace.Resource[] = response;
 
     if (!Array.isArray(resources) || !resources.length) {
       console.error(`${resourceLabel} product not found`);
@@ -123,4 +126,4 @@ export class ManifoldDataDeprovisionButton {
   }
 }
 
-Tunnel.injectProps(ManifoldDataDeprovisionButton, ['connection', 'authToken']);
+Tunnel.injectProps(ManifoldDataDeprovisionButton, ['restFetch']);

--- a/src/components/manifold-data-has-resource/manifold-data-has-resource.spec.ts
+++ b/src/components/manifold-data-has-resource/manifold-data-has-resource.spec.ts
@@ -5,10 +5,27 @@ import { ManifoldDataHasResource } from './manifold-data-has-resource';
 import { Marketplace } from '../../types/marketplace';
 import { Resource } from '../../spec/mock/marketplace';
 import { connections } from '../../utils/connections';
+import { createRestFetch } from '../../utils/restFetch';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const proto = ManifoldDataHasResource.prototype as any;
+const oldCallback = proto.componentWillLoad;
+
+proto.componentWillLoad = function() {
+  (this as any).restFetch = createRestFetch({
+    getAuthToken: jest.fn(() => '1234'),
+    wait: 10,
+    setAuthToken: jest.fn(),
+  });
+
+  if (oldCallback) {
+    oldCallback.call(this);
+  }
+};
 
 const resources: Marketplace.Resource[] = [Resource];
 
-describe('<manifold-resource-list>', () => {
+describe('<manifold-data-has-resource>', () => {
   afterEach(() => {
     fetchMock.restore();
   });

--- a/src/components/manifold-data-has-resource/manifold-data-has-resource.tsx
+++ b/src/components/manifold-data-has-resource/manifold-data-has-resource.tsx
@@ -1,17 +1,19 @@
 import { h, Component, Prop, State, Element, Watch } from '@stencil/core';
 
 import { Marketplace } from '../../types/marketplace';
-import { withAuth } from '../../utils/auth';
-import { Connection, connections } from '../../utils/connections';
+import { Connection } from '../../utils/connections';
 import Tunnel from '../../data/connection';
 
 @Component({ tag: 'manifold-data-has-resource', shadow: true })
 export class ManifoldDataHasResource {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() connection?: Connection = connections.prod; // Provided by manifold-connection
-  /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() authToken?: string;
+  @Prop() restFetch?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+  ) => Promise<T | Error>;
   /** Disable auto-updates? */
   @Prop() paused?: boolean = false;
   @State() interval?: number;
@@ -43,15 +45,18 @@ export class ManifoldDataHasResource {
   }
 
   async fetchResources() {
-    if (!this.connection) {
+    if (!this.restFetch) {
       return;
     }
 
-    const resourcesResp = await fetch(
-      `${this.connection.marketplace}/resources/?me`,
-      withAuth(this.authToken)
-    );
-    const resources: Marketplace.Resource[] = await resourcesResp.json();
+    const response = await this.restFetch<Marketplace.Resource[]>('marketplace', `/resources/?me`);
+
+    if (response instanceof Error) {
+      console.error(response);
+      return;
+    }
+
+    const resources: Marketplace.Resource[] = await response;
     if (Array.isArray(resources) && resources.length) {
       this.hasResources = true;
     }
@@ -62,4 +67,4 @@ export class ManifoldDataHasResource {
   }
 }
 
-Tunnel.injectProps(ManifoldDataHasResource, ['connection', 'authToken']);
+Tunnel.injectProps(ManifoldDataHasResource, ['restFetch']);

--- a/src/components/manifold-data-has-resource/manifold-data-has-resource.tsx
+++ b/src/components/manifold-data-has-resource/manifold-data-has-resource.tsx
@@ -1,19 +1,14 @@
 import { h, Component, Prop, State, Element, Watch } from '@stencil/core';
 
 import { Marketplace } from '../../types/marketplace';
-import { Connection } from '../../utils/connections';
 import Tunnel from '../../data/connection';
+import { RestFetch } from '../../utils/restFetch';
 
 @Component({ tag: 'manifold-data-has-resource', shadow: true })
 export class ManifoldDataHasResource {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() restFetch?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-  ) => Promise<T | Error>;
+  @Prop() restFetch?: RestFetch;
   /** Disable auto-updates? */
   @Prop() paused?: boolean = false;
   @State() interval?: number;
@@ -49,7 +44,10 @@ export class ManifoldDataHasResource {
       return;
     }
 
-    const response = await this.restFetch<Marketplace.Resource[]>('marketplace', `/resources/?me`);
+    const response = await this.restFetch<Marketplace.Resource[]>({
+      service: 'marketplace',
+      endpoint: `/resources/?me`,
+    });
 
     if (response instanceof Error) {
       console.error(response);

--- a/src/components/manifold-data-manage-button/manifold-data-manage-button.tsx
+++ b/src/components/manifold-data-manage-button/manifold-data-manage-button.tsx
@@ -1,9 +1,10 @@
 import { h, Component, Prop, State, Element, Event, EventEmitter, Watch } from '@stencil/core';
+
 import { Gateway } from '../../types/gateway';
 import Tunnel from '../../data/connection';
 import { globalRegion } from '../../data/region';
-import { Connection } from '../../utils/connections';
 import { Marketplace } from '../../types/marketplace';
+import { RestFetch } from '../../utils/restFetch';
 
 /* eslint-disable no-console */
 
@@ -26,12 +27,7 @@ interface ErrorMessage {
 export class ManifoldDataManageButton {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() restFetch?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-  ) => Promise<T | Error>;
+  @Prop() restFetch?: RestFetch;
   /** Name of resource */
   @Prop() resourceLabel?: string;
   @Prop() features?: Gateway.FeatureMap = {};
@@ -57,10 +53,10 @@ export class ManifoldDataManageButton {
       return;
     }
 
-    const response = await this.restFetch<Marketplace.Resource[]>(
-      'marketplace',
-      `/resources/?me&label=${resourceLabel}`
-    );
+    const response = await this.restFetch<Marketplace.Resource[]>({
+      service: 'marketplace',
+      endpoint: `/resources/?me&label=${resourceLabel}`,
+    });
 
     if (response instanceof Error) {
       console.error(response);
@@ -97,15 +93,15 @@ export class ManifoldDataManageButton {
       req.features = this.features;
     }
 
-    const response = await this.restFetch<Gateway.Resource>(
-      'gateway',
-      `/id/resource/${this.resourceId}`,
-      req,
-      {
+    const response = await this.restFetch<Gateway.Resource>({
+      service: 'gateway',
+      endpoint: `/id/resource/${this.resourceId}`,
+      body: req,
+      options: {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-      }
-    );
+      },
+    });
 
     if (response instanceof Error) {
       const error: ErrorMessage = {

--- a/src/components/manifold-data-product-logo/manifold-data-product-logo.tsx
+++ b/src/components/manifold-data-product-logo/manifold-data-product-logo.tsx
@@ -1,9 +1,9 @@
 import { h, Component, Prop, State, Watch } from '@stencil/core';
 import { gql } from '@manifoldco/gql-zero';
+
 import { GraphqlResponseBody, GraphqlRequestBody } from '../../utils/graphqlFetch';
 import { Product } from '../../types/graphql';
 import Tunnel from '../../data/connection';
-import { Connection, connections } from '../../utils/connections';
 
 const query = gql`
   query PRODUCT_LOGO($productLabel: String!) {
@@ -18,10 +18,6 @@ const query = gql`
 export class ManifoldDataProductLogo {
   /** _(optional)_ `alt` attribute */
   @Prop() alt?: string;
-  /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() connection?: Connection = connections.prod; // Provided by manifold-connection
-  /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() authToken?: string;
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() graphqlFetch?: <T>(body: GraphqlRequestBody) => GraphqlResponseBody<T>;
   /** URL-friendly slug (e.g. `"jawsdb-mysql"`) */
@@ -64,4 +60,4 @@ export class ManifoldDataProductLogo {
   }
 }
 
-Tunnel.injectProps(ManifoldDataProductLogo, ['connection', 'authToken', 'graphqlFetch']);
+Tunnel.injectProps(ManifoldDataProductLogo, ['graphqlFetch']);

--- a/src/components/manifold-data-product-name/manifold-data-product-name.tsx
+++ b/src/components/manifold-data-product-name/manifold-data-product-name.tsx
@@ -3,18 +3,13 @@ import { Component, Prop, State, Element, Watch } from '@stencil/core';
 import { Catalog } from '../../types/catalog';
 import { Gateway } from '../../types/gateway';
 import Tunnel from '../../data/connection';
-import { Connection } from '../../utils/connections';
+import { RestFetch } from '../../utils/restFetch';
 
 @Component({ tag: 'manifold-data-product-name' })
 export class ManifoldDataProductName {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() restFetch?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-  ) => Promise<T | Error>;
+  @Prop() restFetch?: RestFetch;
   /** URL-friendly slug (e.g. `"jawsdb-mysql"`) */
   @Prop() productLabel?: string;
   /** Look up product name from resource */
@@ -43,10 +38,10 @@ export class ManifoldDataProductName {
 
     this.productName = undefined;
 
-    const response = await this.restFetch<Catalog.Product[]>(
-      'catalog',
-      `/products?label=${productLabel}`
-    );
+    const response = await this.restFetch<Catalog.Product[]>({
+      service: 'catalog',
+      endpoint: `/products?label=${productLabel}`,
+    });
 
     if (response instanceof Error) {
       console.error(response);
@@ -64,10 +59,10 @@ export class ManifoldDataProductName {
 
     this.productName = undefined;
 
-    const response = await this.restFetch<Gateway.Resource>(
-      'gateway',
-      `/resources/me/${resourceName}`
-    );
+    const response = await this.restFetch<Gateway.Resource>({
+      service: 'gateway',
+      endpoint: `/resources/me/${resourceName}`,
+    });
 
     if (response instanceof Error) {
       console.error(response);

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
@@ -4,8 +4,7 @@ import { gql } from '@manifoldco/gql-zero';
 import { Gateway } from '../../types/gateway';
 import Tunnel from '../../data/connection';
 import { globalRegion } from '../../data/region';
-import { withAuth } from '../../utils/auth';
-import { Connection, connections } from '../../utils/connections';
+import { Connection } from '../../utils/connections';
 import { Catalog } from '../../types/catalog';
 import { GraphqlRequestBody, GraphqlResponseBody } from '../../utils/graphqlFetch';
 
@@ -43,9 +42,12 @@ const query = gql`
 export class ManifoldDataProvisionButton {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() connection?: Connection = connections.prod;
-  /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() authToken?: string;
+  @Prop() restFetch?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+  ) => Promise<T | Error>;
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() graphqlFetch?: <T>(body: GraphqlRequestBody) => GraphqlResponseBody<T>;
   /** Product to provision (slug) */
@@ -56,17 +58,14 @@ export class ManifoldDataProvisionButton {
   @Prop() regionName?: string;
   /** The label of the resource to provision */
   @Prop() resourceLabel?: string;
-  @Prop({ mutable: true }) ownerId?: string = '';
+  @Prop({ mutable: true }) ownerId?: string;
   @State() regionId?: string = globalRegion.id;
   @State() planId?: string = '';
   @State() productId?: string = '';
-  @Event({ eventName: 'manifold-provisionButton-click', bubbles: true })
-  clickEvent: EventEmitter;
-  @Event({ eventName: 'manifold-provisionButton-invalid', bubbles: true })
-  invalidEvent: EventEmitter;
-  @Event({ eventName: 'manifold-provisionButton-error', bubbles: true }) errorEvent: EventEmitter;
-  @Event({ eventName: 'manifold-provisionButton-success', bubbles: true })
-  successEvent: EventEmitter;
+  @Event({ eventName: 'manifold-provisionButton-click', bubbles: true }) click: EventEmitter;
+  @Event({ eventName: 'manifold-provisionButton-invalid', bubbles: true }) invalid: EventEmitter;
+  @Event({ eventName: 'manifold-provisionButton-error', bubbles: true }) error: EventEmitter;
+  @Event({ eventName: 'manifold-provisionButton-success', bubbles: true }) success: EventEmitter;
 
   @Watch('productLabel') productChange(newProduct: string) {
     this.fetchProductPlanId(newProduct, this.planLabel);
@@ -87,7 +86,7 @@ export class ManifoldDataProvisionButton {
   }
 
   async provision() {
-    if (!this.connection) {
+    if (!this.restFetch) {
       return;
     }
 
@@ -97,14 +96,14 @@ export class ManifoldDataProvisionButton {
     }
 
     if (this.resourceLabel && this.resourceLabel.length < 3) {
-      this.invalidEvent.emit({
+      this.invalid.emit({
         message: 'Must be at least 3 characters.',
         resourceLabel: this.resourceLabel,
       });
       return;
     }
     if (this.resourceLabel && !this.validate(this.resourceLabel)) {
-      this.invalidEvent.emit({
+      this.invalid.emit({
         message:
           'Must start with a lowercase letter, and use only lowercase, numbers, and hyphens.',
         resourceLabel: this.resourceLabel,
@@ -113,7 +112,7 @@ export class ManifoldDataProvisionButton {
     }
 
     // We use Gateway b/c it’s much easier to provision w/o generating a base32 ID
-    this.clickEvent.emit({
+    this.click.emit({
       resourceLabel: this.resourceLabel,
     });
 
@@ -130,61 +129,61 @@ export class ManifoldDataProvisionButton {
       features: {},
     };
 
-    const response = await fetch(
-      `${this.connection.gateway}/resource/`,
-      withAuth(this.authToken, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(req),
-      })
-    );
+    const response = await this.restFetch<Gateway.Resource>('gateway', `/resource/`, req, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
 
-    const body = await response.json();
-
-    // If successful, this will return 200 and stop here
-    if (response.status >= 200 && response.status < 300) {
-      const success: SuccessMessage = {
-        createdAt: body.created_at,
-        message: `${this.resourceLabel} successfully provisioned`,
-        resourceId: body.id,
-        resourceLabel: body.label,
-      };
-      this.successEvent.emit(success);
-    } else {
-      // Sometimes messages are an array, sometimes they aren’t. Different strokes!
-      const message = Array.isArray(body) ? body[0].message : body.message;
+    if (response instanceof Error) {
       const error: ErrorMessage = {
-        message,
+        message: response.message,
         resourceLabel: this.resourceLabel,
       };
-      this.errorEvent.emit(error);
+      this.error.emit(error);
+      return;
     }
+
+    const success: SuccessMessage = {
+      createdAt: response.created_at,
+      message: `${this.resourceLabel} successfully provisioned`,
+      resourceId: response.id || '',
+      resourceLabel: response.label,
+    };
+    this.success.emit(success);
   }
 
   async fetchProductPlanId(productLabel: string, planLabel?: string) {
     // TODO: Add region fetching too
-    if (!productLabel || !this.connection) {
+    if (!productLabel || !this.restFetch) {
       return;
     }
 
-    const productResp = await fetch(
-      `${this.connection.catalog}/products/?label=${productLabel}`,
-      withAuth(this.authToken)
+    const productResp = await this.restFetch<Catalog.Product[]>(
+      'catalog',
+      `/products/?label=${productLabel}`
     );
-    const products: Catalog.Product[] = await productResp.json();
+
+    if (productResp instanceof Error) {
+      console.error(productResp);
+      return;
+    }
+    const products: Catalog.Product[] = await productResp;
 
     if (!Array.isArray(products) || !products.length) {
       console.error(`${productLabel} product not found`);
       return;
     }
 
-    const planResp = await fetch(
-      `${this.connection.catalog}/plans/?product_id=${products[0].id}${
-        planLabel ? `&label=${planLabel}` : ''
-      }`,
-      withAuth(this.authToken)
+    const planResp = await this.restFetch<Catalog.Plan[]>(
+      'catalog',
+      `/plans/?product_id=${products[0].id}${planLabel ? `&label=${planLabel}` : ''}`
     );
-    const plans: Catalog.Plan[] = await planResp.json();
+
+    if (planResp instanceof Error) {
+      console.error(planResp);
+      return;
+    }
+    const plans: Catalog.Plan[] = await planResp;
 
     if (!Array.isArray(plans) || !plans.length) {
       console.error(`${productLabel} plans not found`);
@@ -201,7 +200,6 @@ export class ManifoldDataProvisionButton {
     }
 
     const { data } = await this.graphqlFetch<ProfileMessage>({ query });
-    console.log(data);
 
     if (data) {
       this.ownerId = data.profile.id;
@@ -225,4 +223,4 @@ export class ManifoldDataProvisionButton {
   }
 }
 
-Tunnel.injectProps(ManifoldDataProvisionButton, ['connection', 'authToken', 'graphqlFetch']);
+Tunnel.injectProps(ManifoldDataProvisionButton, ['restFetch', 'graphqlFetch']);

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
@@ -4,9 +4,9 @@ import { gql } from '@manifoldco/gql-zero';
 import { Gateway } from '../../types/gateway';
 import Tunnel from '../../data/connection';
 import { globalRegion } from '../../data/region';
-import { Connection } from '../../utils/connections';
 import { Catalog } from '../../types/catalog';
 import { GraphqlRequestBody, GraphqlResponseBody } from '../../utils/graphqlFetch';
+import { RestFetch } from '../../utils/restFetch';
 
 /* eslint-disable no-console */
 
@@ -42,12 +42,7 @@ const query = gql`
 export class ManifoldDataProvisionButton {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() restFetch?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-  ) => Promise<T | Error>;
+  @Prop() restFetch?: RestFetch;
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() graphqlFetch?: <T>(body: GraphqlRequestBody) => GraphqlResponseBody<T>;
   /** Product to provision (slug) */
@@ -128,9 +123,14 @@ export class ManifoldDataProvisionButton {
       features: {},
     };
 
-    const response = await this.restFetch<Gateway.Resource>('gateway', `/resource/`, req, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+    const response = await this.restFetch<Gateway.Resource>({
+      service: 'gateway',
+      endpoint: `/resource/`,
+      body: req,
+      options: {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      },
     });
 
     if (response instanceof Error) {
@@ -157,10 +157,10 @@ export class ManifoldDataProvisionButton {
       return;
     }
 
-    const productResp = await this.restFetch<Catalog.Product[]>(
-      'catalog',
-      `/products/?label=${productLabel}`
-    );
+    const productResp = await this.restFetch<Catalog.Product[]>({
+      service: 'catalog',
+      endpoint: `/products/?label=${productLabel}`,
+    });
 
     if (productResp instanceof Error) {
       console.error(productResp);
@@ -173,10 +173,10 @@ export class ManifoldDataProvisionButton {
       return;
     }
 
-    const planResp = await this.restFetch<Catalog.Plan[]>(
-      'catalog',
-      `/plans/?product_id=${products[0].id}${planLabel ? `&label=${planLabel}` : ''}`
-    );
+    const planResp = await this.restFetch<Catalog.Plan[]>({
+      service: 'catalog',
+      endpoint: `/plans/?product_id=${products[0].id}${planLabel ? `&label=${planLabel}` : ''}`,
+    });
 
     if (planResp instanceof Error) {
       console.error(planResp);

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
@@ -3,8 +3,24 @@ import fetchMock from 'fetch-mock';
 
 import { Resource } from '../../spec/mock/marketplace';
 import { connections } from '../../utils/connections';
-
 import { ManifoldDataRenameButton } from './manifold-data-rename-button';
+import { createRestFetch } from '../../utils/restFetch';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const proto = ManifoldDataRenameButton.prototype as any;
+const oldCallback = proto.componentWillLoad;
+
+proto.componentWillLoad = function() {
+  (this as any).restFetch = createRestFetch({
+    getAuthToken: jest.fn(() => '1234'),
+    wait: 10,
+    setAuthToken: jest.fn(),
+  });
+
+  if (oldCallback) {
+    oldCallback.call(this);
+  }
+};
 
 describe('<manifold-data-rename-button>', () => {
   it('fetches the resource id on load if not set', () => {
@@ -83,7 +99,7 @@ describe('<manifold-data-rename-button>', () => {
     it('will do nothing on a fetch error', async () => {
       const resourceLabel = 'new-resource';
 
-      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&name=${resourceLabel}`, []);
+      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`, []);
 
       const page = await newSpecPage({
         components: [ManifoldDataRenameButton],
@@ -178,12 +194,15 @@ describe('<manifold-data-rename-button>', () => {
     });
 
     it('will do nothing if still loading', async () => {
-      fetchMock.mock(`${connections.prod.gateway}/id/resource/${Resource.id}`, 200);
+      fetchMock
+        .mock(`${connections.prod.gateway}/id/resource/${Resource.id}`, 200)
+        .mock(`${connections.prod.marketplace}/resources/?me&label=test`, []);
 
       const page = await newSpecPage({
         components: [ManifoldDataRenameButton],
         html: `
           <manifold-data-rename-button
+            loading=""
             resource-label="test"
           >Provision</manifold-data-rename-button>
         `,
@@ -200,7 +219,9 @@ describe('<manifold-data-rename-button>', () => {
     });
 
     it('will do nothing if no resourceId is provided', async () => {
-      fetchMock.mock(`${connections.prod.gateway}/id/resource/${Resource.id}`, 200);
+      fetchMock
+        .mock(`${connections.prod.gateway}/id/resource/${Resource.id}`, 200)
+        .mock(`${connections.prod.marketplace}/resources/?me&label=test`, []);
 
       const page = await newSpecPage({
         components: [ManifoldDataRenameButton],

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
@@ -1,8 +1,8 @@
 import { h, Component, Prop, Element, Watch, Event, EventEmitter } from '@stencil/core';
 
 import Tunnel from '../../data/connection';
-import { Connection } from '../../utils/connections';
 import { Marketplace } from '../../types/marketplace';
+import { RestFetch } from '../../utils/restFetch';
 
 /* eslint-disable no-console */
 
@@ -37,12 +37,7 @@ interface ErrorMessage {
 export class ManifoldDataRenameButton {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() restFetch?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-  ) => Promise<T | Error>;
+  @Prop() restFetch?: RestFetch;
   /** The label of the resource to rename */
   @Prop() resourceLabel?: string;
   /** The new label to give to the resource */
@@ -113,9 +108,14 @@ export class ManifoldDataRenameButton {
       },
     };
 
-    const response = await this.restFetch('marketplace', `/resources/${this.resourceId}`, body, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
+    const response = await this.restFetch({
+      service: 'marketplace',
+      endpoint: `/resources/${this.resourceId}`,
+      body,
+      options: {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+      },
     });
 
     if (response instanceof Error) {
@@ -143,10 +143,10 @@ export class ManifoldDataRenameButton {
       return;
     }
 
-    const response = await this.restFetch<Marketplace.Resource[]>(
-      'marketplace',
-      `/resources/?me&label=${resourceLabel}`
-    );
+    const response = await this.restFetch<Marketplace.Resource[]>({
+      service: 'marketplace',
+      endpoint: `/resources/?me&label=${resourceLabel}`,
+    });
 
     if (response instanceof Error) {
       console.error(response);

--- a/src/components/manifold-data-resource-list/manifold-data-resource-list.tsx
+++ b/src/components/manifold-data-resource-list/manifold-data-resource-list.tsx
@@ -2,7 +2,7 @@ import { h, Component, Prop, State, Event, EventEmitter, Element } from '@stenci
 
 import { Marketplace } from '../../types/marketplace';
 import Tunnel from '../../data/connection';
-import { Connection } from '../../utils/connections';
+import { RestFetch } from '../../utils/restFetch';
 
 interface EventDetail {
   ownerId?: string;
@@ -24,12 +24,7 @@ interface RealResourceBody extends Marketplace.ResourceBody {
 export class ManifoldDataResourceList {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() restFetch?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-  ) => Promise<T | Error>;
+  @Prop() restFetch?: RestFetch;
   /** Disable auto-updates? */
   @Prop() paused?: boolean = false;
   /** Link format structure, with `:resource` placeholder */
@@ -58,7 +53,10 @@ export class ManifoldDataResourceList {
       return;
     }
 
-    const response = await this.restFetch<Marketplace.Resource[]>('marketplace', `/resources/?me`);
+    const response = await this.restFetch<Marketplace.Resource[]>({
+      service: 'marketplace',
+      endpoint: `/resources/?me`,
+    });
 
     if (response instanceof Error) {
       console.error(response);

--- a/src/components/manifold-data-resource-list/manifold-data-resource-list.tsx
+++ b/src/components/manifold-data-resource-list/manifold-data-resource-list.tsx
@@ -1,8 +1,8 @@
 import { h, Component, Prop, State, Event, EventEmitter, Element } from '@stencil/core';
+
 import { Marketplace } from '../../types/marketplace';
 import Tunnel from '../../data/connection';
-import { withAuth } from '../../utils/auth';
-import { Connection, connections } from '../../utils/connections';
+import { Connection } from '../../utils/connections';
 
 interface EventDetail {
   ownerId?: string;
@@ -24,9 +24,12 @@ interface RealResourceBody extends Marketplace.ResourceBody {
 export class ManifoldDataResourceList {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() connection?: Connection = connections.prod; // Provided by manifold-connection
-  /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() authToken?: string;
+  @Prop() restFetch?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+  ) => Promise<T | Error>;
   /** Disable auto-updates? */
   @Prop() paused?: boolean = false;
   /** Link format structure, with `:resource` placeholder */
@@ -38,6 +41,7 @@ export class ManifoldDataResourceList {
   @Event({ eventName: 'manifold-resourceList-click', bubbles: true }) clickEvent: EventEmitter;
 
   componentWillLoad() {
+    this.fetchResources();
     if (!this.paused) {
       this.interval = window.setInterval(() => this.fetchResources(), 3000);
     }
@@ -49,21 +53,24 @@ export class ManifoldDataResourceList {
     }
   }
 
-  fetchResources() {
-    if (!this.connection) {
+  fetchResources = async () => {
+    if (!this.restFetch) {
       return;
     }
 
-    fetch(`${this.connection.marketplace}/resources/?me`, withAuth(this.authToken))
-      .then(response => response.json())
-      .then((resources: Marketplace.Resource[]) => {
-        if (Array.isArray(resources)) {
-          this.resources = this.userResources(
-            [...resources].sort((a, b) => a.body.label.localeCompare(b.body.label))
-          );
-        }
-      });
-  }
+    const response = await this.restFetch<Marketplace.Resource[]>('marketplace', `/resources/?me`);
+
+    if (response instanceof Error) {
+      console.error(response);
+      return;
+    }
+
+    if (Array.isArray(response)) {
+      this.resources = this.userResources(
+        [...response].sort((a, b) => a.body.label.localeCompare(b.body.label))
+      );
+    }
+  };
 
   handleClick(resource: Marketplace.Resource, e: Event) {
     if (!this.resourceLinkFormat || this.preserveEvent) {
@@ -110,4 +117,4 @@ export class ManifoldDataResourceList {
     );
   }
 }
-Tunnel.injectProps(ManifoldDataResourceList, ['connection', 'authToken']);
+Tunnel.injectProps(ManifoldDataResourceList, ['restFetch']);

--- a/src/components/manifold-data-resource-logo/manifold-data-resource-logo.tsx
+++ b/src/components/manifold-data-resource-logo/manifold-data-resource-logo.tsx
@@ -3,20 +3,15 @@ import { h, Component, Prop, State, Watch } from '@stencil/core';
 import { Catalog } from '../../types/catalog';
 import { Product } from '../../types/graphql';
 import Tunnel from '../../data/connection';
-import { Connection } from '../../utils/connections';
 import { Marketplace } from '../../types/marketplace';
+import { RestFetch } from '../../utils/restFetch';
 
 @Component({ tag: 'manifold-data-resource-logo' })
 export class ManifoldDataResourceLogo {
   /** _(optional)_ `alt` attribute */
   @Prop() alt?: string;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() restFetch?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-  ) => Promise<T | Error>;
+  @Prop() restFetch?: RestFetch;
   /** Look up product logo from resource */
   @Prop() resourceLabel?: string;
   @State() product?: Product;
@@ -35,10 +30,10 @@ export class ManifoldDataResourceLogo {
     }
 
     this.product = undefined;
-    const resourceResp = await this.restFetch<Marketplace.Resource[]>(
-      'marketplace',
-      `/resources/?me&label=${resourceLabel}`
-    );
+    const resourceResp = await this.restFetch<Marketplace.Resource[]>({
+      service: 'marketplace',
+      endpoint: `/resources/?me&label=${resourceLabel}`,
+    });
 
     if (resourceResp instanceof Error) {
       console.error(resourceResp);
@@ -47,7 +42,10 @@ export class ManifoldDataResourceLogo {
 
     const resource: Marketplace.Resource = resourceResp[0];
     const productId = resource.body.product_id;
-    const productResp = await this.restFetch<Catalog.Product>('catalog', `/products/${productId}`);
+    const productResp = await this.restFetch<Catalog.Product>({
+      service: 'catalog',
+      endpoint: `/products/${productId}`,
+    });
 
     if (productResp instanceof Error) {
       console.error(productResp);

--- a/src/components/manifold-data-sso-button/manifold-data-sso-button.tsx
+++ b/src/components/manifold-data-sso-button/manifold-data-sso-button.tsx
@@ -1,8 +1,7 @@
 import { h, Component, Prop, Element, Watch, Event, EventEmitter } from '@stencil/core';
 
 import Tunnel from '../../data/connection';
-import { withAuth } from '../../utils/auth';
-import { Connection, connections } from '../../utils/connections';
+import { Connection } from '../../utils/connections';
 import { Marketplace } from '../../types/marketplace';
 import { Connector } from '../../types/connector';
 
@@ -30,9 +29,12 @@ interface ErrorMessage {
 export class ManifoldDataSsoButton {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() connection?: Connection = connections.prod;
-  /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() authToken?: string;
+  @Prop() restFetch?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+  ) => Promise<T | Error>;
   /** The label of the resource to rename */
   @Prop() resourceLabel?: string;
   /** The id of the resource to rename, will be fetched if not set */
@@ -55,7 +57,7 @@ export class ManifoldDataSsoButton {
   }
 
   async sso() {
-    if (!this.connection || this.loading) {
+    if (!this.restFetch || this.loading) {
       return;
     }
 
@@ -75,61 +77,53 @@ export class ManifoldDataSsoButton {
         resource_id: this.resourceId,
       },
     };
-    const response = await fetch(
-      `${this.connection.connector}/sso`,
-      withAuth(this.authToken, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      })
-    );
 
-    // If successful, this will return 200 and stop here
-    if (response.status >= 200 && response.status < 300) {
-      const result: Connector.AuthorizationCode = await response.json();
+    const response = await this.restFetch<Connector.AuthorizationCode>('connector', `/sso`, body, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
 
-      const success: SuccessMessage = {
-        message: `${this.resourceLabel} successfully ssoed`,
-        resourceLabel: this.resourceLabel || '',
-        resourceId: this.resourceId,
-        redirectUrl: result.body.redirect_uri,
-      };
-      this.success.emit(success);
-    } else {
-      const result = await response.json();
-
-      // Sometimes messages are an array, sometimes they aren’t. Different strokes!
-      const message = Array.isArray(result) ? result[0].message : result.message;
+    if (response instanceof Error) {
       const error: ErrorMessage = {
-        message,
+        message: response.message,
         resourceLabel: this.resourceLabel || '',
         resourceId: this.resourceId,
       };
       this.error.emit(error);
-    }
-  }
-
-  async fetchResourceId(resourceLabel: string) {
-    if (!this.connection) {
       return;
     }
 
-    const resourceResp = await fetch(
-      `${this.connection.marketplace}/resources/?me&label=${resourceLabel}`,
-      withAuth(this.authToken)
+    const success: SuccessMessage = {
+      message: `${this.resourceLabel} successfully ssoed`,
+      resourceLabel: this.resourceLabel || '',
+      resourceId: this.resourceId,
+      redirectUrl: response.body.redirect_uri,
+    };
+    this.success.emit(success);
+  }
+
+  async fetchResourceId(resourceLabel: string) {
+    if (!this.restFetch) {
+      return;
+    }
+
+    const response = await this.restFetch<Marketplace.Resource[]>(
+      'marketplace',
+      `/resources/?me&label=${resourceLabel}`
     );
-    const resources: Marketplace.Resource[] = await resourceResp.json();
+
+    if (response instanceof Error) {
+      console.error(response);
+      return;
+    }
+    const resources: Marketplace.Resource[] = response;
 
     if (!Array.isArray(resources) || !resources.length) {
-      console.error(`${resourceLabel} product not found`);
+      console.error(`${resourceLabel} resource not found`);
       return;
     }
 
     this.resourceId = resources[0].id;
-  }
-
-  validate(input: string) {
-    return /^[a-z][a-z0-9]*/.test(input);
   }
 
   render() {
@@ -141,4 +135,4 @@ export class ManifoldDataSsoButton {
   }
 }
 
-Tunnel.injectProps(ManifoldDataSsoButton, ['connection', 'authToken']);
+Tunnel.injectProps(ManifoldDataSsoButton, ['restFetch']);

--- a/src/components/manifold-data-sso-button/manifold-data-sso-button.tsx
+++ b/src/components/manifold-data-sso-button/manifold-data-sso-button.tsx
@@ -1,9 +1,9 @@
 import { h, Component, Prop, Element, Watch, Event, EventEmitter } from '@stencil/core';
 
 import Tunnel from '../../data/connection';
-import { Connection } from '../../utils/connections';
 import { Marketplace } from '../../types/marketplace';
 import { Connector } from '../../types/connector';
+import { RestFetch } from '../../utils/restFetch';
 
 /* eslint-disable no-console */
 
@@ -29,12 +29,7 @@ interface ErrorMessage {
 export class ManifoldDataSsoButton {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() restFetch?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-  ) => Promise<T | Error>;
+  @Prop() restFetch?: RestFetch;
   /** The label of the resource to rename */
   @Prop() resourceLabel?: string;
   /** The id of the resource to rename, will be fetched if not set */
@@ -78,9 +73,14 @@ export class ManifoldDataSsoButton {
       },
     };
 
-    const response = await this.restFetch<Connector.AuthorizationCode>('connector', `/sso`, body, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+    const response = await this.restFetch<Connector.AuthorizationCode>({
+      service: 'connector',
+      endpoint: `/sso`,
+      body,
+      options: {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      },
     });
 
     if (response instanceof Error) {
@@ -107,10 +107,10 @@ export class ManifoldDataSsoButton {
       return;
     }
 
-    const response = await this.restFetch<Marketplace.Resource[]>(
-      'marketplace',
-      `/resources/?me&label=${resourceLabel}`
-    );
+    const response = await this.restFetch<Marketplace.Resource[]>({
+      service: 'marketplace',
+      endpoint: `/resources/?me&label=${resourceLabel}`,
+    });
 
     if (response instanceof Error) {
       console.error(response);

--- a/src/components/manifold-marketplace/manifold-marketplace.tsx
+++ b/src/components/manifold-marketplace/manifold-marketplace.tsx
@@ -2,18 +2,13 @@ import { h, Component, Prop, State, Element } from '@stencil/core';
 
 import { Catalog } from '../../types/catalog';
 import Tunnel from '../../data/connection';
-import { Connection } from '../../utils/connections';
+import { RestFetch } from '../../utils/restFetch';
 
 @Component({ tag: 'manifold-marketplace' })
 export class ManifoldMarketplace {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() restFetch?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-  ) => Promise<T | Error>;
+  @Prop() restFetch?: RestFetch;
   /** Comma-separated list of hidden products (labels) */
   @Prop() excludes?: string;
   /** Comma-separated list of featured products (labels) */
@@ -47,7 +42,10 @@ export class ManifoldMarketplace {
       return;
     }
 
-    const response = await this.restFetch<Catalog.ExpandedProduct[]>('catalog', `/products`);
+    const response = await this.restFetch<Catalog.ExpandedProduct[]>({
+      service: 'catalog',
+      endpoint: `/products`,
+    });
 
     if (response instanceof Error) {
       console.error(response);

--- a/src/components/manifold-plan-cost/manifold-plan-cost.tsx
+++ b/src/components/manifold-plan-cost/manifold-plan-cost.tsx
@@ -3,19 +3,14 @@ import { h, Component, Element, Prop, State, Watch } from '@stencil/core';
 import { Catalog } from '../../types/catalog';
 import { Gateway } from '../../types/gateway';
 import Tunnel from '../../data/connection';
-import { Connection } from '../../utils/connections';
 import { planCost, hasCustomizableFeatures, initialFeatures } from '../../utils/plan';
+import { RestFetch } from '../../utils/restFetch';
 
 @Component({ tag: 'manifold-plan-cost' })
 export class ManifoldPlanCost {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() restFetch?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-  ) => Promise<T | Error>;
+  @Prop() restFetch?: RestFetch;
   @Prop() allFeatures: Catalog.ExpandedFeature[] = [];
   @Prop() compact?: boolean = false;
   @Prop() customizable?: boolean = false;

--- a/src/components/manifold-plan-cost/manifold-plan-cost.tsx
+++ b/src/components/manifold-plan-cost/manifold-plan-cost.tsx
@@ -1,16 +1,21 @@
 import { h, Component, Element, Prop, State, Watch } from '@stencil/core';
+
 import { Catalog } from '../../types/catalog';
 import { Gateway } from '../../types/gateway';
 import Tunnel from '../../data/connection';
-import { Connection, connections } from '../../utils/connections';
+import { Connection } from '../../utils/connections';
 import { planCost, hasCustomizableFeatures, initialFeatures } from '../../utils/plan';
 
 @Component({ tag: 'manifold-plan-cost' })
 export class ManifoldPlanCost {
   @Element() el: HTMLElement;
-  @Prop() connection?: Connection = connections.prod;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() authToken?: string;
+  @Prop() restFetch?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+  ) => Promise<T | Error>;
   @Prop() allFeatures: Catalog.ExpandedFeature[] = [];
   @Prop() compact?: boolean = false;
   @Prop() customizable?: boolean = false;
@@ -53,7 +58,7 @@ export class ManifoldPlanCost {
   }
 
   calculateCost() {
-    if (!this.connection) {
+    if (!this.restFetch) {
       return null;
     }
 
@@ -71,15 +76,11 @@ export class ManifoldPlanCost {
     this.controller = new AbortController();
 
     // Returning the promise is necessary for componentWillLoad()
-    return planCost(
-      this.connection,
-      {
-        planID: this.planId,
-        features: allFeatures,
-        init: { signal: this.controller.signal },
-      },
-      this.authToken
-    ).then(({ cost }: Gateway.Price) => {
+    return planCost(this.restFetch, {
+      planID: this.planId,
+      features: allFeatures,
+      init: { signal: this.controller.signal },
+    }).then(({ cost }: Gateway.Price) => {
       this.baseCost = cost || 0;
       this.controller = undefined; // Request finished, so signal no longer needed
     });
@@ -97,4 +98,4 @@ export class ManifoldPlanCost {
   }
 }
 
-Tunnel.injectProps(ManifoldPlanCost, ['connection', 'authToken']);
+Tunnel.injectProps(ManifoldPlanCost, ['restFetch']);

--- a/src/components/manifold-plan-selector/manifold-plan-selector.tsx
+++ b/src/components/manifold-plan-selector/manifold-plan-selector.tsx
@@ -3,19 +3,14 @@ import { h, Component, State, Prop, Element, Watch } from '@stencil/core';
 import { Catalog } from '../../types/catalog';
 import { Gateway } from '../../types/gateway';
 import Tunnel from '../../data/connection';
-import { Connection } from '../../utils/connections';
 import { Marketplace } from '../../types/marketplace';
+import { RestFetch } from '../../utils/restFetch';
 
 @Component({ tag: 'manifold-plan-selector' })
 export class ManifoldPlanSelector {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() restFetch?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-  ) => Promise<T | Error>;
+  @Prop() restFetch?: RestFetch;
   /** URL-friendly slug (e.g. `"jawsdb-mysql"`) */
   @Prop() productLabel?: string;
   /** Specify region order */
@@ -56,10 +51,10 @@ export class ManifoldPlanSelector {
       this.parsedRegions = this.parseRegions(this.regions);
     }
 
-    const response = await this.restFetch<Catalog.ExpandedProduct[]>(
-      'catalog',
-      `/products/?label=${productLabel}`
-    );
+    const response = await this.restFetch<Catalog.ExpandedProduct[]>({
+      service: 'catalog',
+      endpoint: `/products/?label=${productLabel}`,
+    });
 
     if (response instanceof Error) {
       console.error(response);
@@ -77,10 +72,10 @@ export class ManifoldPlanSelector {
 
     this.plans = undefined;
 
-    const response = await this.restFetch<Catalog.ExpandedPlan[]>(
-      'catalog',
-      `/plans/?product_id=${productId}`
-    );
+    const response = await this.restFetch<Catalog.ExpandedPlan[]>({
+      service: 'catalog',
+      endpoint: `/plans/?product_id=${productId}`,
+    });
 
     if (response instanceof Error) {
       console.error(response);
@@ -97,10 +92,10 @@ export class ManifoldPlanSelector {
 
     this.resource = undefined;
 
-    const response = await this.restFetch<Marketplace.Resource[]>(
-      'marketplace',
-      `/resources/?me&label=${resourceLabel}`
-    );
+    const response = await this.restFetch<Marketplace.Resource[]>({
+      service: 'marketplace',
+      endpoint: `/resources/?me&label=${resourceLabel}`,
+    });
 
     if (response instanceof Error) {
       console.error(response);

--- a/src/components/manifold-plan/manifold-plan.tsx
+++ b/src/components/manifold-plan/manifold-plan.tsx
@@ -2,18 +2,13 @@ import { h, Component, State, Prop, Element, Watch } from '@stencil/core';
 
 import { Catalog } from '../../types/catalog';
 import Tunnel from '../../data/connection';
-import { Connection } from '../../utils/connections';
+import { RestFetch } from '../../utils/restFetch';
 
 @Component({ tag: 'manifold-plan' })
 export class ManifoldPlan {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() restFetch?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-  ) => Promise<T | Error>;
+  @Prop() restFetch?: RestFetch;
   /** URL-friendly slug (e.g. `"jawsdb-mysql"`) */
   @Prop() productLabel?: string;
   /** URL-friendly slug (e.g. `"kitefin"`) */
@@ -37,10 +32,10 @@ export class ManifoldPlan {
     }
 
     this.product = undefined;
-    const response = await this.restFetch<Catalog.ExpandedProduct[]>(
-      'catalog',
-      `/products/?label=${productLabel}`
-    );
+    const response = await this.restFetch<Catalog.ExpandedProduct[]>({
+      service: 'catalog',
+      endpoint: `/products/?label=${productLabel}`,
+    });
 
     if (response instanceof Error) {
       console.error(response);
@@ -57,10 +52,10 @@ export class ManifoldPlan {
     }
 
     this.plan = undefined;
-    const response = await this.restFetch<Catalog.ExpandedPlan[]>(
-      'catalog',
-      `/plans/?product_id=${productId}&label=${planLabel}`
-    );
+    const response = await this.restFetch<Catalog.ExpandedPlan[]>({
+      service: 'catalog',
+      endpoint: `/plans/?product_id=${productId}&label=${planLabel}`,
+    });
 
     if (response instanceof Error) {
       console.error(response);

--- a/src/components/manifold-product/manifold-product.tsx
+++ b/src/components/manifold-product/manifold-product.tsx
@@ -1,16 +1,19 @@
 import { h, Component, Prop, State, Element, Watch } from '@stencil/core';
+
 import { Catalog } from '../../types/catalog';
 import Tunnel from '../../data/connection';
-import { withAuth } from '../../utils/auth';
-import { Connection, connections } from '../../utils/connections';
+import { Connection } from '../../utils/connections';
 
 @Component({ tag: 'manifold-product' })
 export class ManifoldProduct {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() connection?: Connection = connections.prod;
-  /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() authToken?: string;
+  @Prop() restFetch?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+  ) => Promise<T | Error>;
   /** _(optional)_ Hide the CTA on the left? */
   @Prop() productLabel?: string;
   @State() product?: Catalog.Product;
@@ -26,22 +29,34 @@ export class ManifoldProduct {
   }
 
   fetchProduct = async (productLabel: string) => {
-    if (!this.connection) {
+    if (!this.restFetch) {
       return;
     }
 
-    const productResp = await fetch(
-      `${this.connection.catalog}/products?label=${productLabel}`,
-      withAuth(this.authToken)
+    this.product = undefined;
+    const productResp = await this.restFetch<Catalog.ExpandedProduct[]>(
+      'catalog',
+      `/products/?label=${productLabel}`
     );
-    const products: Catalog.Product[] = await productResp.json();
-    this.product = products[0]; // eslint-disable-line prefer-destructuring
-    const providerResp = await fetch(
-      `${this.connection.catalog}/providers/${products[0].body.provider_id}`,
-      withAuth(this.authToken)
+
+    if (productResp instanceof Error) {
+      console.error(productResp);
+      return;
+    }
+
+    this.product = productResp[0]; // eslint-disable-line prefer-destructuring
+
+    const providerResp = await this.restFetch<Catalog.Provider>(
+      'catalog',
+      `/providers/${productResp[0].body.provider_id}`
     );
-    const provider = await providerResp.json();
-    this.provider = provider;
+
+    if (providerResp instanceof Error) {
+      console.error(providerResp);
+      return;
+    }
+
+    this.provider = providerResp;
   };
 
   render() {
@@ -55,4 +70,4 @@ export class ManifoldProduct {
   }
 }
 
-Tunnel.injectProps(ManifoldProduct, ['connection', 'authToken']);
+Tunnel.injectProps(ManifoldProduct, ['restFetch']);

--- a/src/components/manifold-product/manifold-product.tsx
+++ b/src/components/manifold-product/manifold-product.tsx
@@ -2,18 +2,13 @@ import { h, Component, Prop, State, Element, Watch } from '@stencil/core';
 
 import { Catalog } from '../../types/catalog';
 import Tunnel from '../../data/connection';
-import { Connection } from '../../utils/connections';
+import { RestFetch } from '../../utils/restFetch';
 
 @Component({ tag: 'manifold-product' })
 export class ManifoldProduct {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() restFetch?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-  ) => Promise<T | Error>;
+  @Prop() restFetch?: RestFetch;
   /** _(optional)_ Hide the CTA on the left? */
   @Prop() productLabel?: string;
   @State() product?: Catalog.Product;
@@ -34,10 +29,10 @@ export class ManifoldProduct {
     }
 
     this.product = undefined;
-    const productResp = await this.restFetch<Catalog.ExpandedProduct[]>(
-      'catalog',
-      `/products/?label=${productLabel}`
-    );
+    const productResp = await this.restFetch<Catalog.ExpandedProduct[]>({
+      service: 'catalog',
+      endpoint: `/products/?label=${productLabel}`,
+    });
 
     if (productResp instanceof Error) {
       console.error(productResp);
@@ -46,10 +41,10 @@ export class ManifoldProduct {
 
     this.product = productResp[0]; // eslint-disable-line prefer-destructuring
 
-    const providerResp = await this.restFetch<Catalog.Provider>(
-      'catalog',
-      `/providers/${productResp[0].body.provider_id}`
-    );
+    const providerResp = await this.restFetch<Catalog.Provider>({
+      service: 'catalog',
+      endpoint: `/providers/${productResp[0].body.provider_id}`,
+    });
 
     if (providerResp instanceof Error) {
       console.error(providerResp);

--- a/src/components/manifold-region-selector/manifold-region-selector.tsx
+++ b/src/components/manifold-region-selector/manifold-region-selector.tsx
@@ -17,8 +17,8 @@ export class ManifoldRegionSelector {
   @Prop() name: string;
   @Prop() preferredRegions?: string[];
   @Prop() value?: string;
+  @Prop({ mutable: true }) regions?: Catalog.Region[];
   @State() globalRegion: Catalog.Region = globalRegion;
-  @State() regions?: Catalog.Region[];
   @Event() updateValue: EventEmitter;
 
   async componentWillLoad() {

--- a/src/components/manifold-region-selector/manifold-region-selector.tsx
+++ b/src/components/manifold-region-selector/manifold-region-selector.tsx
@@ -4,7 +4,7 @@ import { Option } from '../../types/Select';
 import { Catalog } from '../../types/catalog';
 import Tunnel from '../../data/connection';
 import { globalRegion } from '../../data/region';
-import { Connection } from '../../utils/connections';
+import { RestFetch } from '../../utils/restFetch';
 
 @Component({ tag: 'manifold-region-selector' })
 export class ManifoldRegionSelector {
@@ -12,12 +12,7 @@ export class ManifoldRegionSelector {
   @Prop() allowedRegions: string[] = [];
   @Prop() ariaLabel: string;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() restFetch?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-  ) => Promise<T | Error>;
+  @Prop() restFetch?: RestFetch;
   @Prop() name: string;
   @Prop() preferredRegions?: string[];
   @Prop() value?: string;
@@ -30,13 +25,17 @@ export class ManifoldRegionSelector {
       return;
     }
 
-    const response = await this.restFetch<Catalog.Region[]>('catalog', `/regions`);
+    const response = await this.restFetch<Catalog.Region[]>({
+      service: 'catalog',
+      endpoint: `/regions`,
+    });
 
     if (response instanceof Error) {
       console.error(response);
       return;
     }
 
+    debugger;
     // Sorting is important, otherwise the region selector is in a different order every plan
     this.regions = this.sortRegions(response, this.preferredRegions);
     // Set global region (the one in src/data is just a fallback; we should always grab live)

--- a/src/components/manifold-region-selector/manifold-region-selector.tsx
+++ b/src/components/manifold-region-selector/manifold-region-selector.tsx
@@ -1,19 +1,23 @@
 import { h, Component, Prop, State, Event, Element, EventEmitter } from '@stencil/core';
+
 import { Option } from '../../types/Select';
 import { Catalog } from '../../types/catalog';
 import Tunnel from '../../data/connection';
 import { globalRegion } from '../../data/region';
-import { withAuth } from '../../utils/auth';
-import { Connection, connections } from '../../utils/connections';
+import { Connection } from '../../utils/connections';
 
 @Component({ tag: 'manifold-region-selector' })
 export class ManifoldRegionSelector {
   @Element() el: HTMLElement;
   @Prop() allowedRegions: string[] = [];
   @Prop() ariaLabel: string;
-  @Prop() connection?: Connection = connections.prod;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() authToken?: string;
+  @Prop() restFetch?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+  ) => Promise<T | Error>;
   @Prop() name: string;
   @Prop() preferredRegions?: string[];
   @Prop() value?: string;
@@ -22,14 +26,19 @@ export class ManifoldRegionSelector {
   @Event() updateValue: EventEmitter;
 
   async componentWillLoad() {
-    if (!this.connection) {
+    if (!this.restFetch) {
       return;
     }
 
-    const response = await fetch(`${this.connection.catalog}/regions`, withAuth(this.authToken));
-    const regions: Catalog.Region[] = await response.json();
+    const response = await this.restFetch<Catalog.Region[]>('catalog', `/regions`);
+
+    if (response instanceof Error) {
+      console.error(response);
+      return;
+    }
+
     // Sorting is important, otherwise the region selector is in a different order every plan
-    this.regions = this.sortRegions(regions, this.preferredRegions);
+    this.regions = this.sortRegions(response, this.preferredRegions);
     // Set global region (the one in src/data is just a fallback; we should always grab live)
     const global = this.regions.find(({ body: { location } }) => location === 'global');
     if (global) {
@@ -104,4 +113,4 @@ export class ManifoldRegionSelector {
   }
 }
 
-Tunnel.injectProps(ManifoldRegionSelector, ['connection', 'authToken']);
+Tunnel.injectProps(ManifoldRegionSelector, ['restFetch']);

--- a/src/components/manifold-region-selector/manifold-region-selector.tsx
+++ b/src/components/manifold-region-selector/manifold-region-selector.tsx
@@ -35,7 +35,6 @@ export class ManifoldRegionSelector {
       return;
     }
 
-    debugger;
     // Sorting is important, otherwise the region selector is in a different order every plan
     this.regions = this.sortRegions(response, this.preferredRegions);
     // Set global region (the one in src/data is just a fallback; we should always grab live)

--- a/src/components/manifold-resource-card-view/manifold-resource-card-view.tsx
+++ b/src/components/manifold-resource-card-view/manifold-resource-card-view.tsx
@@ -2,8 +2,8 @@ import { Component, Element, Event, EventEmitter, h, Prop, Watch } from '@stenci
 import { refresh_cw } from '@manifoldco/icons';
 
 import Tunnel from '../../data/connection';
-import { Connection } from '../../utils/connections';
 import { Marketplace } from '../../types/marketplace';
+import { RestFetch } from '../../utils/restFetch';
 
 interface EventDetail {
   resourceId?: string;
@@ -24,12 +24,7 @@ const OFFLINE = 'offline';
 export class ManifoldResourceCardView {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() restFetch?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-  ) => Promise<T | Error>;
+  @Prop() restFetch?: RestFetch;
 
   @Prop() label?: string;
   @Prop() name?: string;
@@ -77,10 +72,10 @@ export class ManifoldResourceCardView {
       return;
     }
 
-    const response = await this.restFetch<Marketplace.Resource[]>(
-      'marketplace',
-      `/resources/?me&label=${resourceLabel}`
-    );
+    const response = await this.restFetch<Marketplace.Resource[]>({
+      service: 'marketplace',
+      endpoint: `/resources/?me&label=${resourceLabel}`,
+    });
 
     if (response instanceof Error) {
       console.error(response);

--- a/src/components/manifold-resource-card/manifold-resource-card.tsx
+++ b/src/components/manifold-resource-card/manifold-resource-card.tsx
@@ -1,19 +1,14 @@
 import { Component, Element, h, Prop, State, Watch } from '@stencil/core';
 
 import Tunnel from '../../data/connection';
-import { Connection } from '../../utils/connections';
 import { Gateway } from '../../types/gateway';
+import { RestFetch } from '../../utils/restFetch';
 
 @Component({ tag: 'manifold-resource-card' })
 export class ManifoldResourceCard {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() restFetch?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-  ) => Promise<T | Error>;
+  @Prop() restFetch?: RestFetch;
 
   @Prop() resourceId?: string;
   @Prop() label?: string;
@@ -41,7 +36,10 @@ export class ManifoldResourceCard {
       return;
     }
 
-    const response = await this.restFetch<Gateway.Resource>('gateway', `/resources/${resourceId}`);
+    const response = await this.restFetch<Gateway.Resource>({
+      service: 'gateway',
+      endpoint: `/resources/${resourceId}`,
+    });
 
     if (response instanceof Error) {
       console.error(response);
@@ -56,10 +54,10 @@ export class ManifoldResourceCard {
       return;
     }
 
-    const response = await this.restFetch<Gateway.Resource[]>(
-      'gateway',
-      `/resources/me/${resourceName}`
-    );
+    const response = await this.restFetch<Gateway.Resource[]>({
+      service: 'gateway',
+      endpoint: `/resources/me/${resourceName}`,
+    });
 
     if (response instanceof Error) {
       console.error(response);

--- a/src/components/manifold-resource-container/manifold-resource-container.tsx
+++ b/src/components/manifold-resource-container/manifold-resource-container.tsx
@@ -3,17 +3,12 @@ import { h, Component, Prop, State, Watch } from '@stencil/core';
 import { Gateway } from '../../types/gateway';
 import ConnectionTunnel from '../../data/connection';
 import ResourceTunnel from '../../data/resource';
-import { Connection } from '../../utils/connections';
+import { RestFetch } from '../../utils/restFetch';
 
 @Component({ tag: 'manifold-resource-container' })
 export class ManifoldResourceContainer {
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() restFetch?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-  ) => Promise<T | Error>;
+  @Prop() restFetch?: RestFetch;
   /** Which resource does this belong to? */
   @Prop() resourceLabel?: string;
   @State() resource?: Gateway.Resource;
@@ -35,10 +30,10 @@ export class ManifoldResourceContainer {
     }
 
     this.loading = true;
-    const response = await this.restFetch<Gateway.Resource>(
-      'gateway',
-      `/resources/me/${resourceLabel}`
-    );
+    const response = await this.restFetch<Gateway.Resource>({
+      service: 'gateway',
+      endpoint: `/resources/me/${resourceLabel}`,
+    });
 
     if (response instanceof Error) {
       console.error(response);

--- a/src/components/manifold-resource-list/manifold-resource-list.spec.ts
+++ b/src/components/manifold-resource-list/manifold-resource-list.spec.ts
@@ -7,6 +7,23 @@ import { Provisioning } from '../../types/provisioning';
 import { Resource } from '../../spec/mock/marketplace';
 import { Product } from '../../spec/mock/catalog';
 import { connections } from '../../utils/connections';
+import { createRestFetch } from '../../utils/restFetch';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const proto = ManifoldResourceList.prototype as any;
+const oldCallback = proto.componentWillLoad;
+
+proto.componentWillLoad = function() {
+  (this as any).restFetch = createRestFetch({
+    getAuthToken: jest.fn(() => '1234'),
+    wait: 10,
+    setAuthToken: jest.fn(),
+  });
+
+  if (oldCallback) {
+    oldCallback.call(this);
+  }
+};
 
 const resources: Marketplace.Resource[] = [
   {
@@ -110,13 +127,23 @@ describe('<manifold-resource-list>', () => {
       .mock(`${connections.prod.catalog}/products`, [Product])
       .mock(`${connections.prod.provisioning}/operations/?is_deleted=false`, [provisionOperation]);
 
-    const resourceList = new ManifoldResourceList();
-    resourceList.connection = connections.prod;
+    const page = await newSpecPage({
+      components: [ManifoldResourceList],
+      html: `
+          <manifold-resource-list></manifold-resource-list>
+        `,
+    });
 
-    await resourceList.fetchResources();
+    const instance = page.rootInstance as ManifoldResourceList;
 
-    expect(resourceList.resources).toHaveLength(1);
-    expect(resourceList.resources).toEqual([
+    expect(fetchMock.called(`${connections.prod.marketplace}/resources/?me`)).toBe(true);
+    expect(fetchMock.called(`${connections.prod.catalog}/products`)).toBe(true);
+    expect(fetchMock.called(`${connections.prod.provisioning}/operations/?is_deleted=false`)).toBe(
+      true
+    );
+
+    expect(instance.resources).toHaveLength(1);
+    expect(instance.resources).toEqual([
       {
         id: Resource.id,
         name: Resource.body.name,

--- a/src/components/manifold-resource-list/manifold-resource-list.spec.ts
+++ b/src/components/manifold-resource-list/manifold-resource-list.spec.ts
@@ -130,7 +130,7 @@ describe('<manifold-resource-list>', () => {
     const page = await newSpecPage({
       components: [ManifoldResourceList],
       html: `
-          <manifold-resource-list></manifold-resource-list>
+          <manifold-resource-list paused=""></manifold-resource-list>
         `,
     });
 

--- a/src/components/manifold-resource-list/manifold-resource-list.tsx
+++ b/src/components/manifold-resource-list/manifold-resource-list.tsx
@@ -4,7 +4,7 @@ import { Marketplace } from '../../types/marketplace';
 import { Catalog } from '../../types/catalog';
 import { Provisioning } from '../../types/provisioning';
 import Tunnel from '../../data/connection';
-import { Connection } from '../../utils/connections';
+import { RestFetch } from '../../utils/restFetch';
 
 interface FoundResource {
   id: string;
@@ -31,12 +31,7 @@ interface RealResourceBody extends Marketplace.ResourceBody {
 export class ManifoldResourceList {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() restFetch?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-  ) => Promise<T | Error>;
+  @Prop() restFetch?: RestFetch;
   /** Disable auto-updates? */
   @Prop() paused?: boolean = false;
   /** Link format structure, with `:resource` placeholder */
@@ -102,10 +97,10 @@ export class ManifoldResourceList {
       return;
     }
 
-    const resourcesResp = await this.restFetch<Marketplace.Resource[]>(
-      'marketplace',
-      `/resources/?me`
-    );
+    const resourcesResp = await this.restFetch<Marketplace.Resource[]>({
+      service: 'marketplace',
+      endpoint: `/resources/?me`,
+    });
 
     if (resourcesResp instanceof Error) {
       console.error(resourcesResp);
@@ -113,16 +108,19 @@ export class ManifoldResourceList {
     }
 
     if (Array.isArray(resourcesResp)) {
-      const productsResp = await this.restFetch<Catalog.Product[]>('catalog', `/products`);
+      const productsResp = await this.restFetch<Catalog.Product[]>({
+        service: 'catalog',
+        endpoint: `/products`,
+      });
 
       if (productsResp instanceof Error) {
         return;
       }
 
-      const operationsResp = await this.restFetch<Provisioning.Operation[]>(
-        'provisioning',
-        `/operations/?is_deleted=false`
-      );
+      const operationsResp = await this.restFetch<Provisioning.Operation[]>({
+        service: 'provisioning',
+        endpoint: `/operations/?is_deleted=false`,
+      });
 
       if (operationsResp instanceof Error) {
         console.error(operationsResp);

--- a/src/components/manifold-service-card/manifold-service-card.tsx
+++ b/src/components/manifold-service-card/manifold-service-card.tsx
@@ -2,8 +2,7 @@ import { h, Component, Element, State, Prop, Event, EventEmitter, Watch } from '
 
 import { Catalog } from '../../types/catalog';
 import Tunnel from '../../data/connection';
-import { withAuth } from '../../utils/auth';
-import { Connection, connections } from '../../utils/connections';
+import { Connection } from '../../utils/connections';
 
 interface EventDetail {
   productId?: string;
@@ -13,9 +12,13 @@ interface EventDetail {
 @Component({ tag: 'manifold-service-card' })
 export class ManifoldServiceCard {
   @Element() el: HTMLElement;
-  @Prop() connection?: Connection = connections.prod;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() authToken?: string;
+  @Prop() restFetch?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+  ) => Promise<T | Error>;
   @Prop() skeleton?: boolean = false;
   @Prop() productId?: string;
   @Prop() productLabel?: string;
@@ -65,7 +68,7 @@ export class ManifoldServiceCard {
   }
 
   async fetchProduct(productLabel?: string, productId?: string) {
-    if (!this.connection) {
+    if (!this.restFetch) {
       return;
     }
 
@@ -78,22 +81,34 @@ export class ManifoldServiceCard {
     }
 
     if (productId) {
-      const response = await fetch(
-        `${this.connection.catalog}/products/${productId}`,
-        withAuth(this.authToken)
+      this.product = undefined;
+      const productResp = await this.restFetch<Catalog.ExpandedProduct>(
+        'catalog',
+        `/products/${productId}`
       );
-      this.product = await response.json();
+
+      if (productResp instanceof Error) {
+        console.error(productResp);
+        return;
+      }
+
+      this.product = productResp;
 
       await this.fetchIsFree();
     } else if (productLabel) {
-      const response = await fetch(
-        `${this.connection.catalog}/products/?label=${productLabel}`,
-        withAuth(this.authToken)
+      const productResp = await this.restFetch<Catalog.ExpandedProduct[]>(
+        'catalog',
+        `/products/?label=${productLabel}`
       );
-      const products: Catalog.Product[] = await response.json();
-      if (products.length) {
+
+      if (productResp instanceof Error) {
+        console.error(productResp);
+        return;
+      }
+
+      if (productResp.length) {
         // eslint-disable-next-line prefer-destructuring
-        this.product = products[0];
+        this.product = productResp[0];
 
         await this.fetchIsFree();
       }
@@ -103,17 +118,21 @@ export class ManifoldServiceCard {
   }
 
   async fetchIsFree() {
-    if (!this.connection || !this.product) {
+    if (!this.restFetch || !this.product) {
       return;
     }
 
-    const response = await fetch(
-      `${this.connection.catalog}/plans/?product_id=${this.product.id}`,
-      withAuth(this.authToken)
+    const response = await this.restFetch<Catalog.ExpandedPlan[]>(
+      'catalog',
+      `/plans/?product_id=${this.product.id}`
     );
 
-    const plans: Catalog.ExpandedPlan[] = await response.json();
-    if (Array.isArray(plans) && plans.find(plan => plan.body.free === true)) {
+    if (response instanceof Error) {
+      console.error(response);
+      return;
+    }
+
+    if (Array.isArray(response) && response.find(plan => plan.body.free === true)) {
       this.isFree = true;
     }
   }
@@ -165,4 +184,4 @@ export class ManifoldServiceCard {
   }
 }
 
-Tunnel.injectProps(ManifoldServiceCard, ['connection', 'authToken']);
+Tunnel.injectProps(ManifoldServiceCard, ['restFetch']);

--- a/src/components/manifold-service-card/manifold-service-card.tsx
+++ b/src/components/manifold-service-card/manifold-service-card.tsx
@@ -2,7 +2,7 @@ import { h, Component, Element, State, Prop, Event, EventEmitter, Watch } from '
 
 import { Catalog } from '../../types/catalog';
 import Tunnel from '../../data/connection';
-import { Connection } from '../../utils/connections';
+import { RestFetch } from '../../utils/restFetch';
 
 interface EventDetail {
   productId?: string;
@@ -13,12 +13,7 @@ interface EventDetail {
 export class ManifoldServiceCard {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() restFetch?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-  ) => Promise<T | Error>;
+  @Prop() restFetch?: RestFetch;
   @Prop() skeleton?: boolean = false;
   @Prop() productId?: string;
   @Prop() productLabel?: string;
@@ -82,10 +77,10 @@ export class ManifoldServiceCard {
 
     if (productId) {
       this.product = undefined;
-      const productResp = await this.restFetch<Catalog.ExpandedProduct>(
-        'catalog',
-        `/products/${productId}`
-      );
+      const productResp = await this.restFetch<Catalog.ExpandedProduct>({
+        service: 'catalog',
+        endpoint: `/products/${productId}`,
+      });
 
       if (productResp instanceof Error) {
         console.error(productResp);
@@ -96,10 +91,10 @@ export class ManifoldServiceCard {
 
       await this.fetchIsFree();
     } else if (productLabel) {
-      const productResp = await this.restFetch<Catalog.ExpandedProduct[]>(
-        'catalog',
-        `/products/?label=${productLabel}`
-      );
+      const productResp = await this.restFetch<Catalog.ExpandedProduct[]>({
+        service: 'catalog',
+        endpoint: `/products/?label=${productLabel}`,
+      });
 
       if (productResp instanceof Error) {
         console.error(productResp);
@@ -122,10 +117,10 @@ export class ManifoldServiceCard {
       return;
     }
 
-    const response = await this.restFetch<Catalog.ExpandedPlan[]>(
-      'catalog',
-      `/plans/?product_id=${this.product.id}`
-    );
+    const response = await this.restFetch<Catalog.ExpandedPlan[]>({
+      service: 'catalog',
+      endpoint: `/plans/?product_id=${this.product.id}`,
+    });
 
     if (response instanceof Error) {
       console.error(response);

--- a/src/data/connection.tsx
+++ b/src/data/connection.tsx
@@ -1,19 +1,22 @@
 import { h } from '@stencil/core';
 import { createProviderConsumer } from '@stencil/state-tunnel';
 
-import { Connection, connections } from '../utils/connections';
 import { GraphqlRequestBody, GraphqlResponseBody } from '../utils/graphqlFetch';
+import { Connection } from '../utils/connections';
 
 export interface State {
-  connection: Connection;
-  authToken?: string;
   setAuthToken: (s: string) => void;
+  restFetch?: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+  ) => Promise<T | Error>;
   graphqlFetch?: <T>(body: GraphqlRequestBody) => Promise<GraphqlResponseBody<T>>;
 }
 
 export default createProviderConsumer<State>(
   {
-    connection: connections.prod,
     setAuthToken: () => {},
   },
   (subscribe, child) => <context-consumer subscribe={subscribe} renderer={child} />

--- a/src/data/connection.tsx
+++ b/src/data/connection.tsx
@@ -2,16 +2,11 @@ import { h } from '@stencil/core';
 import { createProviderConsumer } from '@stencil/state-tunnel';
 
 import { GraphqlRequestBody, GraphqlResponseBody } from '../utils/graphqlFetch';
-import { Connection } from '../utils/connections';
+import { RestFetch } from '../utils/restFetch';
 
 export interface State {
   setAuthToken: (s: string) => void;
-  restFetch?: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-  ) => Promise<T | Error>;
+  restFetch?: RestFetch;
   graphqlFetch?: <T>(body: GraphqlRequestBody) => Promise<GraphqlResponseBody<T>>;
 }
 

--- a/src/spec/mock/jawsdb/regions.json
+++ b/src/spec/mock/jawsdb/regions.json
@@ -1,0 +1,393 @@
+[
+  {
+    "body": {
+      "location": "us-west-2",
+      "name": "Google Cloud - US  West 2",
+      "platform": "gcp",
+      "priority": 0
+    },
+    "id": "235gpteq8z5tfk76f8vxhft8b2yap",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "lon1",
+      "name": "DigitalOcean - London 1",
+      "platform": "digital-ocean",
+      "priority": 0
+    },
+    "id": "235gyw8hbev5jy5j3tdzdtpcnzaau",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "eu-central-1",
+      "name": "AWS - EU Central 1 (Frankfurt)",
+      "platform": "aws",
+      "priority": 0
+    },
+    "id": "235h6mbrrafzbhc4pau7mfm6f1c12",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "eu-west-1",
+      "name": "Google Cloud - Europe  West 1",
+      "platform": "gcp",
+      "priority": 0
+    },
+    "id": "235hnmde7fybzbbyugqkqjjpf4r78",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "tor1",
+      "name": "DigitalOcean - Toronto 1",
+      "platform": "digital-ocean",
+      "priority": 0
+    },
+    "id": "235htn96a2v1w1vzey5k49uvqatvc",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "fra1",
+      "name": "DigitalOcean - Frankfurt 1",
+      "platform": "digital-ocean",
+      "priority": 0
+    },
+    "id": "235hw0j1561jp0qnarhnubmwjp2tj",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "nyc1",
+      "name": "DigitalOcean - New York 1",
+      "platform": "digital-ocean",
+      "priority": 0
+    },
+    "id": "235j17hyc3kw0bd5bgh799xdugq7a",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "nyc3",
+      "name": "DigitalOcean - New York 3",
+      "platform": "digital-ocean",
+      "priority": 0
+    },
+    "id": "235jkamf0aptkmjaauzd6f73ttk7j",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "sa-east-1",
+      "name": "AWS - South America East 1 (Sao Paulo)",
+      "platform": "aws",
+      "priority": 0
+    },
+    "id": "235jkr4nn8437aq9hy3ed7kt32uay",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "ap-northeast-2",
+      "name": "AWS - Asia Pacific Northeast 2 (Seoul)",
+      "platform": "aws",
+      "priority": 0
+    },
+    "id": "235k1hqjt37duqn6tmgtb3cw8tm2p",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "dallas-1",
+      "name": "Rackspace - Dallas 1",
+      "platform": "rackspace",
+      "priority": 0
+    },
+    "id": "235kmne2kdkf7gdwjw8z5ekvjpugu",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "us-east-2",
+      "name": "AWS - US East 2 (Ohio)",
+      "platform": "aws",
+      "priority": 0
+    },
+    "id": "235krnd90mb51mu21rgf634vyyvnw",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "nyc2",
+      "name": "DigitalOcean - New York 2",
+      "platform": "digital-ocean",
+      "priority": 0
+    },
+    "id": "235kwrqmb2jfecj6dk9v06y6eqqpu",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "eu-west-1",
+      "name": "AWS - EU West 1 (Ireland)",
+      "platform": "aws",
+      "priority": 0
+    },
+    "id": "235m2c51y0625vvtk6ptf55bhpkty",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "us-east-1",
+      "name": "AWS - US East 1 (N. Virginia)",
+      "platform": "aws",
+      "priority": 0
+    },
+    "id": "235mhkk15ky7ha9qpu4gazrqjt2gr",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "ap-south-1",
+      "name": "AWS - Asia South 1 (Mumbai)",
+      "platform": "aws",
+      "priority": 0
+    },
+    "id": "235muac09p0qf9hwqcfbv6kw9at94",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "ap-northeast-1",
+      "name": "AWS - Asia Pacific Northeast 1 (Tokyo)",
+      "platform": "aws",
+      "priority": 0
+    },
+    "id": "235n0zubj5zv0h67cfqd6nemktr72",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": { "location": "global", "name": "All Regions", "platform": "all", "priority": 0 },
+    "id": "235n4f9pxf8eyraj3y159x89z6jer",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "us-west-1",
+      "name": "AWS - US West 1 (N. California)",
+      "platform": "aws",
+      "priority": 0
+    },
+    "id": "235nu2c0z73hq1f9qby444nnnq1fu",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "us-central-1",
+      "name": "Google Cloud - US  Central 1",
+      "platform": "gcp",
+      "priority": 0
+    },
+    "id": "235p16bz8n7qkjtvqyg599qtqa9ur",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "ap-southeast-1",
+      "name": "AWS - Asia Pacific Southeast 1 (Singapore)",
+      "platform": "aws",
+      "priority": 0
+    },
+    "id": "235pczj6ej834n25rm4c5atnwh3py",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "sgp1",
+      "name": "DigitalOcean - Singapore 1",
+      "platform": "digital-ocean",
+      "priority": 0
+    },
+    "id": "235qxr0g6akn861dqxw0yfkykg0hw",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "ap-southeast-2",
+      "name": "AWS - Asia Pacific Southeast 2 (Sydney)",
+      "platform": "aws",
+      "priority": 0
+    },
+    "id": "235rtvbtj2xr3hn5ghtkab5m0bxrm",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "us-west-2",
+      "name": "AWS - US West 2 (Oregon)",
+      "platform": "aws",
+      "priority": 0
+    },
+    "id": "235t4e0xt86hrgefbvyzh6f5dr7n4",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "eu-west-2",
+      "name": "AWS - EU West 2 (London)",
+      "platform": "aws",
+      "priority": 0
+    },
+    "id": "235tzgr871feggvepe7jmkm1x4r40",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "sfo1",
+      "name": "DigitalOcean - San Francisco 1",
+      "platform": "digital-ocean",
+      "priority": 0
+    },
+    "id": "235u04aer2rrcw4zf15zehy63x546",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "us-east-4",
+      "name": "Google Cloud - US  East 4",
+      "platform": "gcp",
+      "priority": 0
+    },
+    "id": "235u7nm47cknwjyjdyqwxg070zfmm",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "us-west-1",
+      "name": "Google Cloud - US  West 1",
+      "platform": "gcp",
+      "priority": 0
+    },
+    "id": "235uxnm8fnf6d2wbzthz60e347rje",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "blr1",
+      "name": "DigitalOcean - Bangalore 1",
+      "platform": "digital-ocean",
+      "priority": 0
+    },
+    "id": "235uyvbx6qvvar88hdwku19nck34e",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "eu-west-2",
+      "name": "Google Cloud - Europe  West 2",
+      "platform": "gcp",
+      "priority": 0
+    },
+    "id": "235v09pa9uhr2jzpf2j07pyqb771p",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "eu-west-3",
+      "name": "Google Cloud - Europe  West 3",
+      "platform": "gcp",
+      "priority": 0
+    },
+    "id": "235vjynwbkcww95jw7q4d0ypve94m",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "ams3",
+      "name": "DigitalOcean - Amsterdam 3",
+      "platform": "digital-ocean",
+      "priority": 0
+    },
+    "id": "235wf6yejbydr3vndv4rndqxhrjm0",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "us-east-1",
+      "name": "Google Cloud - US  East 1",
+      "platform": "gcp",
+      "priority": 0
+    },
+    "id": "235wy26njfzf53k1d050k2eg9f5ey",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "ca-central-1",
+      "name": "AWS - CA Central 1 (Canada Central)",
+      "platform": "aws",
+      "priority": 0
+    },
+    "id": "235x70bffdftggtpxxp3ar601j2qa",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "ams2",
+      "name": "DigitalOcean - Amsterdam 2",
+      "platform": "digital-ocean",
+      "priority": 0
+    },
+    "id": "235xzuww5zhppnnxxg4xt6wkjjn0r",
+    "type": "region",
+    "version": 1
+  },
+  {
+    "body": {
+      "location": "sfo2",
+      "name": "DigitalOcean - San Francisco 2",
+      "platform": "digital-ocean",
+      "priority": 0
+    },
+    "id": "235z9fptp2za794z7yxn0aft1krza",
+    "type": "region",
+    "version": 1
+  }
+]

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -25,7 +25,7 @@ export function withAuth(authToken?: string, options?: RequestInit): RequestInit
 
 export function isExpired(token: string) {
   try {
-    const expiry = token.split('.').pop() || '';
+    const expiry = token.split('|').pop() || '';
     const decodedExpiry = parseInt(expiry, 10);
     if (Number.isNaN(decodedExpiry)) {
       throw new Error('Expiry not a number.');

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -25,7 +25,7 @@ export function withAuth(authToken?: string, options?: RequestInit): RequestInit
 
 export function isExpired(token: string) {
   try {
-    const expiry = token.split('|').pop() || '';
+    const expiry = token.split('.').pop() || '';
     const decodedExpiry = parseInt(expiry, 10);
     if (Number.isNaN(decodedExpiry)) {
       throw new Error('Expiry not a number.');

--- a/src/utils/plan.ts
+++ b/src/utils/plan.ts
@@ -1,7 +1,6 @@
 import { Option } from '../types/Select';
 import { Catalog } from '../types/catalog';
 import { Gateway } from '../types/gateway';
-import { withAuth } from './auth';
 import { Connection } from './connections';
 import { $ } from './currency';
 import { pluralize } from './string';
@@ -276,17 +275,22 @@ export function initialFeatures(features: Catalog.ExpandedFeature[]): Gateway.Fe
  * Fetch cost from our API
  */
 export function planCost(
-  connection: Connection,
-  { planID, features, init }: PlanCostOptions,
-  authToken?: string
-): Promise<Gateway.Price> {
-  return fetch(
-    `${connection.gateway}/id/plan/${planID}/cost`,
-    withAuth(authToken, {
+  restFetch: <T>(
+    service: keyof Connection,
+    endpoint: string,
+    body?: object,
+    options?: object
+  ) => Promise<T | Error>,
+  { planID, features, init }: PlanCostOptions
+): Promise<Gateway.Price | Error> {
+  return restFetch<Gateway.Price>(
+    'gateway',
+    `/id/plan/${planID}/cost`,
+    { features },
+    {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ features }),
       ...init,
-    })
-  ).then(response => response.json());
+    }
+  );
 }

--- a/src/utils/plan.ts
+++ b/src/utils/plan.ts
@@ -1,9 +1,9 @@
 import { Option } from '../types/Select';
 import { Catalog } from '../types/catalog';
 import { Gateway } from '../types/gateway';
-import { Connection } from './connections';
 import { $ } from './currency';
 import { pluralize } from './string';
+import { RestFetch } from './restFetch';
 
 interface PlanCostOptions {
   planID: string;
@@ -275,22 +275,17 @@ export function initialFeatures(features: Catalog.ExpandedFeature[]): Gateway.Fe
  * Fetch cost from our API
  */
 export function planCost(
-  restFetch: <T>(
-    service: keyof Connection,
-    endpoint: string,
-    body?: object,
-    options?: object
-  ) => Promise<T | Error>,
+  restFetch: RestFetch,
   { planID, features, init }: PlanCostOptions
 ): Promise<Gateway.Price | Error> {
-  return restFetch<Gateway.Price>(
-    'gateway',
-    `/id/plan/${planID}/cost`,
-    { features },
-    {
+  return restFetch<Gateway.Price>({
+    service: 'gateway',
+    endpoint: `/id/plan/${planID}/cost`,
+    body: { features },
+    options: {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       ...init,
-    }
-  );
+    },
+  });
 }

--- a/src/utils/restFetch.ts
+++ b/src/utils/restFetch.ts
@@ -31,12 +31,10 @@ export const createRestFetch = ({
     await new Promise(resolve => setTimeout(resolve, 2000));
   }
 
-  debugger;
   if (!getAuthToken()) {
     return new Error('No auth token given');
   }
   try {
-    debugger;
     const response = await fetch(url as string, {
       ...withAuth(getAuthToken(), args.options),
       body: JSON.stringify(args.body),

--- a/src/utils/restFetch.ts
+++ b/src/utils/restFetch.ts
@@ -1,0 +1,58 @@
+import { Connection, connections } from './connections';
+import { withAuth } from './auth';
+
+interface CreateRestFetch {
+  endpoints?: Connection;
+  wait?: number;
+  getAuthToken?: () => string | undefined;
+  setAuthToken?: (token: string) => void;
+}
+
+export const createRestFetch = ({
+  endpoints = connections.prod,
+  wait = 15000,
+  getAuthToken = () => undefined,
+  setAuthToken = () => {},
+}: CreateRestFetch = {}): (<T>(
+  service: keyof Connection,
+  endpoint: string,
+  body?: object,
+  options?: object
+) => Promise<T | Error>) => async <T>(
+  service: keyof Connection,
+  endpoint: string,
+  requestBody?: object,
+  options?: object
+): Promise<T | Error> => {
+  const url = `${endpoints[service]}${endpoint}`;
+  const start = new Date();
+
+  while (!getAuthToken() && start.getTime() - new Date().getTime() <= wait) {
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise(resolve => setTimeout(resolve, 2000));
+  }
+
+  if (!getAuthToken()) {
+    return new Error('No auth token given');
+  }
+  try {
+    const response = await fetch(url as string, {
+      ...withAuth(getAuthToken(), options),
+      body: JSON.stringify(requestBody),
+    });
+
+    const body = await response.json();
+    if (response.status >= 200 && response.status < 300) {
+      return body;
+    }
+    if (response.status === 401) {
+      setAuthToken('');
+    }
+
+    // Sometimes messages are an array, sometimes they aren’t. Different strokes!
+    const message = Array.isArray(body) ? body[0].message : body.message;
+    return new Error(message);
+  } catch (e) {
+    return e;
+  }
+};

--- a/src/utils/restFetch.ts
+++ b/src/utils/restFetch.ts
@@ -12,7 +12,7 @@ interface RestFetchArguments {
   service: keyof Connection;
   endpoint: string;
   body?: object;
-  options?: object;
+  options?: Omit<RequestInit, 'body'>;
 }
 
 export type RestFetch = <T>(args: RestFetchArguments) => Promise<T | Error>;

--- a/stories/connectionDecorator.js
+++ b/stories/connectionDecorator.js
@@ -1,6 +1,6 @@
 export const manifoldConnectionDecorator = storyFn => `
-  <manifold-connection env="stage">
-    <manifold-auth-token oauth-url="https://login.stage.manifold.co/signin/oauth/web"/>
+  <manifold-connection>
+    <manifold-auth-token/>
     ${storyFn()}
   </manifold-connection>
 `;

--- a/stories/connectionDecorator.js
+++ b/stories/connectionDecorator.js
@@ -1,0 +1,6 @@
+export const manifoldConnectionDecorator = storyFn => `
+  <manifold-connection env="stage">
+    <manifold-auth-token oauth-url="https://login.stage.manifold.co/signin/oauth/web"/>
+    ${storyFn()}
+  </manifold-connection>
+`;

--- a/stories/manifold-data-deprovision-button.stories.js
+++ b/stories/manifold-data-deprovision-button.stories.js
@@ -1,8 +1,11 @@
 import { storiesOf } from '@storybook/html';
+
 import markdown from '../docs/docs/data/manifold-data-deprovision-button.md';
+import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Provision Button [Data]', module)
   .addParameters({ readme: { sidebar: markdown } })
+  .addDecorator(manifoldConnectionDecorator)
   .add(
     'default',
     () => `

--- a/stories/manifold-data-has-resource.stories.js
+++ b/stories/manifold-data-has-resource.stories.js
@@ -1,21 +1,18 @@
 import { storiesOf } from '@storybook/html';
+
 import markdown from '../docs/docs/components/manifold-resource-list.md';
+import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Has Resources 🔒 [Data]', module)
   .addParameters({ readme: { sidebar: markdown } })
-  .addDecorator(storyFn => localStorage.manifold_api_token ?
-    storyFn()
-    : 'Set your token under `manifold_api_token` in localstorage then refresh to view this story')
+  .addDecorator(manifoldConnectionDecorator)
   .add(
     'The user has resources',
     () => `
-      <manifold-connection>
-        <manifold-auth-token token="${localStorage.manifold_api_token}"/>
-        <manifold-data-has-resource>
-          <span slot="has-resource">Has resources</span>
-          <span slot="no-resource">No resources</span>
-        </manifold-data-has-resource>
-      </manifold-connection>
+      <manifold-data-has-resource>
+        <span slot="has-resource">Has resources</span>
+        <span slot="no-resource">No resources</span>
+      </manifold-data-has-resource>
     `
   )
   .add(

--- a/stories/manifold-data-manage-button.stories.js
+++ b/stories/manifold-data-manage-button.stories.js
@@ -1,8 +1,11 @@
 import { storiesOf } from '@storybook/html';
+
 import markdown from '../docs/docs/data/manifold-data-manage-button.md';
+import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Manage Button 🔒 [Data]', module)
   .addParameters({ readme: { sidebar: markdown } })
+  .addDecorator(manifoldConnectionDecorator)
   .add(
     'default',
     () =>

--- a/stories/manifold-data-product-logo.stories.js
+++ b/stories/manifold-data-product-logo.stories.js
@@ -1,15 +1,15 @@
 import { storiesOf } from '@storybook/html';
+
 import markdown from '../docs/docs/data/manifold-data-product-logo.md';
+import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Product Logo [Data]', module)
   .addParameters({ readme: { sidebar: markdown } })
+  .addDecorator(manifoldConnectionDecorator)
   .add(
     'default',
     () =>
       `
-        <manifold-connection>
-          <manifold-auth-token token="empty"/>
-          <manifold-data-product-logo product-label="aiven-redis"></manifold-data-product-logo>
-        </manifold-connection>
+        <manifold-data-product-logo product-label="aiven-redis"></manifold-data-product-logo>
       `
   );

--- a/stories/manifold-data-product-name.stories.js
+++ b/stories/manifold-data-product-name.stories.js
@@ -1,8 +1,11 @@
 import { storiesOf } from '@storybook/html';
+
 import markdown from '../docs/docs/data/manifold-data-product-name.md';
+import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Product Name [Data]', module)
   .addParameters({ readme: { sidebar: markdown } })
+  .addDecorator(manifoldConnectionDecorator)
   .add(
     'default',
     () =>

--- a/stories/manifold-data-provision-button.stories.js
+++ b/stories/manifold-data-provision-button.stories.js
@@ -1,17 +1,20 @@
 import { storiesOf } from '@storybook/html';
+
 import markdown from '../docs/docs/data/manifold-data-provision-button.md';
+import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Provision Button [Data]', module)
   .addParameters({ readme: { sidebar: markdown } })
+  .addDecorator(manifoldConnectionDecorator)
   .add(
     'default',
     () => `
-      <manifold-connection>
+      <div>
         <label for="my-provision-button">Resource Name</label>
         <input id="my-provision-button" value="my-resource">my-resource</input>
         <manifold-data-provision-button resource-label="my-resource">
           🚀 Provision Business plan on Prefab.cloud
         </manifold-data-provision-button>
-      </manifold-connection>
+      </div>
     `
   );

--- a/stories/manifold-data-rename-button.stories.js
+++ b/stories/manifold-data-rename-button.stories.js
@@ -1,8 +1,11 @@
 import { storiesOf } from '@storybook/html';
+
 import markdown from '../docs/docs/data/manifold-data-rename-button.md';
+import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Rename Button 🔒 [Data]', module)
   .addParameters({ readme: { sidebar: markdown } })
+  .addDecorator(manifoldConnectionDecorator)
   .add(
     'default',
     () => `

--- a/stories/manifold-data-resource-list.stories.js
+++ b/stories/manifold-data-resource-list.stories.js
@@ -1,17 +1,20 @@
 import { storiesOf } from '@storybook/html';
+
 import markdown from '../docs/docs/data/manifold-data-resource-list.md';
+import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Resource List 🔒 [Data]', module)
   .addParameters({ readme: { sidebar: markdown } })
+  .addDecorator(manifoldConnectionDecorator)
   .add(
     'default',
     () => `
-  <manifold-data-resource-list resource-link-format="/resources/:resource" paused>
-  <ul>
-    <li><a href="/resources/db-prod">db-prod</a></li>
-    <li><a href="/resources/db-stage">db-stage</a></li>
-    <li><a href="/resources/logging-prod">logging-prod</a></li>
-    <li><a href="/resources/logging-test">logging-test</a></li>
-  </ul>
-</manifold-data-resource-list>`
-  );
+      <manifold-data-resource-list resource-link-format="/resources/:resource" paused>
+        <ul>
+          <li><a href="/resources/db-prod">db-prod</a></li>
+          <li><a href="/resources/db-stage">db-stage</a></li>
+          <li><a href="/resources/logging-prod">logging-prod</a></li>
+          <li><a href="/resources/logging-test">logging-test</a></li>
+        </ul>
+      </manifold-data-resource-list>
+    `);

--- a/stories/manifold-data-sso-button.stories.js
+++ b/stories/manifold-data-sso-button.stories.js
@@ -1,8 +1,11 @@
 import { storiesOf } from '@storybook/html';
+
 import markdown from '../docs/docs/data/manifold-data-sso-button.md';
+import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('SSO Button 🔒 [Data]', module)
   .addParameters({ readme: { sidebar: markdown } })
+  .addDecorator(manifoldConnectionDecorator)
   .add(
     'default',
     () => `

--- a/stories/manifold-marketplace.stories.js
+++ b/stories/manifold-marketplace.stories.js
@@ -1,8 +1,11 @@
 import { storiesOf } from '@storybook/html';
+
 import markdown from '../docs/docs/components/manifold-marketplace.md';
+import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Marketplace', module)
   .addParameters({ readme: { sidebar: markdown } })
+  .addDecorator(manifoldConnectionDecorator)
   .add(
     'default',
     () =>

--- a/stories/manifold-plan-selector.stories.js
+++ b/stories/manifold-plan-selector.stories.js
@@ -1,8 +1,11 @@
 import { storiesOf } from '@storybook/html';
+
 import markdown from '../docs/docs/components/manifold-plan-selector.md';
+import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Plan Selector', module)
   .addParameters({ readme: { sidebar: markdown } })
+  .addDecorator(manifoldConnectionDecorator)
   .add(
     'Blitline',
     () => '<manifold-plan-selector product-label="blitline"></manifold-plan-selector>'

--- a/stories/manifold-plan.stories.js
+++ b/stories/manifold-plan.stories.js
@@ -1,8 +1,11 @@
 import { storiesOf } from '@storybook/html';
+
 import markdown from '../docs/docs/components/manifold-plan.md';
+import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Plan', module)
   .addParameters({ readme: { sidebar: markdown } })
+  .addDecorator(manifoldConnectionDecorator)
   .add(
     'ElegantCMS Free',
     () => '<manifold-plan product-label="elegant-cms" plan-label="manifold-developer"></manifold-plan>'

--- a/stories/manifold-product.stories.js
+++ b/stories/manifold-product.stories.js
@@ -1,8 +1,11 @@
 import { storiesOf } from '@storybook/html';
+
 import markdown from '../docs/docs/components/manifold-product.md';
+import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Product', module)
   .addParameters({ readme: { sidebar: markdown } })
+  .addDecorator(manifoldConnectionDecorator)
   .add(
     'JawsDB',
     () => `

--- a/stories/manifold-resource-credentials.stories.js
+++ b/stories/manifold-resource-credentials.stories.js
@@ -1,5 +1,7 @@
 import { storiesOf } from '@storybook/html';
+
 import markdown from '../docs/docs/components/manifold-credentials.md';
+import { manifoldConnectionDecorator } from './connectionDecorator';
 
 const credentialsView = `
 <manifold-resource-container resource-name="cms-stage">
@@ -9,6 +11,7 @@ const credentialsView = `
 
 storiesOf('Resource Credentials 🔒', module)
   .addParameters({ readme: { sidebar: markdown } })
+  .addDecorator(manifoldConnectionDecorator)
   .add('default', () => {
     window.localStorage.setItem('manifold_api_token', process.env.STORYBOOK_MANIFOLD_API_TOKEN);
     return credentialsView;

--- a/stories/manifold-resource-list.stories.js
+++ b/stories/manifold-resource-list.stories.js
@@ -1,41 +1,32 @@
 import { storiesOf } from '@storybook/html';
+
 import markdown from '../docs/docs/components/manifold-resource-list.md';
+import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Resource list 🔒', module)
   .addParameters({ readme: { sidebar: markdown } })
-  .addDecorator(storyFn => localStorage.manifold_api_token ?
-    storyFn()
-    : 'Set your token under `manifold_api_token` in localstorage then refresh to view this story')
+  .addDecorator(manifoldConnectionDecorator)
   .add(
     'Listing all resources',
     () => `
-      <manifold-connection>
-        <manifold-auth-token token="${localStorage.manifold_api_token}"/>
-        <manifold-resource-list />
-      </manifold-connection>
+      <manifold-resource-list />
     `
   )
   .add(
     'Loading resources',
     () => `
-      <manifold-connection>
-        <manifold-auth-token token="${localStorage.manifold_api_token}"/>
-        <manifold-resource-list paused="">
-          <manifold-resource-card-view loading="" label="loading" slot="loading" />
-        </manifold-resource-list>
-      </manifold-connection>
+      <manifold-resource-list paused="">
+        <manifold-resource-card-view loading="" label="loading" slot="loading" />
+      </manifold-resource-list>
     `
   )
   .add(
     'No resources',
     () => `
-      <manifold-connection>
-        <manifold-auth-token token="empty"/>
-        <manifold-resource-list label-filter="i-do-not-exists">
-          <div slot="no-resources">
-            There are no resources
-          </div>
-        </manifold-resource-list>
-      </manifold-connection>
+      <manifold-resource-list label-filter="i-do-not-exists">
+        <div slot="no-resources">
+          There are no resources
+        </div>
+      </manifold-resource-list>
     `
   );

--- a/stories/manifold-resource-plan.stories.js
+++ b/stories/manifold-resource-plan.stories.js
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import markdown from '../docs/docs/components/manifold-resource-plan.md';
 
 storiesOf('Resource Plan Details 🔒', module)

--- a/stories/manifold-service-card.stories.js
+++ b/stories/manifold-service-card.stories.js
@@ -1,8 +1,11 @@
 import { storiesOf } from '@storybook/html';
+
 import markdown from '../docs/docs/components/manifold-service-card.md';
+import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Service card', module)
   .addParameters({ readme: { sidebar: markdown } })
+  .addDecorator(manifoldConnectionDecorator)
   .add(
     'JawsDB',
     () => `


### PR DESCRIPTION
Work is related to manifoldco/engineering#8858

## Reason for change
When a request for fetching data on graphql or rest is sent to the servers, all the async functions will now wait for a maximum of 15 seconds (Configurable) for the token to exist before returning an error.

All the components using rest have been modified to now use the function added to the manifold-connection. Tests have been adapted to make sure the rest and graphql functions are properly injected in components.

## Testing
Test with storybook or the docs, things should fetch as expected.
