### PR TITLE
Handle responses that don't have content

### DIFF
--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
@@ -130,8 +130,7 @@ describe('<manifold-data-deprovision-button>', () => {
 
     it('will trigger a dom event on successful deprovision', async () => {
       fetchMock.mock(`${connections.prod.gateway}/id/resource/${Resource.id}`, {
-        status: 200,
-        body: Resource,
+        status: 202,
       });
 
       const page = await newSpecPage({

--- a/src/utils/restFetch.ts
+++ b/src/utils/restFetch.ts
@@ -40,6 +40,10 @@ export const createRestFetch = ({
       body: JSON.stringify(args.body),
     });
 
+    if ([202, 203, 204].includes(response.status)) {
+      return {};
+    }
+
     const body = await response.json();
     if (response.status >= 200 && response.status < 300) {
       return body;


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

The deprovision request was causing an error in UI because it sends a 202 with no content in the response, but the client code is assuming that there will be a JSON body. 

This change ensures that a 202 response with no body will not get all explody.

## Testing
<!-- For someone unfamiliar with the issue, how should this be tested? -->

Two ways to test.

1. Pull down the branch and comment out the code that was added to `restFetch.ts`, then run the test for `manifold-data-deprovision-button`. The test should fail. Then uncomment the code and the test should pass.
2. Try this out in Render Dashboard and make sure you can deprovision.