### PR TITLE
Update restFetch to report errors

### DIFF
--- a/src/components/manifold-active-plan/manifold-active-plan-happo.ts
+++ b/src/components/manifold-active-plan/manifold-active-plan-happo.ts
@@ -19,7 +19,6 @@ export const jawsDB = async () => {
       const selector = details.shadowRoot.querySelector('manifold-region-selector');
       if (selector) {
         selector.regions = fromJSON(regions);
-        selector.restFetch = () => Promise.resolve(undefined);
 
         document.body.appendChild(plan);
 

--- a/src/components/manifold-active-plan/manifold-active-plan-happo.ts
+++ b/src/components/manifold-active-plan/manifold-active-plan-happo.ts
@@ -19,6 +19,7 @@ export const jawsDB = async () => {
       const selector = details.shadowRoot.querySelector('manifold-region-selector');
       if (selector) {
         selector.regions = fromJSON(regions);
+        selector.restFetch = () => Promise.resolve(undefined);
 
         document.body.appendChild(plan);
 

--- a/src/components/manifold-credentials/manifold-credentials.tsx
+++ b/src/components/manifold-credentials/manifold-credentials.tsx
@@ -51,7 +51,7 @@ export class ManifoldCredentials {
       endpoint: `/resources/?me&label=${resourceLabel}`,
     });
 
-    if (!Array.isArray(resources) || !resources.length) {
+    if (!resources || !resources.length) {
       console.error(`${resourceLabel} resource not found`);
       return;
     }

--- a/src/components/manifold-credentials/manifold-credentials.tsx
+++ b/src/components/manifold-credentials/manifold-credentials.tsx
@@ -37,11 +37,6 @@ export class ManifoldCredentials {
       endpoint: `/credentials/?resource_id=${this.resourceId}`,
     });
 
-    if (response instanceof Error) {
-      console.error(response);
-      return;
-    }
-
     this.credentials = response;
     this.loading = false;
   };
@@ -51,16 +46,10 @@ export class ManifoldCredentials {
       return;
     }
 
-    const response = await this.restFetch<Marketplace.Resource[]>({
+    const resources = await this.restFetch<Marketplace.Resource[]>({
       service: 'marketplace',
       endpoint: `/resources/?me&label=${resourceLabel}`,
     });
-
-    if (response instanceof Error) {
-      console.error(response);
-      return;
-    }
-    const resources: Marketplace.Resource[] = response;
 
     if (!Array.isArray(resources) || !resources.length) {
       console.error(`${resourceLabel} resource not found`);

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
@@ -175,13 +175,15 @@ describe('<manifold-data-deprovision-button>', () => {
       const instance = page.rootInstance as ManifoldDataDeprovisionButton;
       instance.error.emit = jest.fn();
 
-      await instance.deprovision();
-
-      expect(fetchMock.called(`${connections.prod.gateway}/id/resource/${Resource.id}`)).toBe(true);
-      expect(instance.error.emit).toHaveBeenCalledWith({
-        message: 'ohnoes',
-        resourceLabel: 'test',
-        resourceId: Resource.id,
+      return instance.deprovision().catch(() => {
+        expect(fetchMock.called(`${connections.prod.gateway}/id/resource/${Resource.id}`)).toBe(
+          true
+        );
+        expect(instance.error.emit).toHaveBeenCalledWith({
+          message: 'ohnoes',
+          resourceLabel: 'test',
+          resourceId: Resource.id,
+        });
       });
     });
 

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
@@ -175,6 +175,7 @@ describe('<manifold-data-deprovision-button>', () => {
       const instance = page.rootInstance as ManifoldDataDeprovisionButton;
       instance.error.emit = jest.fn();
 
+      expect.assertions(2);
       return instance.deprovision().catch(() => {
         expect(fetchMock.called(`${connections.prod.gateway}/id/resource/${Resource.id}`)).toBe(
           true

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
@@ -60,11 +60,19 @@ export class ManifoldDataDeprovisionButton {
       resourceLabel: this.resourceLabel || '',
     });
 
-    await this.restFetch({
-      service: 'gateway',
-      endpoint: `/id/resource/${this.resourceId}`,
-      options: { method: 'DELETE' },
-    }).catch(e => {
+    try {
+      await this.restFetch({
+        service: 'gateway',
+        endpoint: `/id/resource/${this.resourceId}`,
+        options: { method: 'DELETE' },
+      });
+      const success: SuccessMessage = {
+        message: `${this.resourceLabel} successfully deprovisioned`,
+        resourceLabel: this.resourceLabel || '',
+        resourceId: this.resourceId,
+      };
+      this.success.emit(success);
+    } catch (e) {
       const error: ErrorMessage = {
         message: e.message,
         resourceLabel: this.resourceLabel || '',
@@ -72,14 +80,8 @@ export class ManifoldDataDeprovisionButton {
       };
 
       this.error.emit(error);
-    });
-
-    const success: SuccessMessage = {
-      message: `${this.resourceLabel} successfully deprovisioned`,
-      resourceLabel: this.resourceLabel || '',
-      resourceId: this.resourceId,
-    };
-    this.success.emit(success);
+      throw error;
+    }
   }
 
   async fetchResourceId(resourceLabel: string) {
@@ -92,7 +94,7 @@ export class ManifoldDataDeprovisionButton {
       endpoint: `/resources/?me&label=${resourceLabel}`,
     });
 
-    if (!Array.isArray(response) || !response.length) {
+    if (!response || !response.length) {
       console.error(`${resourceLabel} product not found`);
       return;
     }

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
@@ -16,7 +16,7 @@ interface SuccessMessage {
 interface ErrorMessage {
   message: string;
   resourceLabel: string;
-  resourceId: string;
+  resourceId?: string;
 }
 
 @Component({ tag: 'manifold-data-deprovision-button' })
@@ -60,21 +60,19 @@ export class ManifoldDataDeprovisionButton {
       resourceLabel: this.resourceLabel || '',
     });
 
-    const response = await this.restFetch({
+    await this.restFetch({
       service: 'gateway',
       endpoint: `/id/resource/${this.resourceId}`,
       options: { method: 'DELETE' },
-    });
-
-    if (response instanceof Error) {
+    }).catch(e => {
       const error: ErrorMessage = {
-        message: response.message,
+        message: e.message,
         resourceLabel: this.resourceLabel || '',
         resourceId: this.resourceId,
       };
       this.error.emit(error);
       return;
-    }
+    });
 
     const success: SuccessMessage = {
       message: `${this.resourceLabel} successfully deprovisioned`,
@@ -94,18 +92,12 @@ export class ManifoldDataDeprovisionButton {
       endpoint: `/resources/?me&label=${resourceLabel}`,
     });
 
-    if (response instanceof Error) {
-      console.error(response);
-      return;
-    }
-    const resources: Marketplace.Resource[] = response;
-
-    if (!Array.isArray(resources) || !resources.length) {
+    if (!Array.isArray(response) || !response.length) {
       console.error(`${resourceLabel} product not found`);
       return;
     }
 
-    this.resourceId = resources[0].id;
+    this.resourceId = response[0].id;
   }
 
   @logger()

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
@@ -70,8 +70,8 @@ export class ManifoldDataDeprovisionButton {
         resourceLabel: this.resourceLabel || '',
         resourceId: this.resourceId,
       };
+
       this.error.emit(error);
-      return;
     });
 
     const success: SuccessMessage = {

--- a/src/components/manifold-data-has-resource/manifold-data-has-resource.tsx
+++ b/src/components/manifold-data-has-resource/manifold-data-has-resource.tsx
@@ -45,18 +45,12 @@ export class ManifoldDataHasResource {
       return;
     }
 
-    const response = await this.restFetch<Marketplace.Resource[]>({
+    const resources = await this.restFetch<Marketplace.Resource[]>({
       service: 'marketplace',
       endpoint: `/resources/?me`,
     });
 
-    if (response instanceof Error) {
-      console.error(response);
-      return;
-    }
-
-    const resources: Marketplace.Resource[] = await response;
-    if (Array.isArray(resources) && resources.length) {
+    if (resources && resources.length) {
       this.hasResources = true;
     }
   }

--- a/src/components/manifold-data-product-name/manifold-data-product-name.tsx
+++ b/src/components/manifold-data-product-name/manifold-data-product-name.tsx
@@ -39,18 +39,14 @@ export class ManifoldDataProductName {
 
     this.productName = undefined;
 
-    const response = await this.restFetch<Catalog.Product[]>({
+    const products = await this.restFetch<Catalog.Product[]>({
       service: 'catalog',
       endpoint: `/products?label=${productLabel}`,
     });
 
-    if (response instanceof Error) {
-      console.error(response);
-      return;
+    if (products) {
+      this.productName = products[0].body.name; // eslint-disable-line prefer-destructuring
     }
-
-    const products: Catalog.Product[] = await response;
-    this.productName = products[0].body.name; // eslint-disable-line prefer-destructuring
   };
 
   fetchResource = async (resourceName: string) => {
@@ -60,18 +56,14 @@ export class ManifoldDataProductName {
 
     this.productName = undefined;
 
-    const response = await this.restFetch<Gateway.Resource>({
+    const resource = await this.restFetch<Gateway.Resource>({
       service: 'gateway',
       endpoint: `/resources/me/${resourceName}`,
     });
 
-    if (response instanceof Error) {
-      console.error(response);
-      return;
+    if (resource) {
+      this.productName = resource.product && resource.product.name;
     }
-
-    const resource: Gateway.Resource = await response;
-    this.productName = resource.product && resource.product.name;
   };
 
   @logger()

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.spec.ts
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.spec.ts
@@ -326,12 +326,12 @@ describe('<manifold-data-provision-button>', () => {
       const instance = page.rootInstance as ManifoldDataProvisionButton;
       instance.error.emit = jest.fn();
 
-      await instance.provision();
-
-      expect(fetchMock.called(`${connections.prod.gateway}/resource/`)).toBe(true);
-      expect(instance.error.emit).toHaveBeenCalledWith({
-        message: 'ohnoes',
-        resourceLabel: 'test',
+      return instance.provision().catch(() => {
+        expect(fetchMock.called(`${connections.prod.gateway}/resource/`)).toBe(true);
+        expect(instance.error.emit).toHaveBeenCalledWith({
+          message: 'ohnoes',
+          resourceLabel: 'test',
+        });
       });
     });
 

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.spec.ts
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.spec.ts
@@ -326,6 +326,7 @@ describe('<manifold-data-provision-button>', () => {
       const instance = page.rootInstance as ManifoldDataProvisionButton;
       instance.error.emit = jest.fn();
 
+      expect.assertions(2);
       return instance.provision().catch(() => {
         expect(fetchMock.called(`${connections.prod.gateway}/resource/`)).toBe(true);
         expect(instance.error.emit).toHaveBeenCalledWith({

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
@@ -132,16 +132,14 @@ export class ManifoldDataProvisionButton {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
       },
-    });
-
-    if (response instanceof Error) {
-      const error: ErrorMessage = {
-        message: response.message,
+    }).catch(error => {
+      const e: ErrorMessage = {
+        message: error.message,
         resourceLabel: this.resourceLabel,
       };
-      this.error.emit(error);
-      return;
-    }
+      this.error.emit(e);
+      return Promise.reject(e);
+    });
 
     const success: SuccessMessage = {
       createdAt: response.created_at,

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
@@ -175,7 +175,7 @@ export class ManifoldDataProvisionButton {
       endpoint: `/plans/?product_id=${products[0].id}${planLabel ? `&label=${planLabel}` : ''}`,
     });
 
-    if (!Array.isArray(plans) || !plans.length) {
+    if (!plans || !plans.length) {
       console.error(`${productLabel} plans not found`);
       return;
     }

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
@@ -124,30 +124,34 @@ export class ManifoldDataProvisionButton {
       features: {},
     };
 
-    const response = await this.restFetch<Gateway.Resource>({
-      service: 'gateway',
-      endpoint: `/resource/`,
-      body: req,
-      options: {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-      },
-    }).catch(error => {
+    try {
+      const response = await this.restFetch<Gateway.Resource>({
+        service: 'gateway',
+        endpoint: `/resource/`,
+        body: req,
+        options: {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        },
+      });
+
+      if (response) {
+        const success: SuccessMessage = {
+          createdAt: response.created_at,
+          message: `${this.resourceLabel} successfully provisioned`,
+          resourceId: response.id || '',
+          resourceLabel: response.label,
+        };
+        this.success.emit(success);
+      }
+    } catch (error) {
       const e: ErrorMessage = {
         message: error.message,
         resourceLabel: this.resourceLabel,
       };
       this.error.emit(e);
-      return Promise.reject(e);
-    });
-
-    const success: SuccessMessage = {
-      createdAt: response.created_at,
-      message: `${this.resourceLabel} successfully provisioned`,
-      resourceId: response.id || '',
-      resourceLabel: response.label,
-    };
-    this.success.emit(success);
+      throw e;
+    }
   }
 
   async fetchProductPlanId(productLabel: string, planLabel?: string) {
@@ -156,32 +160,20 @@ export class ManifoldDataProvisionButton {
       return;
     }
 
-    const productResp = await this.restFetch<Catalog.Product[]>({
+    const products = await this.restFetch<Catalog.Product[]>({
       service: 'catalog',
       endpoint: `/products/?label=${productLabel}`,
     });
 
-    if (productResp instanceof Error) {
-      console.error(productResp);
-      return;
-    }
-    const products: Catalog.Product[] = await productResp;
-
-    if (!Array.isArray(products) || !products.length) {
+    if (!products || !products.length) {
       console.error(`${productLabel} product not found`);
       return;
     }
 
-    const planResp = await this.restFetch<Catalog.Plan[]>({
+    const plans = await this.restFetch<Catalog.Plan[]>({
       service: 'catalog',
       endpoint: `/plans/?product_id=${products[0].id}${planLabel ? `&label=${planLabel}` : ''}`,
     });
-
-    if (planResp instanceof Error) {
-      console.error(planResp);
-      return;
-    }
-    const plans: Catalog.Plan[] = await planResp;
 
     if (!Array.isArray(plans) || !plans.length) {
       console.error(`${productLabel} plans not found`);

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
@@ -180,17 +180,19 @@ describe('<manifold-data-rename-button>', () => {
       const instance = page.rootInstance as ManifoldDataRenameButton;
       instance.error.emit = jest.fn();
 
-      await instance.rename();
-
-      expect(fetchMock.called(`${connections.prod.marketplace}/resources/${Resource.id}`)).toBe(
-        true
-      );
-      expect(instance.error.emit).toHaveBeenCalledWith({
-        message: 'ohnoes',
-        resourceLabel: Resource.body.label,
-        newLabel: 'test2',
-        resourceId: Resource.id,
-      });
+      try {
+        await instance.rename();
+      } catch {
+        expect(fetchMock.called(`${connections.prod.marketplace}/resources/${Resource.id}`)).toBe(
+          true
+        );
+        expect(instance.error.emit).toHaveBeenCalledWith({
+          message: 'ohnoes',
+          resourceLabel: Resource.body.label,
+          newLabel: 'test2',
+          resourceId: Resource.id,
+        });
+      }
     });
 
     it('will do nothing if still loading', async () => {

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
@@ -31,7 +31,7 @@ interface ErrorMessage {
   message: string;
   newLabel: string;
   resourceLabel: string;
-  resourceId: string;
+  resourceId?: string;
 }
 
 @Component({ tag: 'manifold-data-rename-button' })
@@ -109,7 +109,7 @@ export class ManifoldDataRenameButton {
       },
     };
 
-    const response = await this.restFetch({
+    await this.restFetch({
       service: 'marketplace',
       endpoint: `/resources/${this.resourceId}`,
       body,
@@ -117,18 +117,16 @@ export class ManifoldDataRenameButton {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
       },
-    });
-
-    if (response instanceof Error) {
+    }).catch(e => {
       const error: ErrorMessage = {
-        message: response.message,
+        message: e.message,
         resourceLabel: this.resourceLabel || '',
         newLabel: this.newLabel,
         resourceId: this.resourceId,
       };
       this.error.emit(error);
-      return;
-    }
+      return Promise.reject(error);
+    });
 
     const success: SuccessMessage = {
       message: `${this.resourceLabel} successfully renamed`,
@@ -149,18 +147,12 @@ export class ManifoldDataRenameButton {
       endpoint: `/resources/?me&label=${resourceLabel}`,
     });
 
-    if (response instanceof Error) {
-      console.error(response);
-      return;
-    }
-    const resources: Marketplace.Resource[] = response;
-
-    if (!Array.isArray(resources) || !resources.length) {
+    if (!Array.isArray(response) || !response.length) {
       console.error(`${resourceLabel} product not found`);
       return;
     }
 
-    this.resourceId = resources[0].id;
+    this.resourceId = response[0].id;
   }
 
   validate(input: string) {

--- a/src/components/manifold-data-resource-logo/manifold-data-resource-logo.tsx
+++ b/src/components/manifold-data-resource-logo/manifold-data-resource-logo.tsx
@@ -36,29 +36,23 @@ export class ManifoldDataResourceLogo {
       endpoint: `/resources/?me&label=${resourceLabel}`,
     });
 
-    if (resourceResp instanceof Error) {
-      console.error(resourceResp);
-      return;
+    if (resourceResp && resourceResp.length) {
+      const resource: Marketplace.Resource = resourceResp[0];
+      const productId = resource.body.product_id;
+      const productResp = await this.restFetch<Catalog.Product>({
+        service: 'catalog',
+        endpoint: `/products/${productId}`,
+      });
+
+      if (productResp) {
+        // NOTE: Temporary util GraphQL supports resources
+        const newProduct = {
+          displayName: productResp.body.name,
+          logoUrl: productResp.body.logo_url,
+        };
+        this.product = newProduct as Product;
+      }
     }
-
-    const resource: Marketplace.Resource = resourceResp[0];
-    const productId = resource.body.product_id;
-    const productResp = await this.restFetch<Catalog.Product>({
-      service: 'catalog',
-      endpoint: `/products/${productId}`,
-    });
-
-    if (productResp instanceof Error) {
-      console.error(productResp);
-      return;
-    }
-
-    // NOTE: Temporary util GraphQL supports resources
-    const newProduct = {
-      displayName: productResp.body.name,
-      logoUrl: productResp.body.logo_url,
-    };
-    this.product = newProduct as Product;
   };
 
   @logger()

--- a/src/components/manifold-data-sso-button/manifold-data-sso-button.tsx
+++ b/src/components/manifold-data-sso-button/manifold-data-sso-button.tsx
@@ -100,8 +100,8 @@ export class ManifoldDataSsoButton {
         resourceLabel: this.resourceLabel || '',
         resourceId: this.resourceId,
       };
+
       this.error.emit(error);
-      return;
     }
   };
 

--- a/src/components/manifold-data-sso-button/manifold-data-sso-button.tsx
+++ b/src/components/manifold-data-sso-button/manifold-data-sso-button.tsx
@@ -116,7 +116,7 @@ export class ManifoldDataSsoButton {
       endpoint: `/resources/?me&label=${resourceLabel}`,
     });
 
-    if (!Array.isArray(response) || !response.length) {
+    if (!response || !response.length) {
       console.error(`${resourceLabel} resource not found`);
       return;
     }

--- a/src/components/manifold-data-sso-button/manifold-data-sso-button.tsx
+++ b/src/components/manifold-data-sso-button/manifold-data-sso-button.tsx
@@ -75,33 +75,34 @@ export class ManifoldDataSsoButton {
       },
     };
 
-    const response = await this.restFetch<Connector.AuthorizationCode>({
-      service: 'connector',
-      endpoint: `/sso`,
-      body,
-      options: {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-      },
-    });
+    try {
+      const response = await this.restFetch<Connector.AuthorizationCode>({
+        service: 'connector',
+        endpoint: `/sso`,
+        body,
+        options: {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        },
+      });
 
-    if (response instanceof Error) {
+      const success: SuccessMessage = {
+        message: `${this.resourceLabel} successfully ssoed`,
+        resourceLabel: this.resourceLabel || '',
+        resourceId: this.resourceId,
+        redirectUrl: response ? response.body.redirect_uri : '',
+      };
+
+      this.success.emit(success);
+    } catch (e) {
       const error: ErrorMessage = {
-        message: response.message,
+        message: e.message,
         resourceLabel: this.resourceLabel || '',
         resourceId: this.resourceId,
       };
       this.error.emit(error);
       return;
     }
-
-    const success: SuccessMessage = {
-      message: `${this.resourceLabel} successfully ssoed`,
-      resourceLabel: this.resourceLabel || '',
-      resourceId: this.resourceId,
-      redirectUrl: response.body.redirect_uri,
-    };
-    this.success.emit(success);
   };
 
   async fetchResourceId(resourceLabel: string) {
@@ -115,19 +116,13 @@ export class ManifoldDataSsoButton {
       endpoint: `/resources/?me&label=${resourceLabel}`,
     });
 
-    if (response instanceof Error) {
-      console.error(response);
-      return;
-    }
-    const resources: Marketplace.Resource[] = response;
-
-    if (!Array.isArray(resources) || !resources.length) {
+    if (!Array.isArray(response) || !response.length) {
       console.error(`${resourceLabel} resource not found`);
       return;
     }
 
     this.loading = false;
-    this.resourceId = resources[0].id;
+    this.resourceId = response[0].id;
   }
 
   @logger()

--- a/src/components/manifold-marketplace/manifold-marketplace.tsx
+++ b/src/components/manifold-marketplace/manifold-marketplace.tsx
@@ -53,7 +53,7 @@ export class ManifoldMarketplace {
       endpoint: `/products`,
     });
 
-    if (Array.isArray(response)) {
+    if (response) {
       // Alphabetize once, then don’t worry about it
       this.services = [...response].sort((a, b) => a.body.name.localeCompare(b.body.name));
     }

--- a/src/components/manifold-marketplace/manifold-marketplace.tsx
+++ b/src/components/manifold-marketplace/manifold-marketplace.tsx
@@ -53,13 +53,10 @@ export class ManifoldMarketplace {
       endpoint: `/products`,
     });
 
-    if (response instanceof Error) {
-      console.error(response);
-      return;
+    if (Array.isArray(response)) {
+      // Alphabetize once, then don’t worry about it
+      this.services = [...response].sort((a, b) => a.body.name.localeCompare(b.body.name));
     }
-
-    // Alphabetize once, then don’t worry about it
-    this.services = [...response].sort((a, b) => a.body.name.localeCompare(b.body.name));
   };
 
   // fetch free products once, then save

--- a/src/components/manifold-plan-selector/manifold-plan-selector.tsx
+++ b/src/components/manifold-plan-selector/manifold-plan-selector.tsx
@@ -60,13 +60,10 @@ export class ManifoldPlanSelector {
       endpoint: `/products/?label=${productLabel}`,
     });
 
-    if (response instanceof Error) {
-      console.error(response);
-      return;
+    if (response && response.length) {
+      this.product = response[0]; // eslint-disable-line prefer-destructuring
+      this.fetchPlans(this.product.id);
     }
-
-    this.product = response[0]; // eslint-disable-line prefer-destructuring
-    this.fetchPlans(response[0].id);
   }
 
   async fetchPlans(productId: string) {
@@ -81,12 +78,9 @@ export class ManifoldPlanSelector {
       endpoint: `/plans/?product_id=${productId}`,
     });
 
-    if (response instanceof Error) {
-      console.error(response);
-      return;
+    if (response) {
+      this.plans = planSort(response, { free: this.freePlans });
     }
-
-    this.plans = planSort(response, { free: this.freePlans });
   }
 
   async fetchResource(resourceLabel: string) {
@@ -101,18 +95,15 @@ export class ManifoldPlanSelector {
       endpoint: `/resources/?me&label=${resourceLabel}`,
     });
 
-    if (response instanceof Error) {
-      console.error(response);
-      return;
-    }
+    if (response && response.length) {
+      const resource = response[0];
+      if (!resource.body.product_id) {
+        console.error('No resource found');
+        return;
+      }
 
-    const resource = response[0];
-    if (!resource || !resource.body.product_id) {
-      console.error('No resource found');
-      return;
+      this.fetchPlans(resource.body.product_id);
     }
-
-    this.fetchPlans(resource.body.product_id);
   }
 
   parseRegions(regions: string) {

--- a/src/components/manifold-plan/manifold-plan.tsx
+++ b/src/components/manifold-plan/manifold-plan.tsx
@@ -38,13 +38,10 @@ export class ManifoldPlan {
       endpoint: `/products/?label=${productLabel}`,
     });
 
-    if (response instanceof Error) {
-      console.error(response);
-      return;
+    if (response && response.length) {
+      this.product = response[0]; // eslint-disable-line prefer-destructuring
+      await this.fetchPlan(response[0].id, planLabel);
     }
-
-    this.product = response[0]; // eslint-disable-line prefer-destructuring
-    await this.fetchPlan(response[0].id, planLabel);
   }
 
   async fetchPlan(productId: string, planLabel: string) {
@@ -58,12 +55,9 @@ export class ManifoldPlan {
       endpoint: `/plans/?product_id=${productId}&label=${planLabel}`,
     });
 
-    if (response instanceof Error) {
-      console.error(response);
-      return;
+    if (response) {
+      this.plan = response[0]; // eslint-disable-line prefer-destructuring
     }
-
-    this.plan = response[0]; // eslint-disable-line prefer-destructuring
   }
 
   @logger()

--- a/src/components/manifold-product/manifold-product.tsx
+++ b/src/components/manifold-product/manifold-product.tsx
@@ -35,24 +35,14 @@ export class ManifoldProduct {
       endpoint: `/products/?label=${productLabel}`,
     });
 
-    if (productResp instanceof Error) {
-      console.error(productResp);
-      return;
+    if (productResp) {
+      this.product = productResp[0]; // eslint-disable-line prefer-destructuring
+
+      this.provider = await this.restFetch<Catalog.Provider>({
+        service: 'catalog',
+        endpoint: `/providers/${this.product.body.provider_id}`,
+      });
     }
-
-    this.product = productResp[0]; // eslint-disable-line prefer-destructuring
-
-    const providerResp = await this.restFetch<Catalog.Provider>({
-      service: 'catalog',
-      endpoint: `/providers/${productResp[0].body.provider_id}`,
-    });
-
-    if (providerResp instanceof Error) {
-      console.error(providerResp);
-      return;
-    }
-
-    this.provider = providerResp;
   };
 
   @logger()

--- a/src/components/manifold-region-selector/manifold-region-selector.tsx
+++ b/src/components/manifold-region-selector/manifold-region-selector.tsx
@@ -31,17 +31,14 @@ export class ManifoldRegionSelector {
       endpoint: `/regions`,
     });
 
-    if (response instanceof Error) {
-      console.error(response);
-      return;
-    }
-
-    // Sorting is important, otherwise the region selector is in a different order every plan
-    this.regions = this.sortRegions(response, this.preferredRegions);
-    // Set global region (the one in src/data is just a fallback; we should always grab live)
-    const global = this.regions.find(({ body: { location } }) => location === 'global');
-    if (global) {
-      this.globalRegion = global;
+    if (response) {
+      // Sorting is important, otherwise the region selector is in a different order every plan
+      this.regions = this.sortRegions(response, this.preferredRegions);
+      // Set global region (the one in src/data is just a fallback; we should always grab live)
+      const global = this.regions.find(({ body: { location } }) => location === 'global');
+      if (global) {
+        this.globalRegion = global;
+      }
     }
   }
 

--- a/src/components/manifold-resource-card-view/manifold-resource-card-view.tsx
+++ b/src/components/manifold-resource-card-view/manifold-resource-card-view.tsx
@@ -100,18 +100,12 @@ export class ManifoldResourceCardView {
       endpoint: `/resources/?me&label=${resourceLabel}`,
     });
 
-    if (response instanceof Error) {
-      console.error(response);
-      return;
-    }
-    const resources: Marketplace.Resource[] = response;
-
-    if (!Array.isArray(resources) || !resources.length) {
+    if (!response || !response.length) {
       console.error(`${resourceLabel} resource not found`);
       return;
     }
 
-    this.resourceId = resources[0].id;
+    this.resourceId = response[0].id;
   }
 
   onClick = (e: Event): void => {

--- a/src/components/manifold-resource-card/manifold-resource-card.tsx
+++ b/src/components/manifold-resource-card/manifold-resource-card.tsx
@@ -60,12 +60,7 @@ export class ManifoldResourceCard {
       endpoint: `/resources/me/${resourceName}`,
     });
 
-    if (response instanceof Error) {
-      console.error(response);
-      return;
-    }
-
-    if (response.length) {
+    if (response && response.length) {
       // eslint-disable-next-line prefer-destructuring
       this.resource = response[0];
     }

--- a/src/components/manifold-resource-container/manifold-resource-container.tsx
+++ b/src/components/manifold-resource-container/manifold-resource-container.tsx
@@ -43,27 +43,27 @@ export class ManifoldResourceContainer {
     }
 
     this.loading = true;
-    const response = await this.restFetch<Gateway.Resource>({
-      service: 'gateway',
-      endpoint: `/resources/me/${resourceLabel}`,
-    });
+    try {
+      const response = await this.restFetch<Gateway.Resource>({
+        service: 'gateway',
+        endpoint: `/resources/me/${resourceLabel}`,
+      });
 
-    if (response instanceof Error) {
+      if (this.refetchUntilValid && (!response || response.state !== 'available')) {
+        this.timeout = window.setTimeout(() => this.fetchResource(this.resourceLabel), 3000);
+      }
+
+      this.resource = response;
+      this.loading = false;
+    } catch (error) {
       // In case we actually want to keep fetching on an error
       if (this.refetchUntilValid) {
         this.timeout = window.setTimeout(() => this.fetchResource(this.resourceLabel), 3000);
       }
 
-      console.error(response);
+      console.error(error);
       return;
     }
-
-    if (this.refetchUntilValid && (!response || response.state !== 'available')) {
-      this.timeout = window.setTimeout(() => this.fetchResource(this.resourceLabel), 3000);
-    }
-
-    this.resource = response;
-    this.loading = false;
   };
 
   @logger()

--- a/src/components/manifold-resource-container/manifold-resource-container.tsx
+++ b/src/components/manifold-resource-container/manifold-resource-container.tsx
@@ -62,7 +62,6 @@ export class ManifoldResourceContainer {
       }
 
       console.error(error);
-      return;
     }
   };
 

--- a/src/components/manifold-resource-list/manifold-resource-list.tsx
+++ b/src/components/manifold-resource-list/manifold-resource-list.tsx
@@ -102,12 +102,7 @@ export class ManifoldResourceList {
       endpoint: `/operations/?is_deleted=false`,
     });
 
-    if (operationsResp instanceof Error) {
-      console.error(operationsResp);
-      return;
-    }
-
-    if (Array.isArray(operationsResp)) {
+    if (operationsResp) {
       const productsResp = await this.restFetch<Catalog.Product[]>({
         service: 'catalog',
         endpoint: `/products`,
@@ -118,7 +113,7 @@ export class ManifoldResourceList {
         endpoint: `/resources/?me`,
       });
 
-      if (Array.isArray(resourcesResp) && Array.isArray(productsResp)) {
+      if (resourcesResp && Array.isArray(productsResp)) {
         const userResource = ManifoldResourceList.userResources(resourcesResp);
 
         const resources: FoundResource[] = [];

--- a/src/components/manifold-service-card/manifold-service-card.tsx
+++ b/src/components/manifold-service-card/manifold-service-card.tsx
@@ -108,12 +108,7 @@ export class ManifoldServiceCard {
         endpoint: `/products/?label=${label}`,
       });
 
-      if (productResp instanceof Error) {
-        console.error(productResp);
-        return;
-      }
-
-      if (productResp.length) {
+      if (Array.isArray(productResp) && productResp.length) {
         this.product = productResp[0]; // eslint-disable-line prefer-destructuring
       }
     }

--- a/src/data/connection.tsx
+++ b/src/data/connection.tsx
@@ -5,6 +5,5 @@ import { ConnectionState } from '../state/connection';
 
 export default createProviderConsumer<ConnectionState>(
   new ConnectionState(),
-  // @ts-ignore
   (subscribe, child) => <context-consumer subscribe={subscribe} renderer={child} />
 );

--- a/src/utils/errorReport.ts
+++ b/src/utils/errorReport.ts
@@ -1,0 +1,5 @@
+export function report<Detail>(detail: Detail) {
+  console.error(detail); // report error (Rollbar, Datadog, etc.)
+  const evt = new CustomEvent('manifold-error', { bubbles: true, detail });
+  document.dispatchEvent(evt);
+}

--- a/src/utils/logger.tsx
+++ b/src/utils/logger.tsx
@@ -1,4 +1,5 @@
 import { h } from '@stencil/core';
+import { report } from './errorReport';
 
 interface ErrorDetail {
   component?: string;
@@ -25,13 +26,11 @@ export default function logger<T>() {
       try {
         return originalMethod.apply(this); // attempt to call render()
       } catch (e) {
-        console.error(e); // report error (Rollbar, Datadog, etc.)
         const detail: ErrorDetail = {
           component: target.constructor.name,
           error: e.message,
         };
-        const evt = new CustomEvent('manifold-error', { bubbles: true, detail });
-        document.dispatchEvent(evt); // dispatch custom event
+        report(detail);
         return <manifold-toast alert-type="error">{e.message}</manifold-toast>; // show error to user
       }
     };

--- a/src/utils/plan.ts
+++ b/src/utils/plan.ts
@@ -313,10 +313,7 @@ export function planSort(
 /**
  * Fetch cost from our API
  */
-export function planCost(
-  restFetch: RestFetch,
-  { planID, features, init }: PlanCostOptions
-): Promise<Gateway.Price | Error> {
+export function planCost(restFetch: RestFetch, { planID, features, init }: PlanCostOptions) {
   return restFetch<Gateway.Price>({
     service: 'gateway',
     endpoint: `/id/plan/${planID}/cost`,

--- a/src/utils/restFetch.spec.ts
+++ b/src/utils/restFetch.spec.ts
@@ -114,9 +114,9 @@ describe('The fetcher created by createRestFetch', () => {
       service: 'marketplace',
     });
 
-    return result.catch(result => {
+    return result.catch(err => {
       expect(fetchMock.called('path:/v1/test')).toBeFalsy();
-      expect(result.message).toEqual('No auth token given');
+      expect(err.message).toEqual('No auth token given');
     });
   });
 

--- a/src/utils/restFetch.spec.ts
+++ b/src/utils/restFetch.spec.ts
@@ -53,6 +53,7 @@ describe('The fetcher created by createRestFetch', () => {
       body: {},
     });
 
+    expect.assertions(2);
     return fetcher({
       endpoint: '/test',
       service: 'marketplace',
@@ -75,6 +76,7 @@ describe('The fetcher created by createRestFetch', () => {
       body,
     });
 
+    expect.assertions(2);
     return fetcher({
       endpoint: '/test',
       service: 'marketplace',
@@ -92,6 +94,7 @@ describe('The fetcher created by createRestFetch', () => {
 
     fetchMock.mock('path:/v1/test', { throws: err });
 
+    expect.assertions(2);
     return fetcher({
       endpoint: '/test',
       service: 'marketplace',
@@ -114,6 +117,7 @@ describe('The fetcher created by createRestFetch', () => {
       service: 'marketplace',
     });
 
+    expect.assertions(2);
     return result.catch(err => {
       expect(fetchMock.called('path:/v1/test')).toBeFalsy();
       expect(err.message).toEqual('No auth token given');

--- a/src/utils/restFetch.spec.ts
+++ b/src/utils/restFetch.spec.ts
@@ -139,7 +139,7 @@ describe('The fetcher created by createRestFetch', () => {
       wait: 1,
       getAuthToken: () => '1234',
     });
-    fetchMock.mock('path:/v1/test', 200);
+    fetchMock.mock('path:/v1/test', {});
     await fetcher({ endpoint: '/test', service: 'catalog' });
     const [, req] = fetchMock.lastCall() as any;
     expect(req.headers).toEqual({ authorization: 'Bearer 1234' });
@@ -148,7 +148,7 @@ describe('The fetcher created by createRestFetch', () => {
   // TODO: add catalog auth in the future, but STILL KEEP ability for unauth’d reqs
   it('doesn’t auth for catalog if token is absent', async () => {
     const fetcher = createRestFetch({} /* no token */);
-    fetchMock.mock('path:/v1/test', 200);
+    fetchMock.mock('path:/v1/test', {});
     await fetcher({ endpoint: '/test', service: 'catalog' });
     const [, req] = fetchMock.lastCall() as any;
     expect(req.headers).toBe(undefined);

--- a/src/utils/restFetch.ts
+++ b/src/utils/restFetch.ts
@@ -20,14 +20,14 @@ interface RestFetchArguments {
 
 type Success = undefined;
 
-export type RestFetch = <T>(args: RestFetchArguments) => Promise<T>;
+export type RestFetch = <T>(args: RestFetchArguments) => Promise<T | Success>;
 
 export function createRestFetch({
   endpoints = connections.prod,
   wait = 15000,
   getAuthToken = () => undefined,
   setAuthToken = () => {},
-}: CreateRestFetch) {
+}: CreateRestFetch): RestFetch {
   return async function restFetch<T>(args: RestFetchArguments): Promise<T | Success> {
     const start = new Date();
 

--- a/src/utils/restFetch.ts
+++ b/src/utils/restFetch.ts
@@ -1,6 +1,7 @@
 import { Connection, connections } from './connections';
 import { withAuth } from './auth';
 import { hasExpired } from './expiry';
+import { report } from './errorReport';
 
 interface CreateRestFetch {
   endpoints?: Connection;
@@ -17,55 +18,64 @@ interface RestFetchArguments {
   isPublic?: boolean;
 }
 
-export type RestFetch = <T>(args: RestFetchArguments) => Promise<T | Error>;
+type Success = undefined;
 
-export const createRestFetch = ({
+export type RestFetch = <T>(args: RestFetchArguments) => Promise<T>;
+
+export function createRestFetch({
   endpoints = connections.prod,
   wait = 15000,
   getAuthToken = () => undefined,
   setAuthToken = () => {},
-}: CreateRestFetch = {}): RestFetch => async (args: RestFetchArguments) => {
-  const url = `${endpoints[args.service]}${args.endpoint}`;
-  const start = new Date();
+}: CreateRestFetch) {
+  return async function restFetch<T>(args: RestFetchArguments): Promise<T | Success> {
+    const start = new Date();
 
-  // TODO: catalog should ALWAYS be able to fetch WITHOUT auth if needed,
-  // but this prevents the ability for it to auth altogether. We need both!
-  const isCatalog = args.service === 'catalog';
-  const isPublic = isCatalog || args.isPublic;
+    // TODO: catalog should ALWAYS be able to fetch WITHOUT auth if needed,
+    // but this prevents the ability for it to auth altogether. We need both!
+    const isCatalog = args.service === 'catalog';
+    const isPublic = isCatalog || args.isPublic;
 
-  if (!isPublic) {
-    while (!getAuthToken() && !hasExpired(start, wait)) {
-      // eslint-disable-next-line no-await-in-loop
-      await new Promise(resolve => setTimeout(resolve, 2000));
+    if (!isPublic) {
+      while (!getAuthToken() && !hasExpired(start, wait)) {
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise(resolve => setTimeout(resolve, 2000));
+      }
+      if (!getAuthToken()) {
+        const detail = { message: 'No auth token given' };
+        report(detail);
+        throw new Error(detail.message);
+      }
     }
 
-    if (!getAuthToken()) {
-      return new Error('No auth token given');
-    }
-  }
-
-  try {
+    const url = `${endpoints[args.service]}${args.endpoint}`;
     const response = await fetch(url as string, {
       ...withAuth(getAuthToken(), args.options),
       body: JSON.stringify(args.body),
+    }).catch((e: Response) => {
+      // 5xx errors will land here
+      report(e);
+      return Promise.reject(e);
     });
 
     if ([202, 203, 204].includes(response.status)) {
-      return {};
+      return;
     }
 
     const body = await response.json();
     if (response.status >= 200 && response.status < 300) {
       return body;
     }
+
     if (response.status === 401) {
       setAuthToken('');
+      report(response);
+      throw new Error('Auth token expired');
     }
 
     // Sometimes messages are an array, sometimes they aren’t. Different strokes!
     const message = Array.isArray(body) ? body[0].message : body.message;
-    return new Error(message);
-  } catch (e) {
-    return e;
-  }
-};
+    // This is an expected error, it doesn't need to be reported
+    throw new Error(message);
+  };
+}

--- a/src/utils/restFetch.ts
+++ b/src/utils/restFetch.ts
@@ -53,11 +53,12 @@ export function createRestFetch({
       ...withAuth(getAuthToken(), args.options),
       body: JSON.stringify(args.body),
     }).catch((e: Response) => {
-      // 5xx errors will land here
+      /* Handle unexpected errors */
       report(e);
       return Promise.reject(e);
     });
 
+    /* Handle successful responses */
     if ([202, 203, 204].includes(response.status)) {
       return undefined;
     }
@@ -67,6 +68,7 @@ export function createRestFetch({
       return body;
     }
 
+    /* Handle expected errors */
     if (response.status === 401) {
       setAuthToken('');
       report(response);
@@ -74,8 +76,8 @@ export function createRestFetch({
     }
 
     // Sometimes messages are an array, sometimes they aren’t. Different strokes!
+    report(response);
     const message = Array.isArray(body) ? body[0].message : body.message;
-    // This is an expected error, it doesn't need to be reported
     throw new Error(message);
   };
 }

--- a/src/utils/restFetch.ts
+++ b/src/utils/restFetch.ts
@@ -59,7 +59,7 @@ export function createRestFetch({
     });
 
     if ([202, 203, 204].includes(response.status)) {
-      return;
+      return undefined;
     }
 
     const body = await response.json();


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

Errors that occur in API calls need to be reported to platforms. This will be emitted as a custom event named `manifold-error`.

Getting this right involved tightening up the types for `createRestFetch`, which had consequences for every component that calls `restFetch` and every corresponding test.

## Testing
<!-- For someone unfamiliar with the issue, how should this be tested? -->

Make sure Storybook components that fetch data are still working. Components displaying catalog data should continue to work without an API token, and components that display resources or any other private data should still work when a token is set in `localStorage.manifold_api_token`