### PR TITLE
CircleCI: don’t publish to npm on every master merge 😅

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,43 +145,43 @@ workflows:
             - test
             - vrt
 
-  # Final release (only fires on master, and if Git tag is a stable release)
+  # Final release (only fires if Git tag is a stable release)
   release:
     jobs:
       - bundlesize:
           filters: # the same filters are required on ALL jobs here
             branches:
-              only:
-                - master
+              ignore:
+                - /.*/
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
       - lint:
           filters:
             branches:
-              only:
-                - master
+              ignore:
+                - /.*/
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
       - test:
           filters:
             branches:
-              only:
-                - master
+              ignore:
+                - /.*/
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
       - vrt:
           filters:
             branches:
-              only:
-                - master
+              ignore:
+                - /.*/
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
       - confirm:
           type: approval # manual approval step mandatory for final release
           filters:
             branches:
-              only:
-                - master
+              ignore:
+                - /.*/
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
           requires:
@@ -192,8 +192,8 @@ workflows:
       - npm-publish:
           filters:
             branches:
-              only:
-                - master
+              ignore:
+                - /.*/
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
           requires:


### PR DESCRIPTION
## Reason for change
So in the CircleCI config, it fired off an npm `release` job. In the config, it’s set to only run if there’s a tag **AND** we’re on the `master` branch. Turns out, it’s actually **OR** logic, so it was running on `master` with no tag (it would have failed anyway without a tag, but we don’t want to waste compute with it doing nothing).

**These `release` jobs shouldn’t be here:**

![Screen Shot 2019-08-07 at 15 00 20](https://user-images.githubusercontent.com/1369770/62657782-7f775900-b924-11e9-9e9b-69f027bbc2db.png)


## Testing
Tests should pass.