### PR TITLE
Fix region skeleton UI [tiny]

### DIFF
--- a/src/components/manifold-plan-details/manifold-plan-details.tsx
+++ b/src/components/manifold-plan-details/manifold-plan-details.tsx
@@ -297,7 +297,6 @@ export class ManifoldPlanDetails {
           </header>
           <br />
           <manifold-skeleton-text>Features features features features</manifold-skeleton-text>
-          {this.regionSelector}
           <footer class="footer">
             <manifold-skeleton-text>Free</manifold-skeleton-text>
           </footer>


### PR DESCRIPTION
## Reason for change
The region dropdown originally would appear when the component loaded. This removes it from the skeleton loader.

Closes #108 

## Testing
On JawsDB, confirm the region dropdown doesn’t show before the component finishes loading (try testing in Storybook, in a standalone window)
