### PR TITLE
remove expiry from token and isExpiry tests

### DIFF
--- a/src/components/manifold-auth-token/manifold-auth-token.spec.ts
+++ b/src/components/manifold-auth-token/manifold-auth-token.spec.ts
@@ -20,24 +20,6 @@ describe('<manifold-auth-token>', () => {
     });
   });
 
-  describe('when the token is expired', () => {
-    const expiry = new Date();
-    expiry.setDate(expiry.getDate() - 1);
-    const expiryUTC = expiry.toUTCString();
-
-    it('does not call the set auth token on load', () => {
-      const token = `test.${expiryUTC}`;
-
-      const provisionButton = new ManifoldAuthToken();
-      provisionButton.setAuthToken = jest.fn();
-
-      provisionButton.token = token;
-      provisionButton.componentWillLoad();
-
-      expect(provisionButton.setAuthToken).not.toHaveBeenCalled();
-    });
-  });
-
   it('calls the set auth token on change', () => {
     const token = 'test';
     const newToken = 'test-new';

--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -1,7 +1,6 @@
 import { h, Component, Prop, Watch, Event, EventEmitter } from '@stencil/core';
 import { AuthToken } from '@manifoldco/shadowcat';
 import Tunnel from '../../data/connection';
-import { isExpired } from '../../utils/auth';
 import logger from '../../utils/logger';
 
 @Component({ tag: 'manifold-auth-token' })
@@ -20,9 +19,7 @@ export class ManifoldAuthToken {
 
   componentWillLoad() {
     if (this.token) {
-      if (!isExpired(this.token)) {
-        this.setAuthToken(this.token);
-      }
+      this.setAuthToken(this.token);
     }
   }
 

--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -29,8 +29,7 @@ export class ManifoldAuthToken {
   setInternalToken = (e: CustomEvent) => {
     const payload = e.detail as AuthToken;
     if (!payload.error && payload.expiry) {
-      const expiry = payload.expiry.toString();
-      this.token = `${payload.token}.${expiry}`;
+      this.token = `${payload.token}`;
     }
   };
 

--- a/src/components/manifold-connection/manifold-connection.tsx
+++ b/src/components/manifold-connection/manifold-connection.tsx
@@ -33,8 +33,7 @@ export class ManiTunnel {
 
   get accessToken() {
     if (this.authToken) {
-      const [token] = this.authToken.split('.');
-      return token;
+      return this.authToken;
     }
 
     return undefined;

--- a/src/components/manifold-connection/manifold-connection.tsx
+++ b/src/components/manifold-connection/manifold-connection.tsx
@@ -3,14 +3,13 @@ import { h, Component, Prop, State } from '@stencil/core';
 import Tunnel from '../../data/connection';
 import { connections } from '../../utils/connections';
 import { createGraphqlFetch } from '../../utils/graphqlFetch';
-import { isExpired } from '../../utils/auth';
 import logger from '../../utils/logger';
 
 const TOKEN_KEY = 'manifold_api_token';
 
 function getDefaultToken() {
   const token = localStorage.getItem(TOKEN_KEY);
-  if (token && !isExpired(token)) {
+  if (token) {
     return token;
   }
 

--- a/src/utils/auth.spec.ts
+++ b/src/utils/auth.spec.ts
@@ -1,4 +1,4 @@
-import { withAuth, isExpired } from './auth';
+import { withAuth } from './auth';
 
 describe('withAuth method', () => {
   it('passes objects through', () => {
@@ -8,36 +8,5 @@ describe('withAuth method', () => {
 
   it('reads manifold_api_token from the given token', () => {
     expect(withAuth('larry')).toEqual({ headers: { authorization: 'Bearer larry' } });
-  });
-});
-
-describe('isExpired', () => {
-  it('returns TRUE when token is expired (2-part token).', () => {
-    const now = new Date();
-    const past = Math.floor(now.getTime() / 1000 - 1000); // 1000 seconds in the past
-    expect(isExpired(`hello.${past}`)).toBe(true);
-  });
-
-  it('returns TRUE when token is expired (3-part token).', () => {
-    const now = new Date();
-    now.setSeconds(now.getSeconds() + 1000);
-    const past = Math.floor(now.getTime() / 1000 - 1000); // 1000 seconds in the past
-    expect(isExpired(`hello.world.${past}`)).toBe(true);
-  });
-
-  it('returns FALSE when token is NOT expired (2-part token).', () => {
-    const now = new Date();
-    const future = Math.floor(now.getTime() / 1000 + 1000); // 1000 seconds in the future
-    expect(isExpired(`hello.${future}`)).toBe(false);
-  });
-
-  it('returns FALSE when token is NOT expired (3-part token).', () => {
-    const now = new Date();
-    const future = Math.floor(now.getTime() / 1000 + 1000); // 1000 seconds in the future
-    expect(isExpired(`hello.world.${future}`)).toBe(false);
-  });
-
-  it('returns TRUE when token is not formatted correctly.', () => {
-    expect(isExpired('this.is-not_a+token')).toBe(true);
   });
 });

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -22,20 +22,3 @@ export function withAuth(authToken?: string, options?: RequestInit): RequestInit
     },
   };
 }
-
-export function isExpired(token: string) {
-  try {
-    const expiry = token.split('.').pop() || '';
-    const decodedExpiry = parseInt(expiry, 10);
-    if (Number.isNaN(decodedExpiry)) {
-      throw new Error('Expiry not a number.');
-    }
-
-    const d = new Date(decodedExpiry * 1000);
-    const now = new Date();
-
-    return d < now;
-  } catch (error) {
-    return true;
-  }
-}


### PR DESCRIPTION
## Issue

Currently this breaks the tokens in use.
Let's remove this until we have a robust decision we feel good about.