### PR TITLE
Add @logger decorator to all components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,7 @@ module.exports = {
   },
   rules: {
     '@manifoldco/stencil/component-prefix': ['error', { prefix: 'manifold-' }],
+    '@manifoldco/stencil/require-render-decorator': ['error'],
     '@manifoldco/stencil/restrict-required-props': 'error',
     '@typescript-eslint/camelcase': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
@@ -55,7 +56,7 @@ module.exports = {
     'lines-between-class-members': 'off', // class members don’t need that space!
     'max-len': 'off', // let Prettier decide
     'object-curly-newline': 'off', // let Prettier decide,
-    "curly": ["error", "all"],
+    curly: ['error', 'all'],
     'prettier/prettier': 'error',
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1724,9 +1724,9 @@
       }
     },
     "@manifoldco/eslint-plugin-stencil": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@manifoldco/eslint-plugin-stencil/-/eslint-plugin-stencil-0.2.1.tgz",
-      "integrity": "sha512-s237Vs97w2jXAvTfTN1GA2dCafRRVc6EnmqkdCCgbXhyFI/+M7kd/2ufGXHluDckqy7b0jTjHlfp/EY+J78ubQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@manifoldco/eslint-plugin-stencil/-/eslint-plugin-stencil-0.4.1.tgz",
+      "integrity": "sha512-De66pcm7LAUqRJPhofJaPZtgFPzM8JwpxEku/Lu2O900CEDPstdAqZ0yfgVtjGPBfx3kSpQu2OsPI3zpcvIkzg==",
       "dev": true
     },
     "@manifoldco/gql-zero": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@graphql-codegen/introspection": "^1.4.0",
     "@graphql-codegen/typescript": "^1.4.0",
     "@graphql-codegen/typescript-operations": "^1.3.1",
-    "@manifoldco/eslint-plugin-stencil": "^0.2.1",
+    "@manifoldco/eslint-plugin-stencil": "^0.4.1",
     "@manifoldco/icons": "0.0.3",
     "@reach/observe-rect": "^1.0.3",
     "@stencil/core": "^1.2.2",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -199,9 +199,9 @@ export namespace Components {
     */
     'productLabel'?: string;
     /**
-    * Region to provision (complete name), omit for all region
+    * Region to provision (ID)
     */
-    'regionName'?: string;
+    'regionId'?: string;
     /**
     * The label of the resource to provision
     */
@@ -1292,9 +1292,9 @@ declare namespace LocalJSX {
     */
     'productLabel'?: string;
     /**
-    * Region to provision (complete name), omit for all region
+    * Region to provision (ID)
     */
-    'regionName'?: string;
+    'regionId'?: string;
     /**
     * The label of the resource to provision
     */

--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -2,6 +2,7 @@ import { h, Component, Prop, Watch, Event, EventEmitter } from '@stencil/core';
 import { AuthToken } from '@manifoldco/shadowcat';
 import Tunnel from '../../data/connection';
 import { isExpired } from '../../utils/auth';
+import logger from '../../utils/logger';
 
 @Component({ tag: 'manifold-auth-token' })
 export class ManifoldAuthToken {
@@ -33,6 +34,7 @@ export class ManifoldAuthToken {
     }
   };
 
+  @logger()
   render() {
     return (
       <manifold-oauth onReceiveManifoldToken={this.setInternalToken} oauthUrl={this.oauthUrl} />

--- a/src/components/manifold-badge/manifold-badge.tsx
+++ b/src/components/manifold-badge/manifold-badge.tsx
@@ -1,4 +1,5 @@
 import { h, Component } from '@stencil/core';
+import logger from '../../utils/logger';
 
 @Component({
   tag: 'manifold-badge',
@@ -6,6 +7,7 @@ import { h, Component } from '@stencil/core';
   shadow: true,
 })
 export class ManifoldBadge {
+  @logger()
   render() {
     return <slot />;
   }

--- a/src/components/manifold-button-link/manifold-button-link.tsx
+++ b/src/components/manifold-button-link/manifold-button-link.tsx
@@ -1,4 +1,5 @@
 import { h, Component, Prop, Event, EventEmitter } from '@stencil/core';
+import logger from '../../utils/logger';
 
 interface EventDetail {
   href?: string;
@@ -32,6 +33,7 @@ export class ManifoldButtonLink {
     }
   };
 
+  @logger()
   render() {
     return (
       <a

--- a/src/components/manifold-button/manifold-button.tsx
+++ b/src/components/manifold-button/manifold-button.tsx
@@ -1,4 +1,5 @@
 import { h, Component, Prop, Event, EventEmitter } from '@stencil/core';
+import logger from '../../utils/logger';
 
 @Component({
   tag: 'manifold-button',
@@ -22,6 +23,7 @@ export class ManifoldButton {
     }
   };
 
+  @logger()
   render() {
     return (
       <button

--- a/src/components/manifold-connection/manifold-connection.tsx
+++ b/src/components/manifold-connection/manifold-connection.tsx
@@ -4,6 +4,7 @@ import Tunnel from '../../data/connection';
 import { connections } from '../../utils/connections';
 import { createGraphqlFetch } from '../../utils/graphqlFetch';
 import { isExpired } from '../../utils/auth';
+import logger from '../../utils/logger';
 
 const TOKEN_KEY = 'manifold_api_token';
 
@@ -39,6 +40,7 @@ export class ManiTunnel {
     return undefined;
   }
 
+  @logger()
   render() {
     return (
       <Tunnel.Provider

--- a/src/components/manifold-cost-display/manifold-cost-display.tsx
+++ b/src/components/manifold-cost-display/manifold-cost-display.tsx
@@ -2,6 +2,7 @@ import { h, JSX, Component, Element, Prop } from '@stencil/core';
 import { Catalog } from '../../types/catalog';
 import { $ } from '../../utils/currency';
 import { numberFeatureMeasurableDisplayValue } from '../../utils/plan';
+import logger from '../../utils/logger';
 
 @Component({ tag: 'manifold-cost-display', styleUrl: 'manifold-cost-display.css', shadow: true })
 export class ManifoldCostDisplay {
@@ -55,6 +56,7 @@ export class ManifoldCostDisplay {
     return output;
   }
 
+  @logger()
   render() {
     if (typeof this.baseCost !== 'number') {
       return <div class="cost" />;

--- a/src/components/manifold-credentials-view/manifold-credentials-view.tsx
+++ b/src/components/manifold-credentials-view/manifold-credentials-view.tsx
@@ -2,6 +2,7 @@ import { h, Component, Prop, Event, EventEmitter } from '@stencil/core';
 import { eye, lock, loader } from '@manifoldco/icons';
 
 import { Marketplace } from '../../types/marketplace';
+import logger from '../../utils/logger';
 
 @Component({
   tag: 'manifold-resource-credentials-view',
@@ -34,6 +35,7 @@ export class ManifoldResourceCredentials {
     this.credentialsRequested.emit();
   };
 
+  @logger()
   render() {
     return [
       <menu class="secrets-menu" data-showing={!!this.credentials}>

--- a/src/components/manifold-credentials/manifold-credentials.tsx
+++ b/src/components/manifold-credentials/manifold-credentials.tsx
@@ -4,6 +4,7 @@ import { Marketplace } from '../../types/marketplace';
 import ConnectionTunnel from '../../data/connection';
 import { withAuth } from '../../utils/auth';
 import { Connection, connections } from '../../utils/connections';
+import logger from '../../utils/logger';
 
 @Component({ tag: 'manifold-credentials' })
 export class ManifoldCredentials {
@@ -66,6 +67,7 @@ export class ManifoldCredentials {
     this.fetchCredentials();
   };
 
+  @logger()
   render() {
     return (
       <manifold-resource-credentials-view

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
@@ -4,6 +4,7 @@ import Tunnel from '../../data/connection';
 import { withAuth } from '../../utils/auth';
 import { Connection, connections } from '../../utils/connections';
 import { Marketplace } from '../../types/marketplace';
+import logger from '../../utils/logger';
 
 /* eslint-disable no-console */
 
@@ -110,6 +111,7 @@ export class ManifoldDataDeprovisionButton {
     this.resourceId = resources[0].id;
   }
 
+  @logger()
   render() {
     return (
       <button

--- a/src/components/manifold-data-has-resource/manifold-data-has-resource.tsx
+++ b/src/components/manifold-data-has-resource/manifold-data-has-resource.tsx
@@ -4,6 +4,7 @@ import { Marketplace } from '../../types/marketplace';
 import { withAuth } from '../../utils/auth';
 import { Connection, connections } from '../../utils/connections';
 import Tunnel from '../../data/connection';
+import logger from '../../utils/logger';
 
 @Component({ tag: 'manifold-data-has-resource', shadow: true })
 export class ManifoldDataHasResource {
@@ -57,6 +58,7 @@ export class ManifoldDataHasResource {
     }
   }
 
+  @logger()
   render() {
     return <slot name={this.hasResources ? 'has-resource' : 'no-resource'} />;
   }

--- a/src/components/manifold-data-manage-button/manifold-data-manage-button.tsx
+++ b/src/components/manifold-data-manage-button/manifold-data-manage-button.tsx
@@ -4,6 +4,7 @@ import Tunnel from '../../data/connection';
 import { globalRegion } from '../../data/region';
 import { withAuth } from '../../utils/auth';
 import { Connection, connections } from '../../utils/connections';
+import logger from '../../utils/logger';
 
 /* eslint-disable no-console */
 
@@ -120,6 +121,7 @@ export class ManifoldDataManageButton {
     }
   }
 
+  @logger()
   render() {
     return (
       <button type="button" onClick={() => this.update()}>

--- a/src/components/manifold-data-product-logo/manifold-data-product-logo.tsx
+++ b/src/components/manifold-data-product-logo/manifold-data-product-logo.tsx
@@ -4,6 +4,7 @@ import { GraphqlResponseBody, GraphqlRequestBody } from '../../utils/graphqlFetc
 import { Product } from '../../types/graphql';
 import Tunnel from '../../data/connection';
 import { Connection, connections } from '../../utils/connections';
+import logger from '../../utils/logger';
 
 const query = gql`
   query PRODUCT_LOGO($productLabel: String!) {
@@ -52,6 +53,7 @@ export class ManifoldDataProductLogo {
     this.product = data.product;
   };
 
+  @logger()
   render() {
     if (this.resourceLabel) {
       console.warn('DEPRECATION WARNING: Use `manifold-data-resource-logo` instead.');

--- a/src/components/manifold-data-product-name/manifold-data-product-name.tsx
+++ b/src/components/manifold-data-product-name/manifold-data-product-name.tsx
@@ -4,6 +4,7 @@ import { Gateway } from '../../types/gateway';
 import Tunnel from '../../data/connection';
 import { withAuth } from '../../utils/auth';
 import { Connection, connections } from '../../utils/connections';
+import logger from '../../utils/logger';
 
 @Component({ tag: 'manifold-data-product-name' })
 export class ManifoldDataProductName {
@@ -63,6 +64,7 @@ export class ManifoldDataProductName {
     this.productName = resource.product && resource.product.name;
   };
 
+  @logger()
   render() {
     return this.productName || null;
   }

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
@@ -8,6 +8,7 @@ import { withAuth } from '../../utils/auth';
 import { Connection, connections } from '../../utils/connections';
 import { Catalog } from '../../types/catalog';
 import { GraphqlRequestBody, GraphqlResponseBody } from '../../utils/graphqlFetch';
+import logger from '../../utils/logger';
 
 /* eslint-disable no-console */
 
@@ -211,6 +212,7 @@ export class ManifoldDataProvisionButton {
     return /^[a-z][a-z0-9]*/.test(input);
   }
 
+  @logger()
   render() {
     return (
       <button

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
@@ -4,6 +4,7 @@ import Tunnel from '../../data/connection';
 import { withAuth } from '../../utils/auth';
 import { Connection, connections } from '../../utils/connections';
 import { Marketplace } from '../../types/marketplace';
+import logger from '../../utils/logger';
 
 /* eslint-disable no-console */
 
@@ -166,6 +167,7 @@ export class ManifoldDataRenameButton {
     return /^[a-z][a-z0-9]*/.test(input);
   }
 
+  @logger()
   render() {
     return (
       <button

--- a/src/components/manifold-data-resource-list/manifold-data-resource-list.tsx
+++ b/src/components/manifold-data-resource-list/manifold-data-resource-list.tsx
@@ -3,6 +3,7 @@ import { Marketplace } from '../../types/marketplace';
 import Tunnel from '../../data/connection';
 import { withAuth } from '../../utils/auth';
 import { Connection, connections } from '../../utils/connections';
+import logger from '../../utils/logger';
 
 interface EventDetail {
   ownerId?: string;
@@ -92,6 +93,7 @@ export class ManifoldDataResourceList {
     );
   }
 
+  @logger()
   render() {
     if (!Array.isArray(this.resources)) {
       return null;

--- a/src/components/manifold-data-resource-logo/manifold-data-resource-logo.tsx
+++ b/src/components/manifold-data-resource-logo/manifold-data-resource-logo.tsx
@@ -5,6 +5,7 @@ import { Product } from '../../types/graphql';
 import Tunnel from '../../data/connection';
 import { withAuth } from '../../utils/auth';
 import { Connection, connections } from '../../utils/connections';
+import logger from '../../utils/logger';
 
 @Component({ tag: 'manifold-data-resource-logo' })
 export class ManifoldDataResourceLogo {
@@ -50,6 +51,7 @@ export class ManifoldDataResourceLogo {
     this.product = newProduct as Product;
   };
 
+  @logger()
   render() {
     return this.product ? (
       <img src={this.product.logoUrl} alt={this.alt || this.product.displayName} />

--- a/src/components/manifold-data-sso-button/manifold-data-sso-button.tsx
+++ b/src/components/manifold-data-sso-button/manifold-data-sso-button.tsx
@@ -5,6 +5,7 @@ import { withAuth } from '../../utils/auth';
 import { Connection, connections } from '../../utils/connections';
 import { Marketplace } from '../../types/marketplace';
 import { Connector } from '../../types/connector';
+import logger from '../../utils/logger';
 
 /* eslint-disable no-console */
 
@@ -132,6 +133,7 @@ export class ManifoldDataSsoButton {
     return /^[a-z][a-z0-9]*/.test(input);
   }
 
+  @logger()
   render() {
     return (
       <button type="submit" onClick={() => this.sso()} disabled={!this.resourceId && !this.loading}>

--- a/src/components/manifold-forward-slot/manifold-forward-slot.tsx
+++ b/src/components/manifold-forward-slot/manifold-forward-slot.tsx
@@ -1,9 +1,11 @@
 import { Component } from '@stencil/core';
+import logger from '../../utils/logger';
 
 @Component({
   tag: 'manifold-forward-slot',
 })
 export class ManifoldForwardSlot {
+  @logger()
   render() {
     return null;
   }

--- a/src/components/manifold-icon/manifold-icon.tsx
+++ b/src/components/manifold-icon/manifold-icon.tsx
@@ -1,4 +1,5 @@
 import { h, Component, Element, Prop } from '@stencil/core';
+import logger from '../../utils/logger';
 
 @Component({
   tag: 'manifold-icon',
@@ -39,6 +40,7 @@ export class ManifoldIcon {
     });
   }
 
+  @logger()
   render() {
     return (
       <svg

--- a/src/components/manifold-image-gallery/manifold-image-gallery.tsx
+++ b/src/components/manifold-image-gallery/manifold-image-gallery.tsx
@@ -1,4 +1,5 @@
 import { h, Component, Prop, State, FunctionalComponent } from '@stencil/core';
+import logger from '../../utils/logger';
 
 interface ThumbnailProps {
   src: string;
@@ -27,6 +28,7 @@ export class ImageGallery {
     this.selectedImage = image;
   };
 
+  @logger()
   render() {
     if (Array.isArray(this.images)) {
       if (this.images.length === 0) {

--- a/src/components/manifold-input/manifold-input.tsx
+++ b/src/components/manifold-input/manifold-input.tsx
@@ -1,4 +1,5 @@
 import { h, Component, Prop, Event, State, EventEmitter, Watch } from '@stencil/core';
+import logger from '../../utils/logger';
 
 @Component({
   tag: 'manifold-input',
@@ -35,6 +36,7 @@ export class ManifoldSelect {
     this.updateValue.emit({ name: this.name, value: this.value });
   };
 
+  @logger()
   render() {
     return (
       <input

--- a/src/components/manifold-lazy-image/manifold-lazy-image.tsx
+++ b/src/components/manifold-lazy-image/manifold-lazy-image.tsx
@@ -1,4 +1,5 @@
 import { h, Component, Prop, State } from '@stencil/core';
+import logger from '../../utils/logger';
 
 @Component({ tag: 'manifold-lazy-image' })
 export class ManifoldLazyImage {
@@ -37,6 +38,7 @@ export class ManifoldLazyImage {
     }
   };
 
+  @logger()
   render() {
     // TODO reimplement lazy loading and ensure it works on search in manifold-marketplace
     return (

--- a/src/components/manifold-marketplace-grid/manifold-marketplace-grid.tsx
+++ b/src/components/manifold-marketplace-grid/manifold-marketplace-grid.tsx
@@ -9,6 +9,7 @@ import {
   formatCategoryLabel,
   filteredServices,
 } from '../../utils/marketplace';
+import logger from '../../utils/logger';
 
 @Component({
   tag: 'manifold-marketplace-grid',
@@ -197,6 +198,7 @@ export class ManifoldMarketplaceGrid {
     />
   );
 
+  @logger()
   render() {
     return (
       <div class="wrapper" data-categorized={this.showCategories}>

--- a/src/components/manifold-marketplace/manifold-marketplace.tsx
+++ b/src/components/manifold-marketplace/manifold-marketplace.tsx
@@ -4,6 +4,7 @@ import { Catalog } from '../../types/catalog';
 import Tunnel from '../../data/connection';
 import { withAuth } from '../../utils/auth';
 import { Connection, connections } from '../../utils/connections';
+import logger from '../../utils/logger';
 
 @Component({ tag: 'manifold-marketplace' })
 export class ManifoldMarketplace {
@@ -68,6 +69,7 @@ export class ManifoldMarketplace {
     }
   }
 
+  @logger()
   render() {
     return (
       <manifold-marketplace-grid

--- a/src/components/manifold-mock-resource/manifold-mock-resource.tsx
+++ b/src/components/manifold-mock-resource/manifold-mock-resource.tsx
@@ -1,6 +1,7 @@
 import { h, Component, State, Prop } from '@stencil/core';
 import { Gateway } from '../../types/gateway';
 import ResourceTunnel from '../../data/resource';
+import logger from '../../utils/logger';
 
 const ResourceMock: Gateway.Resource = {
   id: '1',
@@ -951,6 +952,7 @@ export class ManifoldMockResource {
     }, 2000);
   }
 
+  @logger()
   render() {
     return (
       <ResourceTunnel.Provider state={{ data: this.resource, loading: this.loading }}>

--- a/src/components/manifold-number-input/manifold-number-input.tsx
+++ b/src/components/manifold-number-input/manifold-number-input.tsx
@@ -1,5 +1,6 @@
 import { h, Component, Prop, Event, EventEmitter, Watch } from '@stencil/core';
 import { minus, plus } from '@manifoldco/icons';
+import logger from '../../utils/logger';
 
 @Component({
   tag: 'manifold-number-input',
@@ -62,6 +63,7 @@ export class ManifoldNumberInput {
     this.value = value;
   };
 
+  @logger()
   render() {
     return (
       <div class="container" data-error={this.outOfBound}>

--- a/src/components/manifold-plan-cost/manifold-plan-cost.tsx
+++ b/src/components/manifold-plan-cost/manifold-plan-cost.tsx
@@ -4,6 +4,7 @@ import { Gateway } from '../../types/gateway';
 import Tunnel from '../../data/connection';
 import { Connection, connections } from '../../utils/connections';
 import { planCost, hasCustomizableFeatures, initialFeatures } from '../../utils/plan';
+import logger from '../../utils/logger';
 
 @Component({ tag: 'manifold-plan-cost' })
 export class ManifoldPlanCost {
@@ -85,6 +86,7 @@ export class ManifoldPlanCost {
     });
   }
 
+  @logger()
   render() {
     return (
       <manifold-cost-display

--- a/src/components/manifold-plan-details/manifold-plan-details.tsx
+++ b/src/components/manifold-plan-details/manifold-plan-details.tsx
@@ -5,6 +5,7 @@ import { globalRegion } from '../../data/region';
 import { initialFeatures } from '../../utils/plan';
 import { FeatureValue } from './components/FeatureValue';
 import { FeatureLabel } from './components/FeatureLabel';
+import logger from '../../utils/logger';
 
 interface EventDetail {
   planId: string;
@@ -238,6 +239,7 @@ export class ManifoldPlanDetails {
     }
   };
 
+  @logger()
   render() {
     if (this.plan && this.product) {
       const { logo_url, name: productName } = this.product.body;

--- a/src/components/manifold-plan-menu/manifold-plan-menu.tsx
+++ b/src/components/manifold-plan-menu/manifold-plan-menu.tsx
@@ -1,6 +1,7 @@
 import { h, Component, Prop, FunctionalComponent } from '@stencil/core';
 import { check, sliders } from '@manifoldco/icons';
 import { Catalog } from '../../types/catalog';
+import logger from '../../utils/logger';
 
 const PlanButton: FunctionalComponent<{
   checked?: boolean;
@@ -40,6 +41,7 @@ export class ManifoldPlanMenu {
     });
   }
 
+  @logger()
   render() {
     if (this.plans) {
       const plans = this.sortPlans(this.plans);

--- a/src/components/manifold-plan-selector/manifold-plan-selector.tsx
+++ b/src/components/manifold-plan-selector/manifold-plan-selector.tsx
@@ -4,6 +4,7 @@ import { Gateway } from '../../types/gateway';
 import Tunnel from '../../data/connection';
 import { withAuth } from '../../utils/auth';
 import { Connection, connections } from '../../utils/connections';
+import logger from '../../utils/logger';
 
 @Component({ tag: 'manifold-plan-selector' })
 export class ManifoldPlanSelector {
@@ -106,6 +107,7 @@ export class ManifoldPlanSelector {
     return regions.split(',').map(region => region.trim().toLowerCase());
   }
 
+  @logger()
   render() {
     return (
       <manifold-active-plan

--- a/src/components/manifold-plan/manifold-plan.tsx
+++ b/src/components/manifold-plan/manifold-plan.tsx
@@ -3,6 +3,7 @@ import { Catalog } from '../../types/catalog';
 import Tunnel from '../../data/connection';
 import { withAuth } from '../../utils/auth';
 import { Connection, connections } from '../../utils/connections';
+import logger from '../../utils/logger';
 
 @Component({ tag: 'manifold-plan' })
 export class ManifoldPlan {
@@ -63,6 +64,7 @@ export class ManifoldPlan {
     this.plan = plans[0]; // eslint-disable-line prefer-destructuring
   }
 
+  @logger()
   render() {
     return <manifold-plan-details scrollLocked={false} plan={this.plan} product={this.product} />;
   }

--- a/src/components/manifold-product-details/manifold-product-details.tsx
+++ b/src/components/manifold-product-details/manifold-product-details.tsx
@@ -1,6 +1,7 @@
 import { h, Component, Prop } from '@stencil/core';
 import { Catalog } from '../../types/catalog';
 import skeletonProduct from '../../data/product';
+import logger from '../../utils/logger';
 
 @Component({
   tag: 'manifold-product-details',
@@ -10,6 +11,7 @@ import skeletonProduct from '../../data/product';
 export class ManifoldProductDetails {
   @Prop() product?: Catalog.Product;
 
+  @logger()
   render() {
     const {
       body: { tagline, value_props, images = [] },

--- a/src/components/manifold-product-page/manifold-product-page.tsx
+++ b/src/components/manifold-product-page/manifold-product-page.tsx
@@ -3,6 +3,7 @@ import { arrow_up_right, book, life_buoy } from '@manifoldco/icons';
 import { Catalog } from '../../types/catalog';
 import skeletonProduct from '../../data/product';
 import { categoryIcon } from '../../utils/marketplace';
+import logger from '../../utils/logger';
 
 @Component({
   tag: 'manifold-product-page',
@@ -22,6 +23,7 @@ export class ManifoldProductPage {
     );
   }
 
+  @logger()
   render() {
     if (this.product) {
       const { documentation_url, support_email, name, label, logo_url, tags } = this.product.body;

--- a/src/components/manifold-product/manifold-product.tsx
+++ b/src/components/manifold-product/manifold-product.tsx
@@ -3,6 +3,7 @@ import { Catalog } from '../../types/catalog';
 import Tunnel from '../../data/connection';
 import { withAuth } from '../../utils/auth';
 import { Connection, connections } from '../../utils/connections';
+import logger from '../../utils/logger';
 
 @Component({ tag: 'manifold-product' })
 export class ManifoldProduct {
@@ -44,6 +45,7 @@ export class ManifoldProduct {
     this.provider = provider;
   };
 
+  @logger()
   render() {
     return (
       <manifold-product-page product={this.product} provider={this.provider}>

--- a/src/components/manifold-region-selector/manifold-region-selector.tsx
+++ b/src/components/manifold-region-selector/manifold-region-selector.tsx
@@ -5,6 +5,7 @@ import Tunnel from '../../data/connection';
 import { globalRegion } from '../../data/region';
 import { withAuth } from '../../utils/auth';
 import { Connection, connections } from '../../utils/connections';
+import logger from '../../utils/logger';
 
 @Component({ tag: 'manifold-region-selector' })
 export class ManifoldRegionSelector {
@@ -81,6 +82,7 @@ export class ManifoldRegionSelector {
     return `${platform.replace('digital-ocean', 'do')}-${location}`;
   }
 
+  @logger()
   render() {
     const regions = this.filterRegions(this.regions || []);
 

--- a/src/components/manifold-resource-card-view/manifold-resource-card-view.tsx
+++ b/src/components/manifold-resource-card-view/manifold-resource-card-view.tsx
@@ -5,6 +5,7 @@ import Tunnel from '../../data/connection';
 import { withAuth } from '../../utils/auth';
 import { Connection, connections } from '../../utils/connections';
 import { Gateway } from '../../types/gateway';
+import logger from '../../utils/logger';
 
 interface EventDetail {
   resourceId?: string;
@@ -97,6 +98,7 @@ export class ManifoldResourceCardView {
     }
   };
 
+  @logger()
   render() {
     return !this.loading && this.resourceId ? (
       <a

--- a/src/components/manifold-resource-card/manifold-resource-card.tsx
+++ b/src/components/manifold-resource-card/manifold-resource-card.tsx
@@ -4,6 +4,7 @@ import Tunnel from '../../data/connection';
 import { withAuth } from '../../utils/auth';
 import { Connection, connections } from '../../utils/connections';
 import { Gateway } from '../../types/gateway';
+import logger from '../../utils/logger';
 
 @Component({ tag: 'manifold-resource-card' })
 export class ManifoldResourceCard {
@@ -61,6 +62,7 @@ export class ManifoldResourceCard {
     }
   }
 
+  @logger()
   render() {
     return this.resource ? (
       <manifold-resource-card-view

--- a/src/components/manifold-resource-container/manifold-resource-container.tsx
+++ b/src/components/manifold-resource-container/manifold-resource-container.tsx
@@ -4,6 +4,7 @@ import ConnectionTunnel from '../../data/connection';
 import ResourceTunnel from '../../data/resource';
 import { withAuth } from '../../utils/auth';
 import { Connection, connections } from '../../utils/connections';
+import logger from '../../utils/logger';
 
 @Component({ tag: 'manifold-resource-container' })
 export class ManifoldResourceContainer {
@@ -41,6 +42,7 @@ export class ManifoldResourceContainer {
     this.loading = false;
   };
 
+  @logger()
   render() {
     return (
       <ResourceTunnel.Provider state={{ data: this.resource, loading: this.loading }}>

--- a/src/components/manifold-resource-credentials/manifold-resource-credentials.tsx
+++ b/src/components/manifold-resource-credentials/manifold-resource-credentials.tsx
@@ -1,9 +1,11 @@
 import { h, Component } from '@stencil/core';
 
 import ResourceTunnel, { ResourceState } from '../../data/resource';
+import logger from '../../utils/logger';
 
 @Component({ tag: 'manifold-resource-credentials' })
 export class ManifoldResourceCredentials {
+  @logger()
   render() {
     return (
       <ResourceTunnel.Consumer>

--- a/src/components/manifold-resource-deprovision/manifold-resource-deprovision.tsx
+++ b/src/components/manifold-resource-deprovision/manifold-resource-deprovision.tsx
@@ -2,6 +2,7 @@ import { h, Component, Prop, Event, EventEmitter } from '@stencil/core';
 
 import ResourceTunnel from '../../data/resource';
 import { Gateway } from '../../types/gateway';
+import logger from '../../utils/logger';
 
 @Component({ tag: 'manifold-resource-deprovision' })
 export class ManifoldResourceDeprovision {
@@ -11,6 +12,7 @@ export class ManifoldResourceDeprovision {
   @Event({ eventName: 'manifold-deprovisionButton-error', bubbles: true }) error: EventEmitter;
   @Event({ eventName: 'manifold-deprovisionButton-success', bubbles: true }) success: EventEmitter;
 
+  @logger()
   render() {
     return (
       <manifold-data-deprovision-button

--- a/src/components/manifold-resource-details-view/manifold-resource-details-view.tsx
+++ b/src/components/manifold-resource-details-view/manifold-resource-details-view.tsx
@@ -3,6 +3,7 @@ import { Gateway } from '../../types/gateway';
 import { FeatureName } from './components/FeatureName';
 import { FeatureValue } from './components/FeatureValue';
 import { $ } from '../../utils/currency';
+import logger from '../../utils/logger';
 
 @Component({
   tag: 'manifold-resource-details-view',
@@ -12,6 +13,7 @@ import { $ } from '../../utils/currency';
 export class ManifoldResourceDetails {
   @Prop() data?: Gateway.Resource;
 
+  @logger()
   render() {
     if (this.data) {
       const { expanded_features, name } = this.data.plan as Gateway.ResolvedPlan;

--- a/src/components/manifold-resource-details/manifold-resource-details.tsx
+++ b/src/components/manifold-resource-details/manifold-resource-details.tsx
@@ -1,9 +1,11 @@
 import { h, Component } from '@stencil/core';
 
 import ResourceTunnel, { ResourceState } from '../../data/resource';
+import logger from '../../utils/logger';
 
 @Component({ tag: 'manifold-resource-details' })
 export class ManifoldResourceDetails {
+  @logger()
   render() {
     return (
       <ResourceTunnel.Consumer>

--- a/src/components/manifold-resource-list/manifold-resource-list.tsx
+++ b/src/components/manifold-resource-list/manifold-resource-list.tsx
@@ -6,6 +6,7 @@ import { Provisioning } from '../../types/provisioning';
 import Tunnel from '../../data/connection';
 import { withAuth } from '../../utils/auth';
 import { Connection, connections } from '../../utils/connections';
+import logger from '../../utils/logger';
 
 interface FoundResource {
   id: string;
@@ -159,6 +160,7 @@ export class ManifoldResourceList {
     }
   }
 
+  @logger()
   render() {
     if (Array.isArray(this.resources) && !this.resources.length) {
       return <slot name="no-resources" />;

--- a/src/components/manifold-resource-plan/manifold-resource-plan.tsx
+++ b/src/components/manifold-resource-plan/manifold-resource-plan.tsx
@@ -2,9 +2,11 @@ import { h, Component } from '@stencil/core';
 
 import ResourceTunnel, { ResourceState } from '../../data/resource';
 import { convertPlan, convertProduct } from '../../utils/gatewayToCatalog';
+import logger from '../../utils/logger';
 
 @Component({ tag: 'manifold-resource-plan' })
 export class ManifoldResourcePlan {
+  @logger()
   render() {
     return (
       <ResourceTunnel.Consumer>

--- a/src/components/manifold-resource-product/manifold-resource-product.tsx
+++ b/src/components/manifold-resource-product/manifold-resource-product.tsx
@@ -2,6 +2,7 @@ import { h, Component, Prop } from '@stencil/core';
 
 import ResourceTunnel from '../../data/resource';
 import { Gateway } from '../../types/gateway';
+import logger from '../../utils/logger';
 
 @Component({ tag: 'manifold-resource-product' })
 export class ManifoldResourceProduct {
@@ -9,6 +10,7 @@ export class ManifoldResourceProduct {
   @Prop() loading: boolean = true;
   @Prop() asCard?: boolean = false;
 
+  @logger()
   render() {
     return this.data && this.data.product ? (
       <manifold-service-view

--- a/src/components/manifold-resource-rename/manifold-resource-rename.tsx
+++ b/src/components/manifold-resource-rename/manifold-resource-rename.tsx
@@ -2,6 +2,7 @@ import { h, Component, Prop, Event, EventEmitter } from '@stencil/core';
 
 import ResourceTunnel from '../../data/resource';
 import { Gateway } from '../../types/gateway';
+import logger from '../../utils/logger';
 
 @Component({ tag: 'manifold-resource-rename' })
 export class ManifoldResourceRename {
@@ -14,6 +15,7 @@ export class ManifoldResourceRename {
   @Event({ eventName: 'manifold-renameButton-error', bubbles: true }) error: EventEmitter;
   @Event({ eventName: 'manifold-renameButton-success', bubbles: true }) success: EventEmitter;
 
+  @logger()
   render() {
     return (
       <manifold-data-rename-button

--- a/src/components/manifold-resource-sso/manifold-resource-sso.tsx
+++ b/src/components/manifold-resource-sso/manifold-resource-sso.tsx
@@ -2,6 +2,7 @@ import { h, Component, Prop, Event, EventEmitter } from '@stencil/core';
 
 import ResourceTunnel from '../../data/resource';
 import { Gateway } from '../../types/gateway';
+import logger from '../../utils/logger';
 
 @Component({ tag: 'manifold-resource-sso' })
 export class ManifoldResourceSso {
@@ -11,6 +12,7 @@ export class ManifoldResourceSso {
   @Event({ eventName: 'manifold-ssoButton-error', bubbles: true }) error: EventEmitter;
   @Event({ eventName: 'manifold-ssoButton-success', bubbles: true }) success: EventEmitter;
 
+  @logger()
   render() {
     return (
       <manifold-data-sso-button

--- a/src/components/manifold-resource-status-view/manifold-resource-status-view.tsx
+++ b/src/components/manifold-resource-status-view/manifold-resource-status-view.tsx
@@ -1,5 +1,6 @@
 import { h, Component, Prop } from '@stencil/core';
 import { refresh_cw } from '@manifoldco/icons';
+import logger from '../../utils/logger';
 
 const AVAILABLE = 'available';
 const OFFLINE = 'offline';
@@ -37,6 +38,7 @@ export class ManifoldResourceStatusView {
     return message[OFFLINE];
   }
 
+  @logger()
   render() {
     if (this.loading) {
       return (

--- a/src/components/manifold-resource-status/manifold-resource-status.tsx
+++ b/src/components/manifold-resource-status/manifold-resource-status.tsx
@@ -1,11 +1,13 @@
 import { h, Component, Prop } from '@stencil/core';
 
 import Tunnel, { ResourceState } from '../../data/resource';
+import logger from '../../utils/logger';
 
 @Component({ tag: 'manifold-resource-status' })
 export class ManifoldResourceStatus {
   @Prop() size?: 'small' | 'medium' = 'medium';
 
+  @logger()
   render() {
     return (
       <Tunnel.Consumer>

--- a/src/components/manifold-select/manifold-select.tsx
+++ b/src/components/manifold-select/manifold-select.tsx
@@ -1,5 +1,6 @@
 import { h, Component, Prop, Event, EventEmitter, Watch } from '@stencil/core';
 import { Option } from '../../types/Select';
+import logger from '../../utils/logger';
 
 @Component({
   tag: 'manifold-select',
@@ -24,6 +25,7 @@ export class ManifoldSelect {
     this.updateValue.emit({ name: this.name, value });
   };
 
+  @logger()
   render() {
     return (
       <select name={this.name} required={this.required} onChange={this.onChangeHandler}>

--- a/src/components/manifold-service-card-view/manifold-service-card-view.tsx
+++ b/src/components/manifold-service-card-view/manifold-service-card-view.tsx
@@ -1,4 +1,5 @@
 import { h, Component, Element, Prop } from '@stencil/core';
+import logger from '../../utils/logger';
 
 @Component({
   tag: 'manifold-service-card-view',
@@ -18,6 +19,7 @@ export class ManifoldServiceView {
   @Prop() asCard?: boolean = true;
   @Prop() hideTags?: boolean = false;
 
+  @logger()
   render() {
     return !this.loading ? (
       <div class={this.asCard ? 'card-wrapper' : 'wrapper'}>

--- a/src/components/manifold-service-card/manifold-service-card.tsx
+++ b/src/components/manifold-service-card/manifold-service-card.tsx
@@ -4,6 +4,7 @@ import { Catalog } from '../../types/catalog';
 import Tunnel from '../../data/connection';
 import { withAuth } from '../../utils/auth';
 import { Connection, connections } from '../../utils/connections';
+import logger from '../../utils/logger';
 
 interface EventDetail {
   productId?: string;
@@ -129,6 +130,7 @@ export class ManifoldServiceCard {
     }
   };
 
+  @logger()
   render() {
     return !this.skeleton && !this.loading && this.product ? (
       <a

--- a/src/components/manifold-service-view/manifold-service-view.tsx
+++ b/src/components/manifold-service-view/manifold-service-view.tsx
@@ -1,5 +1,6 @@
 /* DEPRECATED: replaced by manifold-service-card-view */
 import { h, Component, Element, Prop } from '@stencil/core';
+import logger from '../../utils/logger';
 
 @Component({
   tag: 'manifold-service-view',
@@ -19,6 +20,7 @@ export class ManifoldServiceView {
   @Prop() asCard?: boolean = true;
   @Prop() hideTags?: boolean = false;
 
+  @logger()
   render() {
     console.warn('DEPRECATED: replaced by manifold-service-card-view');
 

--- a/src/components/manifold-skeleton-img/manifold-skeleton-img.tsx
+++ b/src/components/manifold-skeleton-img/manifold-skeleton-img.tsx
@@ -1,4 +1,5 @@
 import { h, Component } from '@stencil/core';
+import logger from '../../utils/logger';
 
 @Component({
   tag: 'manifold-skeleton-img',
@@ -6,6 +7,7 @@ import { h, Component } from '@stencil/core';
   shadow: true,
 })
 export class ManifoldSkeletonImg {
+  @logger()
   render() {
     return <div class="img" />;
   }

--- a/src/components/manifold-skeleton-text/manifold-skeleton-text.tsx
+++ b/src/components/manifold-skeleton-text/manifold-skeleton-text.tsx
@@ -1,4 +1,5 @@
 import { h, Component } from '@stencil/core';
+import logger from '../../utils/logger';
 
 @Component({
   tag: 'manifold-skeleton-text',
@@ -6,6 +7,7 @@ import { h, Component } from '@stencil/core';
   shadow: true,
 })
 export class ManifoldSkeletonText {
+  @logger()
   render() {
     return (
       <div class="wrapper">

--- a/src/components/manifold-template-card/manifold-template-card.tsx
+++ b/src/components/manifold-template-card/manifold-template-card.tsx
@@ -1,6 +1,7 @@
 import { h, Component, Prop, Event, EventEmitter } from '@stencil/core';
 import { categoryIcon } from '../../utils/marketplace';
 import serviceTemplates from '../../data/templates';
+import logger from '../../utils/logger';
 
 interface EventDetail {
   category: string;
@@ -36,6 +37,7 @@ export class ManifoldTemplateCard {
     return serviceTemplates.filter(({ category }) => category === this.category);
   }
 
+  @logger()
   render() {
     if (this.templates.length === 0) {
       return null;

--- a/src/components/manifold-toast/manifold-toast.tsx
+++ b/src/components/manifold-toast/manifold-toast.tsx
@@ -1,6 +1,7 @@
 import { h, Component, Element, Prop, State, Host } from '@stencil/core';
 import { alert_triangle, check_circle, bell, slash, x } from '@manifoldco/icons';
 import observeRect, { Observer } from '@reach/observe-rect';
+import logger from '../../utils/logger';
 
 const READY = 'READY';
 const DISMISSED = 'DISMISSED';
@@ -75,6 +76,7 @@ export class ManifoldToast {
     }
   }
 
+  @logger()
   render() {
     return (
       <Host style={{ '--height': this.dismissable ? this.lastHeight : undefined }}>

--- a/src/components/manifold-toggle/manifold-toggle.tsx
+++ b/src/components/manifold-toggle/manifold-toggle.tsx
@@ -1,4 +1,5 @@
 import { h, Component, Prop, Event, EventEmitter, Watch } from '@stencil/core';
+import logger from '../../utils/logger';
 
 @Component({
   tag: 'manifold-toggle',
@@ -27,6 +28,7 @@ export class MfToggle {
     });
   };
 
+  @logger()
   render() {
     return (
       <label class="wrapper">

--- a/src/components/manifold-tooltip/manifold-tooltip.tsx
+++ b/src/components/manifold-tooltip/manifold-tooltip.tsx
@@ -1,4 +1,5 @@
 import { h, Component, Prop } from '@stencil/core';
+import logger from '../../utils/logger';
 
 @Component({
   tag: 'manifold-tooltip',
@@ -8,6 +9,7 @@ import { h, Component, Prop } from '@stencil/core';
 export class ManifoldTooltip {
   @Prop() labelText?: string;
 
+  @logger()
   render() {
     return [<slot />, this.labelText && <div class="tooltip">{this.labelText}</div>];
   }


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

This integrates the eslint rule that requires all components to decorate their render methods with `@logger()`, and updates all components to comply.

## Testing
<!-- For someone unfamiliar with the issue, how should this be tested? -->

ESLint should pass! Try checking out the branch and removing the `@logger()` decorator from any component, and then ESLint should fail!