### PR TITLE
 Add a timeout on the resource container to keep fetching until valid

### DIFF
--- a/docs/docs/advanced/resource-details.md
+++ b/docs/docs/advanced/resource-details.md
@@ -45,6 +45,9 @@ a `manifold-resource-container` component with access to the resource label.
   <manifold-resource-credentials></manifold-resource-credentials>
 </resource-mock-resource>
 
+## Refetching until the resource is valid
+The `refetch-until-valid` property on the `resource-container` can be used to force the container to refetch the resource until it has found one and the status of that resource is available. This is useful for reloading the page until the resource has finished resizing or provisioning for example.
+
 ## The resource credentials
 
 The [`manifold-credentials`](/components/credentials) component can be used inside the container without any attribute by

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -480,6 +480,10 @@ export namespace Components {
   }
   interface ManifoldResourceContainer {
     /**
+    * Set whether or not to refetch the resource from the api until it is in an available and valid state
+    */
+    'refetchUntilValid': boolean;
+    /**
     * Which resource does this belong to?
     */
     'resourceLabel'?: string;
@@ -539,6 +543,8 @@ export namespace Components {
     'loading': boolean;
   }
   interface ManifoldResourceStatus {
+    'data'?: Gateway.Resource;
+    'loading': boolean;
     'size'?: 'small' | 'medium';
   }
   interface ManifoldResourceStatusView {
@@ -1538,6 +1544,10 @@ declare namespace LocalJSX {
   }
   interface ManifoldResourceContainer extends JSXBase.HTMLAttributes<HTMLManifoldResourceContainerElement> {
     /**
+    * Set whether or not to refetch the resource from the api until it is in an available and valid state
+    */
+    'refetchUntilValid'?: boolean;
+    /**
     * Which resource does this belong to?
     */
     'resourceLabel'?: string;
@@ -1608,6 +1618,8 @@ declare namespace LocalJSX {
     'onManifold-ssoButton-success'?: (event: CustomEvent<any>) => void;
   }
   interface ManifoldResourceStatus extends JSXBase.HTMLAttributes<HTMLManifoldResourceStatusElement> {
+    'data'?: Gateway.Resource;
+    'loading'?: boolean;
     'size'?: 'small' | 'medium';
   }
   interface ManifoldResourceStatusView extends JSXBase.HTMLAttributes<HTMLManifoldResourceStatusViewElement> {

--- a/src/components/manifold-resource-container/manifold-resource-container.spec.ts
+++ b/src/components/manifold-resource-container/manifold-resource-container.spec.ts
@@ -79,7 +79,7 @@ describe('<manifold-resource-credentials>', () => {
   it('will refetch the resource after load if given an invalid resource', async () => {
     const resourceLabel = 'test-resource';
     // @ts-ignore
-    window.setTimeout = jest.fn(call => call());
+    page.win.setTimeout = jest.fn(call => call());
 
     fetchMock
       .once(`${connections.prod.gateway}/resources/me/${resourceLabel}`, {})
@@ -100,7 +100,7 @@ describe('<manifold-resource-credentials>', () => {
   it('will refetch the resource after load if it received an error', async () => {
     const resourceLabel = 'test-resource';
     // @ts-ignore
-    window.setTimeout = jest.fn(call => call());
+    page.win.setTimeout = jest.fn(call => call());
 
     fetchMock
       .once(`${connections.prod.gateway}/resources/me/${resourceLabel}`, 404)

--- a/src/components/manifold-resource-container/manifold-resource-container.spec.ts
+++ b/src/components/manifold-resource-container/manifold-resource-container.spec.ts
@@ -94,6 +94,27 @@ describe('<manifold-resource-credentials>', () => {
     expect(fetchMock.called(`${connections.prod.gateway}/resources/me/${resourceLabel}`)).toBe(
       true
     );
-    expect(window.setTimeout).toHaveBeenCalled();
+    expect(window.setTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it('will refetch the resource after load if it received an error', async () => {
+    const resourceLabel = 'test-resource';
+    // @ts-ignore
+    window.setTimeout = jest.fn(call => call());
+
+    fetchMock
+      .once(`${connections.prod.gateway}/resources/me/${resourceLabel}`, 404)
+      .once(`${connections.prod.gateway}/resources/me/${resourceLabel}`, GatewayResource);
+
+    const root = page.root as HTMLElement;
+    element.resourceLabel = resourceLabel;
+    element.refetchUntilValid = true;
+    root.appendChild(element);
+    await page.waitForChanges();
+
+    expect(fetchMock.called(`${connections.prod.gateway}/resources/me/${resourceLabel}`)).toBe(
+      true
+    );
+    expect(window.setTimeout).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/manifold-resource-container/manifold-resource-container.spec.ts
+++ b/src/components/manifold-resource-container/manifold-resource-container.spec.ts
@@ -1,17 +1,35 @@
+import { newSpecPage, SpecPage } from '@stencil/core/testing';
+import fetchMock from 'fetch-mock';
+
 import { ManifoldResourceContainer } from './manifold-resource-container';
+import { connections } from '../../utils/connections';
+import { createRestFetch } from '../../utils/restFetch';
+import { GatewayResource } from '../../spec/mock/gateway';
+
+fetchMock.config.overwriteRoutes = false;
 
 describe('<manifold-resource-credentials>', () => {
-  it('fetches resource on load', () => {
-    const resourceLabel = 'my-resource';
+  let page: SpecPage;
+  let element: HTMLManifoldResourceContainerElement;
 
-    const resourceCreds = new ManifoldResourceContainer();
-    resourceCreds.fetchResource = jest.fn();
-    resourceCreds.resourceLabel = resourceLabel;
-    resourceCreds.componentWillLoad();
-    expect(resourceCreds.fetchResource).toHaveBeenCalledWith(resourceLabel);
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [ManifoldResourceContainer],
+      html: `<div></div>`,
+    });
+    element = page.doc.createElement('manifold-resource-container');
+    element.restFetch = createRestFetch({
+      getAuthToken: jest.fn(() => '1234'),
+      wait: 10,
+      setAuthToken: jest.fn(),
+    });
   });
 
-  it('fetches resource  on change', () => {
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
+  it('fetches resource on label change', () => {
     const newResource = 'new-resource';
 
     const resourceCreds = new ManifoldResourceContainer();
@@ -19,5 +37,63 @@ describe('<manifold-resource-credentials>', () => {
     resourceCreds.resourceLabel = 'old-resource';
     resourceCreds.resourceChange(newResource);
     expect(resourceCreds.fetchResource).toHaveBeenCalledWith(newResource);
+  });
+
+  it('fetches resource on refetch change', () => {
+    const resourceCreds = new ManifoldResourceContainer();
+    resourceCreds.fetchResource = jest.fn();
+    resourceCreds.resourceLabel = 'old-resource';
+    resourceCreds.refreshChange(true);
+    expect(resourceCreds.fetchResource).toHaveBeenCalledWith('old-resource');
+  });
+
+  it('will fetch the resource on load', async () => {
+    const resourceLabel = 'test-resource';
+
+    fetchMock.mock(`${connections.prod.gateway}/resources/me/${resourceLabel}`, GatewayResource);
+
+    const root = page.root as HTMLElement;
+    element.resourceLabel = resourceLabel;
+    root.appendChild(element);
+    await page.waitForChanges();
+
+    expect(fetchMock.called(`${connections.prod.gateway}/resources/me/${resourceLabel}`)).toBe(
+      true
+    );
+  });
+
+  it('will not fetch the resource if the component has no resource label', async () => {
+    const resourceLabel = 'test-resource';
+
+    fetchMock.mock(`${connections.prod.gateway}/resources/me/${resourceLabel}`, GatewayResource);
+
+    const root = page.root as HTMLElement;
+    root.appendChild(element);
+    await page.waitForChanges();
+
+    expect(fetchMock.called(`${connections.prod.gateway}/resources/me/${resourceLabel}`)).toBe(
+      false
+    );
+  });
+
+  it('will refetch the resource after load if given an invalid resource', async () => {
+    const resourceLabel = 'test-resource';
+    // @ts-ignore
+    window.setTimeout = jest.fn(call => call());
+
+    fetchMock
+      .once(`${connections.prod.gateway}/resources/me/${resourceLabel}`, {})
+      .once(`${connections.prod.gateway}/resources/me/${resourceLabel}`, GatewayResource);
+
+    const root = page.root as HTMLElement;
+    element.resourceLabel = resourceLabel;
+    element.refetchUntilValid = true;
+    root.appendChild(element);
+    await page.waitForChanges();
+
+    expect(fetchMock.called(`${connections.prod.gateway}/resources/me/${resourceLabel}`)).toBe(
+      true
+    );
+    expect(window.setTimeout).toHaveBeenCalled();
   });
 });

--- a/src/components/manifold-resource-container/manifold-resource-container.tsx
+++ b/src/components/manifold-resource-container/manifold-resource-container.tsx
@@ -23,10 +23,14 @@ export class ManifoldResourceContainer {
     this.fetchResource(newName);
   }
 
-  componentWillLoad() {
-    if (this.resourceLabel) {
+  @Watch('refetchUntilValid') refreshChange(newRefresh: boolean) {
+    if (newRefresh && (!this.resource || this.resource.state !== 'available')) {
       this.fetchResource(this.resourceLabel);
     }
+  }
+
+  componentWillLoad() {
+    return this.fetchResource(this.resourceLabel);
   }
 
   componentDidUnload() {
@@ -34,7 +38,7 @@ export class ManifoldResourceContainer {
   }
 
   fetchResource = async (resourceLabel?: string) => {
-    if (!this.restFetch || this.resourceLabel) {
+    if (!this.restFetch || !this.resourceLabel) {
       return;
     }
 

--- a/src/components/manifold-resource-container/manifold-resource-container.tsx
+++ b/src/components/manifold-resource-container/manifold-resource-container.tsx
@@ -49,6 +49,11 @@ export class ManifoldResourceContainer {
     });
 
     if (response instanceof Error) {
+      // In case we actually want to keep fetching on an error
+      if (this.refetchUntilValid) {
+        this.timeout = window.setTimeout(() => this.fetchResource(this.resourceLabel), 3000);
+      }
+
       console.error(response);
       return;
     }

--- a/src/components/manifold-resource-status/manifold-resource-status.tsx
+++ b/src/components/manifold-resource-status/manifold-resource-status.tsx
@@ -12,7 +12,6 @@ export class ManifoldResourceStatus {
 
   @logger()
   render() {
-    console.log('resource status', this.loading);
     return (
       <manifold-resource-status-view
         size={this.size}

--- a/src/components/manifold-resource-status/manifold-resource-status.tsx
+++ b/src/components/manifold-resource-status/manifold-resource-status.tsx
@@ -1,24 +1,26 @@
 import { h, Component, Prop } from '@stencil/core';
 
-import Tunnel, { ResourceState } from '../../data/resource';
+import Tunnel from '../../data/resource';
 import logger from '../../utils/logger';
+import { Gateway } from '../../types/gateway';
 
 @Component({ tag: 'manifold-resource-status' })
 export class ManifoldResourceStatus {
+  @Prop() data?: Gateway.Resource;
+  @Prop() loading: boolean = true;
   @Prop() size?: 'small' | 'medium' = 'medium';
 
   @logger()
   render() {
+    console.log('resource status', this.loading);
     return (
-      <Tunnel.Consumer>
-        {(state: ResourceState) => (
-          <manifold-resource-status-view
-            size={this.size}
-            resourceState={state.data && (state.data.state as string)}
-            loading={state.loading}
-          />
-        )}
-      </Tunnel.Consumer>
+      <manifold-resource-status-view
+        size={this.size}
+        resourceState={this.data && (this.data.state as string)}
+        loading={this.loading}
+      />
     );
   }
 }
+
+Tunnel.injectProps(ManifoldResourceStatus, ['data', 'loading']);

--- a/src/spec/mock/gateway.ts
+++ b/src/spec/mock/gateway.ts
@@ -42,6 +42,7 @@ export const GatewayResource: Gateway.Resource = {
   id: Resource.id,
   ...Resource.body,
   type: 'resource',
+  state: 'available',
   owner: {
     id: '1',
     name: 'test',


### PR DESCRIPTION
Work is related to manifoldco/engineering#8832

## Reason for change
This will enable the container to fetch a resource that is still provisioning or is having an operation run on it. It will keep fetching until "done" to ensure that the container can handle cases like being rendered on a provisioning resource.

## Testing
Test with the render dashboard after provisioning a resource to see it in action.
