### PR TITLE
Rework how the resources list work with operations

### DIFF
--- a/docs/docs/components/manifold-resource-list.md
+++ b/docs/docs/components/manifold-resource-list.md
@@ -21,7 +21,13 @@ example: |
           label="my-resource-3" 
           logo="https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png" 
           resource-id="1234" 
-          resource-status="unavailable"
+          resource-status="resize"
+        ></manifold-resource-card-view>
+        <manifold-resource-card-view
+          label="my-resource-4" 
+          logo="https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png" 
+          resource-id="1234" 
+          resource-status="deprovision"
         ></manifold-resource-card-view>
       </div>
     </manifold-resource-list>

--- a/src/components/manifold-resource-card-view/manifold-resource-card-view.css
+++ b/src/components/manifold-resource-card-view/manifold-resource-card-view.css
@@ -118,11 +118,11 @@
     --status-color: var(--manifold-color-info);
   }
 
-  &[data-status='degraded'] {
+  &[data-status='resize'] {
     --status-color: var(--manifold-color-warn);
   }
 
-  &[data-status='offline'] {
+  &[data-status='deprovision'], &[data-status='offline'] {
     --status-color: var(--manifold-color-error);
   }
 }

--- a/src/components/manifold-resource-card-view/manifold-resource-card-view.e2e.ts
+++ b/src/components/manifold-resource-card-view/manifold-resource-card-view.e2e.ts
@@ -40,6 +40,6 @@ describe('<manifold-resource-card>', () => {
     });
     const el = await page.find('manifold-resource-card-view >>> [itemprop="status"]');
 
-    expect(el.innerText).toBe('Provision');
+    expect(el.innerText).toBe('Provisioning');
   });
 });

--- a/src/components/manifold-resource-card-view/manifold-resource-card-view.tsx
+++ b/src/components/manifold-resource-card-view/manifold-resource-card-view.tsx
@@ -14,8 +14,17 @@ interface EventDetail {
 
 const AVAILABLE = 'available';
 const PROVISIONING = 'provision';
-const DEGRADED = 'degraded';
+const RESIZING = 'resize';
+const DEPROVISION = 'deprovision';
 const OFFLINE = 'offline';
+
+const statusToText = {
+  [AVAILABLE]: 'Available',
+  [PROVISIONING]: 'Provisioning',
+  [RESIZING]: 'Resizing',
+  [DEPROVISION]: 'Deprovisioning',
+  [OFFLINE]: 'Offline',
+};
 
 @Component({
   tag: 'manifold-resource-card-view',
@@ -56,16 +65,32 @@ export class ManifoldResourceCardView {
     return this.resourceLinkFormat.replace(/:resource/gi, this.label);
   }
 
-  get status(): string {
+  get status() {
     if (
       this.resourceStatus &&
       (this.resourceStatus === AVAILABLE ||
         this.resourceStatus === PROVISIONING ||
-        this.resourceStatus === DEGRADED)
+        this.resourceStatus === RESIZING ||
+        this.resourceStatus === DEPROVISION)
     ) {
       return this.resourceStatus;
     }
     return OFFLINE;
+  }
+
+  get statusText() {
+    switch (this.resourceStatus) {
+      case AVAILABLE:
+        return statusToText[AVAILABLE];
+      case PROVISIONING:
+        return statusToText[PROVISIONING];
+      case RESIZING:
+        return statusToText[RESIZING];
+      case DEPROVISION:
+        return statusToText[DEPROVISION];
+      default:
+        return statusToText[OFFLINE];
+    }
   }
 
   async fetchResourceId(resourceLabel: string) {
@@ -122,7 +147,7 @@ export class ManifoldResourceCardView {
         <div class="status-box">
           <div class="status" data-status={this.status}>
             <div class="inner" itemprop="status">
-              {this.status[0].toUpperCase() + this.status.slice(1)}
+              {this.statusText}
             </div>
           </div>
         </div>

--- a/src/components/manifold-resource-card-view/manifold-resource-card-view.tsx
+++ b/src/components/manifold-resource-card-view/manifold-resource-card-view.tsx
@@ -68,10 +68,7 @@ export class ManifoldResourceCardView {
   get status() {
     if (
       this.resourceStatus &&
-      (this.resourceStatus === AVAILABLE ||
-        this.resourceStatus === PROVISIONING ||
-        this.resourceStatus === RESIZING ||
-        this.resourceStatus === DEPROVISION)
+      [AVAILABLE, PROVISIONING, RESIZING, DEPROVISION].includes(this.resourceStatus)
     ) {
       return this.resourceStatus;
     }


### PR DESCRIPTION
Work is related to manifoldco/engineering#8832

## Reason for change
We now use the code from the ZEIT hackahton, slightly modified to fit our needs. This is still FAR from perfect, but the list will now properly show provisioning and resizing operations if they exist. It will also show the data we want when deprovisoning.

The optimal next step right now would be to implement a GraphQl endpoint and rework components that use the resources rest endpoints to use GraphQl and not worry about operations anymore.

## Testing
Try testing with the render dashboard, it should show the proper behavior.
