### PR TITLE
Add the terms of service if provided to the product page component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added a `refetch-until-valid` property on the `resource-container` component to allow users to reload this component until the found resource exists and is of state `available`.
+- Added the terms of service to the product page component.
 
 ## [v0.5.2]
 ### Added

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added a `refetch-until-valid` property on the `resource-container` component to allow users to reload this component until the found resource exists and is of state `available`.
+- Added the terms of service to the product page component.
 
 ## [v0.5.2]
 ### Added

--- a/src/components/manifold-product-page/manifold-product-page.tsx
+++ b/src/components/manifold-product-page/manifold-product-page.tsx
@@ -1,5 +1,5 @@
 import { h, Component, Prop } from '@stencil/core';
-import { arrow_up_right, book, life_buoy } from '@manifoldco/icons';
+import { arrow_up_right, book, life_buoy, file_text } from '@manifoldco/icons';
 import { Catalog } from '../../types/catalog';
 import skeletonProduct from '../../data/product';
 import { categoryIcon } from '../../utils/marketplace';
@@ -26,7 +26,15 @@ export class ManifoldProductPage {
   @logger()
   render() {
     if (this.product) {
-      const { documentation_url, support_email, name, label, logo_url, tags } = this.product.body;
+      const {
+        documentation_url,
+        support_email,
+        name,
+        label,
+        logo_url,
+        tags,
+        terms,
+      } = this.product.body;
       const gradient = `var(--manifold-g-${label}, var(--manifold-g-default))`;
 
       return (
@@ -81,6 +89,19 @@ export class ManifoldProductPage {
                       <manifold-icon class="external-link-icon" icon={arrow_up_right} margin-left />
                     </a>
                   </div>
+                  {terms.provided && (
+                    <div class="provider-link">
+                      <a href={terms.url} target="_blank" rel="noopener noreferrer">
+                        <manifold-icon icon={file_text} margin-right />
+                        Terms of service
+                        <manifold-icon
+                          class="external-link-icon"
+                          icon={arrow_up_right}
+                          margin-left
+                        />
+                      </a>
+                    </div>
+                  )}
                 </div>
               </div>
             </aside>


### PR DESCRIPTION
Work is related to manifoldco/engineering#8916

## Reason for change
Some providers have terms of services that need to be displayed on the product details component for legal reasons. This adds those terms if provided.

![Capture d’écran 2019-08-07 à 10 22 34](https://user-images.githubusercontent.com/20424444/62631023-0bc25580-b8fe-11e9-8040-7403ee6c7f89.png)

## Testing
Test with the docs or storybook. Aiven cassandra is a product with terms.
