### PR TITLE
Fix free badges on manifold-marketplace

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1951,7 +1951,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-      "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "core-js": "^2.5.0",
@@ -1961,8 +1960,7 @@
         "regenerator-runtime": {
           "version": "0.10.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
-          "dev": true
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
         }
       }
     },
@@ -5182,7 +5180,6 @@
       "version": "7.3.9",
       "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-7.3.9.tgz",
       "integrity": "sha512-PgsTbiQBNapFz2P2UwDl3gowK3nZqfV4HdyDZ1dI4eTGGH9MLAeBglIPbyDbbNQoGYBOfla6/9uaiq7az2z4Aw==",
-      "dev": true,
       "requires": {
         "babel-polyfill": "^6.26.0",
         "core-js": "^2.6.9",
@@ -5194,14 +5191,12 @@
         "glob-to-regexp": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-          "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-          "dev": true
+          "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
         },
         "path-to-regexp": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
-          "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
-          "dev": true
+          "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w=="
         }
       }
     },
@@ -8463,8 +8458,7 @@
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-      "dev": true
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
     "lodash.throttle": {
       "version": "4.1.1",
@@ -13977,7 +13971,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -14669,8 +14662,7 @@
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
     },
     "webpack": {
       "version": "4.28.4",
@@ -15159,7 +15151,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
       "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
-      "dev": true,
       "requires": {
         "lodash.sortby": "^4.7.0",
         "tr46": "^1.0.1",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -329,6 +329,7 @@ export namespace Components {
   interface ManifoldMarketplaceGrid {
     'excludes'?: string[];
     'featured'?: string[];
+    'freeProducts': string[];
     'hideCategories'?: boolean;
     'hideSearch'?: boolean;
     'hideTemplates'?: boolean;
@@ -553,6 +554,7 @@ export namespace Components {
   }
   interface ManifoldServiceCard {
     'isFeatured'?: boolean;
+    'isFree': boolean;
     'preserveEvent'?: boolean;
     'product'?: Catalog.Product;
     'productId'?: string;
@@ -1380,6 +1382,7 @@ declare namespace LocalJSX {
   interface ManifoldMarketplaceGrid extends JSXBase.HTMLAttributes<HTMLManifoldMarketplaceGridElement> {
     'excludes'?: string[];
     'featured'?: string[];
+    'freeProducts'?: string[];
     'hideCategories'?: boolean;
     'hideSearch'?: boolean;
     'hideTemplates'?: boolean;
@@ -1621,6 +1624,7 @@ declare namespace LocalJSX {
   }
   interface ManifoldServiceCard extends JSXBase.HTMLAttributes<HTMLManifoldServiceCardElement> {
     'isFeatured'?: boolean;
+    'isFree'?: boolean;
     'onManifold-marketplace-click'?: (event: CustomEvent<any>) => void;
     'preserveEvent'?: boolean;
     'product'?: Catalog.Product;

--- a/src/components/manifold-marketplace-grid/manifold-marketplace-grid.tsx
+++ b/src/components/manifold-marketplace-grid/manifold-marketplace-grid.tsx
@@ -21,6 +21,7 @@ export class ManifoldMarketplaceGrid {
   @Element() el: HTMLElement;
   @Prop() excludes?: string[] = [];
   @Prop() featured?: string[] = [];
+  @Prop() freeProducts: string[] = [];
   @Prop() hideCategories?: boolean = false;
   @Prop() hideSearch?: boolean = false;
   @Prop() hideTemplates?: boolean = false;
@@ -216,6 +217,7 @@ export class ManifoldMarketplaceGrid {
       data-label={product.body.label}
       data-featured={this.featured && this.featured.includes(product.body.label)}
       isFeatured={this.featured && this.featured.includes(product.body.label)}
+      isFree={this.freeProducts.includes(product.id)}
       product={product}
       skeleton={this.skeleton}
     />

--- a/src/components/manifold-marketplace/manifold-marketplace.tsx
+++ b/src/components/manifold-marketplace/manifold-marketplace.tsx
@@ -70,18 +70,22 @@ export class ManifoldMarketplace {
       this.services.map(
         ({ id }) =>
           new Promise(async resolve => {
-            if (!this.connection) {
+            if (!this.restFetch) {
               resolve();
               return;
             }
 
-            const response = await fetch(
-              `${this.connection.catalog}/plans/?product_id=${id}`,
-              withAuth(this.authToken)
-            );
+            const plansResp = await this.restFetch<Catalog.ExpandedPlan[]>({
+              service: 'catalog',
+              endpoint: `/plans/?product_id=${id}`,
+            });
 
-            const plans: Catalog.ExpandedPlan[] = await response.json();
-            if (Array.isArray(plans) && plans.find(plan => plan.body.free === true)) {
+            if (plansResp instanceof Error) {
+              console.error(plansResp);
+              return;
+            }
+
+            if (Array.isArray(plansResp) && plansResp.find(plan => plan.body.free === true)) {
               freeProducts.push(id);
             }
             resolve();

--- a/src/components/manifold-service-card/manifold-service-card.e2e.ts
+++ b/src/components/manifold-service-card/manifold-service-card.e2e.ts
@@ -12,14 +12,15 @@ describe('<manifold-service-card>', () => {
     expect(loading).toBe(true);
   });
 
-  it('formats links correctly', async () => {
+  it('formats links from products', async () => {
     const page = await newE2EPage({
-      html: `<manifold-service-card product-id="${Product.id}" product-label="${Product.body.label}" product-link-format="/product/:product"></manifold-service-card>`,
+      html: `<manifold-service-card></manifold-service-card>`,
     });
     await page.$eval(
       'manifold-service-card',
       (elm: any, props: any) => {
         elm.product = props.product;
+        elm.productLinkFormat = '/product/:product';
       },
       { product: Product }
     );
@@ -32,7 +33,7 @@ describe('<manifold-service-card>', () => {
 
   it('displays a free badge if marked as free', async () => {
     const page = await newE2EPage({
-      html: `<manifold-service-card product-id="${Product.id}" product-label="${Product.body.label}"></manifold-service-card>`,
+      html: `<manifold-service-card></manifold-service-card>`,
     });
     await page.$eval(
       'manifold-service-card',

--- a/src/components/manifold-service-card/manifold-service-card.e2e.ts
+++ b/src/components/manifold-service-card/manifold-service-card.e2e.ts
@@ -1,0 +1,50 @@
+import { newE2EPage } from '@stencil/core/testing';
+import { Product } from '../../spec/mock/catalog';
+
+/* eslint-disable no-param-reassign, @typescript-eslint/no-explicit-any */
+
+describe('<manifold-service-card>', () => {
+  it('displays skeleton component initially', async () => {
+    const page = await newE2EPage({ html: `<manifold-service-card></manifold-service-card>` });
+    await page.waitForChanges();
+    const card = await page.find('manifold-service-card-view');
+    const loading = await card.getProperty('loading');
+    expect(loading).toBe(true);
+  });
+
+  it('formats links correctly', async () => {
+    const page = await newE2EPage({
+      html: `<manifold-service-card product-id="${Product.id}" product-label="${Product.body.label}" product-link-format="/product/:product"></manifold-service-card>`,
+    });
+    await page.$eval(
+      'manifold-service-card',
+      (elm: any, props: any) => {
+        elm.product = props.product;
+      },
+      { product: Product }
+    );
+    await page.waitForChanges();
+
+    const link = await page.find('a');
+    const href = await link.getAttribute('href');
+    expect(href).toBe(`/product/${Product.body.label}`);
+  });
+
+  it('displays a free badge if marked as free', async () => {
+    const page = await newE2EPage({
+      html: `<manifold-service-card product-id="${Product.id}" product-label="${Product.body.label}"></manifold-service-card>`,
+    });
+    await page.$eval(
+      'manifold-service-card',
+      (elm: any, props: any) => {
+        elm.isFree = true;
+        elm.product = props.product;
+      },
+      { product: Product }
+    );
+    await page.waitForChanges();
+
+    const tag = await page.find('manifold-service-card-view >>> [data-tag="free"]');
+    expect(tag).not.toBeNull();
+  });
+});

--- a/src/components/manifold-service-card/manifold-service-card.spec.ts
+++ b/src/components/manifold-service-card/manifold-service-card.spec.ts
@@ -40,15 +40,6 @@ describe('<manifold-service-card>', () => {
     });
   });
 
-  it('formats links correctly', () => {
-    const serviceCard = new ManifoldServiceCard();
-    serviceCard.productLabel = Product.body.label;
-    serviceCard.productId = Product.id;
-    serviceCard.productLinkFormat = '/product/:product';
-
-    expect(serviceCard.href).toBe(`/product/${Product.body.label}`);
-  });
-
   it('fetches product by id on load', () => {
     const productId = '1234';
 
@@ -56,17 +47,17 @@ describe('<manifold-service-card>', () => {
     provisionButton.fetchProduct = jest.fn();
     provisionButton.productId = productId;
     provisionButton.componentWillLoad();
-    expect(provisionButton.fetchProduct).toHaveBeenCalledWith(undefined, productId);
+    expect(provisionButton.fetchProduct).toHaveBeenCalledWith({ id: productId });
   });
 
-  it('fetches product by label  on load', () => {
+  it('fetches product by label on load', () => {
     const productLabel = 'test-product';
 
     const provisionButton = new ManifoldServiceCard();
     provisionButton.fetchProduct = jest.fn();
     provisionButton.productLabel = productLabel;
     provisionButton.componentWillLoad();
-    expect(provisionButton.fetchProduct).toHaveBeenCalledWith(productLabel);
+    expect(provisionButton.fetchProduct).toHaveBeenCalledWith({ label: productLabel });
   });
 
   it('fetches product by id on id change', () => {
@@ -77,7 +68,7 @@ describe('<manifold-service-card>', () => {
     provisionButton.productId = '1234';
 
     provisionButton.productIdChange(newProduct);
-    expect(provisionButton.fetchProduct).toHaveBeenCalledWith(undefined, newProduct);
+    expect(provisionButton.fetchProduct).toHaveBeenCalledWith({ id: newProduct });
   });
 
   it('fetches product by label on label change', () => {
@@ -88,7 +79,7 @@ describe('<manifold-service-card>', () => {
     provisionButton.productLabel = 'old-product';
 
     provisionButton.productLabelChange(newProduct);
-    expect(provisionButton.fetchProduct).toHaveBeenCalledWith(newProduct);
+    expect(provisionButton.fetchProduct).toHaveBeenCalledWith({ label: newProduct });
   });
 
   describe('when created with a product label', () => {

--- a/src/components/manifold-service-card/manifold-service-card.tsx
+++ b/src/components/manifold-service-card/manifold-service-card.tsx
@@ -41,13 +41,22 @@ export class ManifoldServiceCard {
   }
 
   @Watch('productId') productIdChange(newProductId: string) {
-    if (!this.skeleton) {
+    if (this.skeleton) {
+      return;
+    }
+    // don’t re-fetch same product
+    if (!this.product || (this.product && this.product.id !== newProductId)) {
       this.fetchProduct({ id: newProductId });
     }
   }
 
   @Watch('productLabel') productLabelChange(newProductLabel: string) {
-    if (!this.skeleton) {
+    if (this.skeleton) {
+      return;
+    }
+
+    // don’t re-fetch same product
+    if (!this.product || (this.product && this.product.body.label !== newProductLabel)) {
       this.fetchProduct({ label: newProductLabel });
     }
   }
@@ -65,10 +74,11 @@ export class ManifoldServiceCard {
   }
 
   get href() {
-    if (!this.productLinkFormat || !this.productLabel) {
+    // if no format, or product is loading, don’t calculate href
+    if (!this.productLinkFormat || !this.product) {
       return '';
     }
-    return this.productLinkFormat.replace(/:product/gi, this.productLabel);
+    return this.productLinkFormat.replace(/:product/gi, this.product.body.label);
   }
 
   async fetchProduct({ id, label }: { id?: string; label?: string }) {

--- a/src/components/manifold-service-card/manifold-service-card.tsx
+++ b/src/components/manifold-service-card/manifold-service-card.tsx
@@ -35,25 +35,25 @@ export class ManifoldServiceCard {
   }
 
   @Watch('skeleton') skeletonChange(newSkeleton: boolean) {
-    if (newSkeleton !== true) {
+    if (!newSkeleton) {
       this.fetchProduct({ id: this.productId, label: this.productLabel });
     }
   }
 
   @Watch('productId') productIdChange(newProductId: string) {
-    if (this.skeleton !== true) {
+    if (!this.skeleton) {
       this.fetchProduct({ id: newProductId });
     }
   }
 
   @Watch('productLabel') productLabelChange(newProductLabel: string) {
-    if (this.skeleton !== true) {
+    if (!this.skeleton) {
       this.fetchProduct({ label: newProductLabel });
     }
   }
 
   componentWillLoad() {
-    if (this.skeleton === true || typeof this.product === 'object') {
+    if (this.skeleton || typeof this.product === 'object') {
       return; // if skeleton UI or it’s passed a product, don’t fetch anything
     }
 


### PR DESCRIPTION
## Reason for change
The “free“ badge on products either sometimes doesn’t display, or requires more API fetches than it needs to (products appear in different categories, so if a product appears multiple times it’ll send one API request per appearance).

What’s more, it breaks when you search by name.

This changes how “free“ is fetched, making it more data-efficient, and it also persists across searching.

**Before**

![2019-07-31 12-17-42 2019-07-31 12_18_46](https://user-images.githubusercontent.com/1369770/62237206-d2359b80-b38d-11e9-9b51-106df76efdd2.gif)

**After**

![2019-07-31 12-20-01 2019-07-31 12_22_01](https://user-images.githubusercontent.com/1369770/62237213-d5c92280-b38d-11e9-9b1b-d51b7760f115.gif)

## Testing
1. Make sure free tags appear on marketplace (Storybook or Docs)
2. Try searching
3. Make sure free tags are still there during/after clearing search
