### PR TITLE
Improve handling of token and expiry

### DIFF
--- a/src/components/manifold-auth-token/manifold-auth-token.spec.ts
+++ b/src/components/manifold-auth-token/manifold-auth-token.spec.ts
@@ -18,28 +18,27 @@ describe('<manifold-auth-token>', () => {
 
       expect(provisionButton.setAuthToken).toHaveBeenCalledWith(token);
     });
-  });
 
-  it('calls the set auth token on change', () => {
-    const token = 'test';
-    const newToken = 'test-new';
+    it('calls the set auth token on change', () => {
+      const newToken = `test-new|${expirySeconds}`;
 
-    const provisionButton = new ManifoldAuthToken();
-    provisionButton.setAuthToken = jest.fn();
+      const provisionButton = new ManifoldAuthToken();
+      provisionButton.setAuthToken = jest.fn();
 
-    provisionButton.token = token;
-    provisionButton.tokenChange(newToken);
+      provisionButton.tokenChange(newToken);
 
-    expect(provisionButton.setAuthToken).toHaveBeenCalledWith(newToken);
+      expect(provisionButton.setAuthToken).toHaveBeenCalledWith(newToken);
+    });
   });
 
   describe('when the token is expired', () => {
     const expiry = new Date();
     expiry.setDate(expiry.getDate() - 1);
-    const expiryUTC = expiry.toUTCString();
+    const unixTime = Math.floor(expiry.getTime() / 1000);
+    const expirySeconds = unixTime.toString();
 
     it('does not call the set auth token on load', () => {
-      const token = `test|${expiryUTC}`;
+      const token = `test|${expirySeconds}`;
 
       const provisionButton = new ManifoldAuthToken();
       provisionButton.setAuthToken = jest.fn();
@@ -48,6 +47,17 @@ describe('<manifold-auth-token>', () => {
       provisionButton.componentWillLoad();
 
       expect(provisionButton.setAuthToken).not.toHaveBeenCalled();
+    });
+
+    it('does not call the set auth token on change', () => {
+      const newToken = `test-new${expirySeconds}`;
+
+      const provisionButton = new ManifoldAuthToken();
+      provisionButton.setAuthToken = jest.fn();
+
+      provisionButton.tokenChange(newToken);
+
+      expect(provisionButton.setAuthToken).not.toHaveBeenCalledWith();
     });
   });
 });

--- a/src/components/manifold-auth-token/manifold-auth-token.spec.ts
+++ b/src/components/manifold-auth-token/manifold-auth-token.spec.ts
@@ -8,7 +8,7 @@ describe('<manifold-auth-token>', () => {
     const expirySeconds = unixTime.toString();
 
     it('calls the set auth token on load', () => {
-      const token = `test.${expirySeconds}`;
+      const token = `test|${expirySeconds}`;
 
       const provisionButton = new ManifoldAuthToken();
       provisionButton.setAuthToken = jest.fn();
@@ -31,5 +31,23 @@ describe('<manifold-auth-token>', () => {
     provisionButton.tokenChange(newToken);
 
     expect(provisionButton.setAuthToken).toHaveBeenCalledWith(newToken);
+  });
+
+  describe('when the token is expired', () => {
+    const expiry = new Date();
+    expiry.setDate(expiry.getDate() - 1);
+    const expiryUTC = expiry.toUTCString();
+
+    it('does not call the set auth token on load', () => {
+      const token = `test|${expiryUTC}`;
+
+      const provisionButton = new ManifoldAuthToken();
+      provisionButton.setAuthToken = jest.fn();
+
+      provisionButton.token = token;
+      provisionButton.componentWillLoad();
+
+      expect(provisionButton.setAuthToken).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -3,6 +3,7 @@ import { h, Component, Prop, Watch, Event, EventEmitter } from '@stencil/core';
 import { AuthToken } from '@manifoldco/shadowcat';
 import Tunnel from '../../data/connection';
 import logger from '../../utils/logger';
+import { isExpired } from '../../utils/auth';
 
 @Component({ tag: 'manifold-auth-token' })
 export class ManifoldAuthToken {
@@ -20,14 +21,16 @@ export class ManifoldAuthToken {
 
   componentWillLoad() {
     if (this.token) {
-      this.setAuthToken(this.token);
+      if (!isExpired(this.token)) {
+        this.setAuthToken(this.token);
+      }
     }
   }
 
   setInternalToken = (e: CustomEvent) => {
     const payload = e.detail as AuthToken;
     if (!payload.error && payload.expiry) {
-      this.token = `${payload.token}`;
+      this.token = `${payload.token}|${payload.expiry}`;
     }
   };
 

--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -10,19 +10,22 @@ export class ManifoldAuthToken {
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() setAuthToken: (s: string) => void = () => {};
   /* Authorisation header token that can be used to authenticate the user in manifold */
-  @Prop({ mutable: true }) token?: string;
+  @Prop() token?: string;
   @Prop() oauthUrl?: string;
   @Event() manifoldOauthTokenChange: EventEmitter;
 
-  @Watch('token') tokenChange(newToken: string) {
-    this.setAuthToken(newToken);
-    this.manifoldOauthTokenChange.emit(newToken);
+  @Watch('token') tokenChange(newToken?: string) {
+    this.setExternalToken(newToken);
   }
 
   componentWillLoad() {
-    if (this.token) {
-      if (!isExpired(this.token)) {
-        this.setAuthToken(this.token);
+    this.setExternalToken(this.token);
+  }
+
+  setExternalToken(token?: string) {
+    if (token) {
+      if (!isExpired(token)) {
+        this.setAuthToken(token);
       }
     }
   }
@@ -30,7 +33,9 @@ export class ManifoldAuthToken {
   setInternalToken = (e: CustomEvent) => {
     const payload = e.detail as AuthToken;
     if (!payload.error && payload.expiry) {
-      this.token = `${payload.token}|${payload.expiry}`;
+      const formattedToken = `${payload.token}|${payload.expiry}`;
+      this.setAuthToken(formattedToken);
+      this.manifoldOauthTokenChange.emit(formattedToken);
     }
   };
 

--- a/src/components/manifold-connection/manifold-connection.tsx
+++ b/src/components/manifold-connection/manifold-connection.tsx
@@ -6,17 +6,7 @@ import { createGraphqlFetch } from '../../utils/graphqlFetch';
 import { createRestFetch } from '../../utils/restFetch';
 import logger from '../../utils/logger';
 
-const TOKEN_KEY = 'manifold_api_token';
 const baseWait = 15000;
-
-function getDefaultToken() {
-  const token = localStorage.getItem(TOKEN_KEY);
-  if (token) {
-    return token;
-  }
-
-  return undefined;
-}
 
 @Component({ tag: 'manifold-connection' })
 export class ManiTunnel {
@@ -25,18 +15,18 @@ export class ManiTunnel {
   /** _(optional)_ Wait time for the fetch calls before it times out */
   @Prop() waitTime: number = baseWait;
 
-  @State() authToken?: string = getDefaultToken();
+  @State() authToken?: string;
 
   setAuthToken = (token: string) => {
     this.authToken = token;
-    localStorage.setItem(TOKEN_KEY, token);
   };
 
   getAuthToken = () => this.accessToken;
 
   get accessToken() {
     if (this.authToken) {
-      return this.authToken;
+      const [token] = this.authToken.split('|');
+      return token;
     }
 
     return undefined;

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -22,3 +22,20 @@ export function withAuth(authToken?: string, options?: RequestInit): RequestInit
     },
   };
 }
+
+export function isExpired(token: string) {
+  try {
+    const [, expiry] = token.split('|');
+    const numericExpiry = parseInt(expiry, 10);
+    if (Number.isNaN(numericExpiry)) {
+      // We have no expiry information, or it's badly formatted. Consider this expired.
+      return true;
+    }
+
+    const d = new Date(numericExpiry * 1000);
+    return d < new Date();
+  } catch {
+    // Not a valid unix timestamp. Consider this expired.
+    return true;
+  }
+}


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

1. The expiry should be delimited by a value that doesn't appear in JWT tokens. We chose `|`.
2. We should not use our local storage as backup. Doing so causes us to set the value in local storage even when a platform decides to control it themselves. This creates a false reassurance that the security of the token is in their hands.

## Testing
<!-- For someone unfamiliar with the issue, how should this be tested? -->
