### PR TITLE
Fix support link targets [tiny]

### DIFF
--- a/src/components/manifold-product-page/manifold-product-page.e2e.ts
+++ b/src/components/manifold-product-page/manifold-product-page.e2e.ts
@@ -33,4 +33,19 @@ describe('<manifold-product-page>', () => {
     const el = await page.find('manifold-product-page >>> [itemprop="logo"]');
     expect(el.getAttribute('src')).toBe(Product.body.logo_url);
   });
+
+  it('support links don’t open a new tab', async () => {
+    const page = await newE2EPage({ html: `<manifold-product-page />` });
+    await page.$eval(
+      'manifold-product-page',
+      (elm: any, props: any) => {
+        elm.product = props.product;
+      },
+      { product: Product }
+    );
+    await page.waitForChanges();
+
+    const el = await page.find('manifold-product-page >>> [href^="mailto"]');
+    expect(el.getAttribute('target')).toBeNull();
+  });
 });

--- a/src/components/manifold-product-page/manifold-product-page.tsx
+++ b/src/components/manifold-product-page/manifold-product-page.tsx
@@ -75,7 +75,7 @@ export class ManifoldProductPage {
                     </a>
                   </div>
                   <div class="provider-link">
-                    <a href={`mailto:${support_email}`} target="_blank" rel="noopener noreferrer">
+                    <a href={`mailto:${support_email}`}>
                       <manifold-icon icon={life_buoy} margin-right />
                       Support
                       <manifold-icon class="external-link-icon" icon={arrow_up_right} margin-left />


### PR DESCRIPTION
## Reason for change
Fixes #271 

## Testing
Make sure the support email link doesn’t open up in a new tab for native email clients
