### PR TITLE
Plan Selector free plans filtering

### DIFF
--- a/docs/docs/components/manifold-plan-selector.md
+++ b/docs/docs/components/manifold-plan-selector.md
@@ -12,7 +12,7 @@ example: |
 Display the plans for a product.
 
 ```html
-<manifold-plan-selector product-label="jawsdb-mysql" />
+<manifold-plan-selector product-label="jawsdb-mysql"></manifold-plan-selector>
 ```
 
 You can find the `:product` label for each at
@@ -53,6 +53,12 @@ The following events are emitted:
 | `manifold-planSelector-change` | Fires whenever a user makes a change.                                                                                      | `planID`, `planLabel`, `planName`, `productLabel`, `features` |
 | `manifold-planSelector-load`   | Identical to `-update` above, but this fires once on DOM mount to set the initial state (i.e. user hasn’t interacted yet). | `planID`, `planLabel`, `planName`, `productLabel`, `features` |
 
+## Free plans only
+
+```html
+<manifold-plan-selector free-plans></manifold-plan-selector>
+```
+
 ## Regions
 
 Most of our products are regionless, but some plans let users specify the
@@ -60,7 +66,9 @@ region. In this case, you may optionally want to order the regions with the
 `regions` attribute:
 
 ```html
-<manifold-plan-selector regions="aws-eu-west-1,aws-eu-west-2,aws-us-east-1,aws-us-east-2" />
+<manifold-plan-selector
+  regions="aws-eu-west-1,aws-eu-west-2,aws-us-east-1,aws-us-east-2"
+></manifold-plan-selector>
 ```
 
 Regions will be ordered in the order specified. Any regions not mentioned

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -409,9 +409,9 @@ export namespace Components {
   }
   interface ManifoldPlanSelector {
     /**
-    * (TEMPORARY) Which platform is this for?
+    * Show only free plans?
     */
-    'platform'?: 'do';
+    'freePlans'?: boolean;
     /**
     * URL-friendly slug (e.g. `"jawsdb-mysql"`)
     */
@@ -1475,9 +1475,9 @@ declare namespace LocalJSX {
   }
   interface ManifoldPlanSelector extends JSXBase.HTMLAttributes<HTMLManifoldPlanSelectorElement> {
     /**
-    * (TEMPORARY) Which platform is this for?
+    * Show only free plans?
     */
-    'platform'?: 'do';
+    'freePlans'?: boolean;
     /**
     * URL-friendly slug (e.g. `"jawsdb-mysql"`)
     */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -409,6 +409,10 @@ export namespace Components {
   }
   interface ManifoldPlanSelector {
     /**
+    * (TEMPORARY) Which platform is this for?
+    */
+    'platform'?: 'do';
+    /**
     * URL-friendly slug (e.g. `"jawsdb-mysql"`)
     */
     'productLabel'?: string;
@@ -1470,6 +1474,10 @@ declare namespace LocalJSX {
     'selectedPlanId'?: string;
   }
   interface ManifoldPlanSelector extends JSXBase.HTMLAttributes<HTMLManifoldPlanSelectorElement> {
+    /**
+    * (TEMPORARY) Which platform is this for?
+    */
+    'platform'?: 'do';
     /**
     * URL-friendly slug (e.g. `"jawsdb-mysql"`)
     */

--- a/src/components/manifold-plan-selector/manifold-plan-selector.tsx
+++ b/src/components/manifold-plan-selector/manifold-plan-selector.tsx
@@ -11,10 +11,10 @@ import { planSort } from '../../utils/plan';
 @Component({ tag: 'manifold-plan-selector' })
 export class ManifoldPlanSelector {
   @Element() el: HTMLElement;
+  /** Show only free plans? */
+  @Prop() freePlans?: boolean = false;
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() restFetch?: RestFetch;
-  /** (TEMPORARY) Which platform is this for? */
-  @Prop() platform?: 'do';
   /** URL-friendly slug (e.g. `"jawsdb-mysql"`) */
   @Prop() productLabel?: string;
   /** Specify region order */
@@ -86,8 +86,7 @@ export class ManifoldPlanSelector {
       return;
     }
 
-    // TODO: remove “platform” that is filtering plans, and replace with API call
-    this.plans = planSort(response, { platform: this.platform });
+    this.plans = planSort(response, { free: this.freePlans });
   }
 
   async fetchResource(resourceLabel: string) {

--- a/src/components/manifold-plan-selector/manifold-plan-selector.tsx
+++ b/src/components/manifold-plan-selector/manifold-plan-selector.tsx
@@ -13,6 +13,8 @@ export class ManifoldPlanSelector {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() restFetch?: RestFetch;
+  /** (TEMPORARY) Which platform is this for? */
+  @Prop() platform?: 'do';
   /** URL-friendly slug (e.g. `"jawsdb-mysql"`) */
   @Prop() productLabel?: string;
   /** Specify region order */
@@ -84,7 +86,8 @@ export class ManifoldPlanSelector {
       return;
     }
 
-    this.plans = planSort(response);
+    // TODO: remove “platform” that is filtering plans, and replace with API call
+    this.plans = planSort(response, { platform: this.platform });
   }
 
   async fetchResource(resourceLabel: string) {

--- a/src/utils/plan.spec.ts
+++ b/src/utils/plan.spec.ts
@@ -183,6 +183,6 @@ describe('plan sort function', () => {
   });
 
   it('sort() handles temporary platform designation', () => {
-    expect(planSort(rightOrder, { platform: 'do' })).toEqual([freePlan, fauxFreePlan]);
+    expect(planSort(rightOrder, { free: true })).toEqual([freePlan, fauxFreePlan]);
   });
 });

--- a/src/utils/plan.spec.ts
+++ b/src/utils/plan.spec.ts
@@ -181,4 +181,8 @@ describe('plan sort function', () => {
     planSort(clone);
     expect(clone).toEqual(wrongOrder);
   });
+
+  it('sort() handles temporary platform designation', () => {
+    expect(planSort(rightOrder, { platform: 'do' })).toEqual([freePlan, fauxFreePlan]);
+  });
 });

--- a/src/utils/plan.spec.ts
+++ b/src/utils/plan.spec.ts
@@ -176,13 +176,13 @@ describe('plan sort function', () => {
     expect(planSort(wrongOrder)).toEqual(rightOrder);
   });
 
-  it('sort() doesn’t reorder original reference', () => {
+  it('doesn’t reorder original reference', () => {
     const clone = [...wrongOrder];
     planSort(clone);
     expect(clone).toEqual(wrongOrder);
   });
 
-  it('sort() handles temporary platform designation', () => {
+  it('filters to free-only plans', () => {
     expect(planSort(rightOrder, { free: true })).toEqual([freePlan, fauxFreePlan]);
   });
 });

--- a/src/utils/plan.ts
+++ b/src/utils/plan.ts
@@ -276,7 +276,7 @@ export function initialFeatures(features: Catalog.ExpandedFeature[]): Gateway.Fe
  */
 export function planSort(
   plans: Catalog.ExpandedPlan[],
-  options?: { platform?: 'do' }
+  options?: { free?: boolean }
 ): Catalog.ExpandedPlan[] {
   // Clone array to prevent accidental mutation with sort()
   const sorted = [...plans].sort((a, b) => {
@@ -299,8 +299,8 @@ export function planSort(
     return (a.body.defaultCost || a.body.cost) - (b.body.defaultCost || b.body.cost);
   });
 
-  // TODO: remove this platform-specific filtering, and handle via API
-  if (options && options.platform === 'do') {
+  // TODO: return only free plans
+  if (options && options.free === true) {
     return plans.filter(
       ({ body }) =>
         body.free === true || body.defaultCost === 0 || (!body.defaultCost && body.cost === 0)

--- a/src/utils/plan.ts
+++ b/src/utils/plan.ts
@@ -299,7 +299,7 @@ export function planSort(
     return (a.body.defaultCost || a.body.cost) - (b.body.defaultCost || b.body.cost);
   });
 
-  // TODO: return only free plans
+  // TODO: remove when we have API-level filtering
   if (options && options.free === true) {
     return plans.filter(
       ({ body }) =>

--- a/src/utils/plan.ts
+++ b/src/utils/plan.ts
@@ -274,9 +274,12 @@ export function initialFeatures(features: Catalog.ExpandedFeature[]): Gateway.Fe
 /**
  * Sort plans
  */
-export function planSort(plans: Catalog.ExpandedPlan[]): Catalog.ExpandedPlan[] {
+export function planSort(
+  plans: Catalog.ExpandedPlan[],
+  options?: { platform?: 'do' }
+): Catalog.ExpandedPlan[] {
   // Clone array to prevent accidental mutation with sort()
-  return [...plans].sort((a, b) => {
+  const sorted = [...plans].sort((a, b) => {
     // If comparing 2 free plans, they both cost 0 anyway so don’t reorder
     if (a.body.free === true && b.body.free === true) {
       return 0;
@@ -295,6 +298,16 @@ export function planSort(plans: Catalog.ExpandedPlan[]): Catalog.ExpandedPlan[] 
     // By default, sort by cost
     return (a.body.defaultCost || a.body.cost) - (b.body.defaultCost || b.body.cost);
   });
+
+  // TODO: remove this platform-specific filtering, and handle via API
+  if (options && options.platform === 'do') {
+    return plans.filter(
+      ({ body }) =>
+        body.free === true || body.defaultCost === 0 || (!body.defaultCost && body.cost === 0)
+    );
+  }
+
+  return sorted;
 }
 
 /**

--- a/stories/manifold-plan-selector.stories.js
+++ b/stories/manifold-plan-selector.stories.js
@@ -10,6 +10,10 @@ storiesOf('Plan Selector', module)
     'Blitline',
     () => '<manifold-plan-selector product-label="blitline"></manifold-plan-selector>'
   )
+  .add(
+    'DO filtering',
+    () => '<manifold-plan-selector product-label="logdna" platform="do"></manifold-plan-selector>'
+  )
   .add('LogDNA', () => '<manifold-plan-selector product-label="logdna"></manifold-plan-selector>')
   .add('Mailgun', () => '<manifold-plan-selector product-label="mailgun"></manifold-plan-selector>')
   .add(

--- a/stories/manifold-plan-selector.stories.js
+++ b/stories/manifold-plan-selector.stories.js
@@ -11,8 +11,8 @@ storiesOf('Plan Selector', module)
     () => '<manifold-plan-selector product-label="blitline"></manifold-plan-selector>'
   )
   .add(
-    'DO filtering',
-    () => '<manifold-plan-selector product-label="logdna" platform="do"></manifold-plan-selector>'
+    'LogDNA (free plan)',
+    () => '<manifold-plan-selector product-label="logdna" free-plans></manifold-plan-selector>'
   )
   .add('LogDNA', () => '<manifold-plan-selector product-label="logdna"></manifold-plan-selector>')
   .add('Mailgun', () => '<manifold-plan-selector product-label="mailgun"></manifold-plan-selector>')


### PR DESCRIPTION
## Reason for change
We need to add free plan filtering that satisfy the following requirements:

- [ ] No changes are required on the user end end (i.e. the list should be able to be updated without changing any attributes)
- [ ] It’s a temporary shim until it’s supported by the API

<img width="1226" alt="Screen Shot 2019-08-06 at 15 48 49" src="https://user-images.githubusercontent.com/1369770/62576514-a5d4c000-b862-11e9-8d12-316b10e2f964.png">

## Testing
Test the `<manifold-plan-selector>` component with the new `platform` attribute, and see if the plan list filters (free plans only—LogDNA, Mailgun, etc.).

_Note: until #349 merges, you’ll have to manually authenticate into Storybook to see the plan selector component:_

- Log into dashboard.manifold.co
- In your JS Console, run `localStorage.getItem('manifold_api_token')`. **Copy** that value (including the surrounding `""`, if there are any).
- Go back to the Storybook preview link from this PR. In that page, open a JS Console, and run `localStorage.setItem('manifold_api_token', MYTOKEN)`, pasting in the value from dashboard.manifold.co instead of `MYTOKEN` (add surrounding quotes if they were missing before)
- Refresh. You should see everything load now.
