### PR TITLE
Improve marketplace scrollspy

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -199,9 +199,9 @@ export namespace Components {
     */
     'productLabel'?: string;
     /**
-    * Region to provision (complete name), omit for all region
+    * Region to provision (ID)
     */
-    'regionName'?: string;
+    'regionId'?: string;
     /**
     * The label of the resource to provision
     */
@@ -1292,9 +1292,9 @@ declare namespace LocalJSX {
     */
     'productLabel'?: string;
     /**
-    * Region to provision (complete name), omit for all region
+    * Region to provision (ID)
     */
-    'regionName'?: string;
+    'regionId'?: string;
     /**
     * The label of the resource to provision
     */

--- a/src/components/manifold-marketplace-grid/manifold-marketplace-grid.css
+++ b/src/components/manifold-marketplace-grid/manifold-marketplace-grid.css
@@ -5,7 +5,7 @@
   --grid-m: 1.5rem;
 
   /* theme */
-  --link-color: var(--manifold-text-color-secondary);
+  --link-color: var(--manifold-text-color-secondary, var(--manifold-color-gray60));
   --link-color-hover: var(--manifold-color-primary);
   --link-color-active: var(--link-color-hover);
   --heading-color: var(--manifold-grayscale-60);
@@ -77,9 +77,15 @@
     color: var(--link-color-active);
   }
 
-  &:hover,
-  &:focus {
+  &:hover {
     color: var(--link-color-hover);
+  }
+
+  &:focus:focus-visible {
+    color: var(--link-color-active);
+  }
+
+  &:not(:focus-visible):focus {
     outline: 0;
   }
 }
@@ -98,6 +104,8 @@
   left: 0;
   z-index: var(--manifold-layer-hover);
   grid-column: 1 / -1; /* always start new row, and span full row */
+  display: flex;
+  align-items: center;
   box-sizing: border-box;
   width: 100%;
   margin-top: 0;

--- a/src/components/manifold-marketplace-grid/manifold-marketplace-grid.css
+++ b/src/components/manifold-marketplace-grid/manifold-marketplace-grid.css
@@ -5,7 +5,7 @@
   --grid-m: 1.5rem;
 
   /* theme */
-  --link-color: var(--manifold-text-color-secondary, var(--manifold-color-gray60));
+  --link-color: var(--manifold-text-color-secondary);
   --link-color-hover: var(--manifold-color-primary);
   --link-color-active: var(--link-color-hover);
   --heading-color: var(--manifold-grayscale-60);

--- a/src/components/manifold-service-card/manifold-service-card.tsx
+++ b/src/components/manifold-service-card/manifold-service-card.tsx
@@ -141,13 +141,13 @@ export class ManifoldServiceCard {
         style={{ textDecoration: 'none' }}
       >
         <manifold-service-card-view
-          name={this.product.body.name}
           description={this.product.body.tagline}
           isFeatured={this.isFeatured}
+          isFree={this.isFree}
           label={this.productLabel}
           logo={this.product.body.logo_url}
+          name={this.product.body.name}
           productId={this.productId}
-          isFree={this.isFree}
         >
           <manifold-forward-ref slot="cta">
             <slot name="cta" />

--- a/src/components/manifold-template-card/manifold-template-card.css
+++ b/src/components/manifold-template-card/manifold-template-card.css
@@ -40,6 +40,8 @@
 }
 
 .heading {
+  display: flex;
+  align-items: center;
   margin-top: 0;
   margin-bottom: 0;
   padding: var(--padding);


### PR DESCRIPTION
## Reason for change
`IntersectionObserver` is great for many things, and we all thought it would be great for scrollspy, but after a few months we realized it’s not. It’s inconsistent with user-expected behavior, doesn’t run at 60FPS, and has some browser-specific quirks (we’ve had issues in Firefox specifically). It’s more intended for lazyloading than scrollspies.

This replaces it with the amazing `@reach/observe-rect` library, which I’m a fan of because:
- it’s so lightweight it’s basically free
- it uses `RequestAnimationFrame` so it’s browser-throttled to 60FPS the way it should be
- it automatically memoizes to reduce updates
- using a community library means we don’t have to maintain / test this part of our code (similar to `IntersectionObserver`

**Before: active category skips and jumps around**

![2019-07-30 17-18-12 2019-07-30 17_19_13](https://user-images.githubusercontent.com/1369770/62172228-d1016180-b2ee-11e9-8bc3-9bd66a9fd052.gif)

**After: every section is scrolled to properly**

![2019-07-30 16-54-46 2019-07-30 17_01_25](https://user-images.githubusercontent.com/1369770/62172239-d9f23300-b2ee-11e9-8919-563d4103804b.gif)

## Testing
Test scrolling through `<manifold-marketplace>` either in Storybook or the docs site
