### PR TITLE
Fix catalog auth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ defaults: &defaults
     - NODE_ENV: development # CircleCI needs devDeps
 
 orbs:
-  happo: happo/happo@2.0.0
+  happo: happo/happo@latest
 
 commands:
   # cache Stencil if npm run build is run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ defaults: &defaults
     - NODE_ENV: development # CircleCI needs devDeps
 
 orbs:
-  happo: happo/happo@latest
+  happo: happo/happo@2.0.0
 
 commands:
   # cache Stencil if npm run build is run

--- a/src/utils/auth.spec.ts
+++ b/src/utils/auth.spec.ts
@@ -18,4 +18,9 @@ describe('withAuth method', () => {
   it('doesn’t submit auth token if empty string', () => {
     expect(withAuth('')).toBe(undefined);
   });
+
+  it('doesn’t submit auth token if “undefined”', () => {
+    // Yes this is actually a very important test
+    expect(withAuth('undefined')).toBe(undefined);
+  });
 });

--- a/src/utils/auth.spec.ts
+++ b/src/utils/auth.spec.ts
@@ -18,9 +18,4 @@ describe('withAuth method', () => {
   it('doesn’t submit auth token if empty string', () => {
     expect(withAuth('')).toBe(undefined);
   });
-
-  it('doesn’t submit auth token if “undefined”', () => {
-    // Yes this is actually a very important test
-    expect(withAuth('undefined')).toBe(undefined);
-  });
 });

--- a/src/utils/auth.spec.ts
+++ b/src/utils/auth.spec.ts
@@ -9,4 +9,13 @@ describe('withAuth method', () => {
   it('reads manifold_api_token from the given token', () => {
     expect(withAuth('larry')).toEqual({ headers: { authorization: 'Bearer larry' } });
   });
+
+  it('doesn’t submit auth token if null', () => {
+    const token: any = null;
+    expect(withAuth(token)).toBe(undefined);
+  });
+
+  it('doesn’t submit auth token if empty string', () => {
+    expect(withAuth('')).toBe(undefined);
+  });
 });

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -14,9 +14,8 @@ export function withAuth(authToken?: string, options?: RequestInit): RequestInit
 
   const isNotString = typeof token !== 'string';
   const isEmpty = token === '';
-  const isUndefined = typeof token === 'string' && token.toLowerCase() === 'undefined';
 
-  if (isNotString || isEmpty || isUndefined) {
+  if (isNotString || isEmpty) {
     return options;
   }
 

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -11,9 +11,10 @@ export function withAuth(authToken?: string, options?: RequestInit): RequestInit
    * working.
    */
   const token = authToken || localStorage.getItem('manifold_api_token');
-  if (!token) {
+  if (typeof token !== 'string' || token.length === 0) {
     return options;
   }
+
   return {
     ...(options || {}),
     headers: {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -11,7 +11,12 @@ export function withAuth(authToken?: string, options?: RequestInit): RequestInit
    * working.
    */
   const token = authToken || localStorage.getItem('manifold_api_token');
-  if (typeof token !== 'string' || token.length === 0 || token.toLowerCase() === 'undefined') {
+
+  const isNotString = typeof token !== 'string';
+  const isEmpty = token === '';
+  const isUndefined = typeof token === 'string' && token.toLowerCase() === 'undefined';
+
+  if (isNotString || isEmpty || isUndefined) {
     return options;
   }
 

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -11,7 +11,7 @@ export function withAuth(authToken?: string, options?: RequestInit): RequestInit
    * working.
    */
   const token = authToken || localStorage.getItem('manifold_api_token');
-  if (typeof token !== 'string' || token.length === 0) {
+  if (typeof token !== 'string' || token.length === 0 || token.toLowerCase() === 'undefined') {
     return options;
   }
 

--- a/src/utils/restFetch.spec.ts
+++ b/src/utils/restFetch.spec.ts
@@ -132,12 +132,22 @@ describe('The fetcher created by createRestFetch', () => {
       return expect(req.headers).toEqual({ authorization: 'Bearer 1234' });
     }));
 
-  // TODO: add catalog auth in the future, but STILL KEEP ability for unauth’d reqs
-  it('doesn’t auth for catalog', async () => {
+  // TODO: make catalog wait for auth if provided
+  // (catalog will auth if token is there like it is in these tests, but won’t wait if it’s not)
+  it('auths for catalog if token is present initially', async () => {
     const fetcher = createRestFetch({
       wait: 1,
       getAuthToken: () => '1234',
     });
+    fetchMock.mock('path:/v1/test', 200);
+    await fetcher({ endpoint: '/test', service: 'catalog' });
+    const [, req] = fetchMock.lastCall() as any;
+    expect(req.headers).toEqual({ authorization: 'Bearer 1234' });
+  });
+
+  // TODO: add catalog auth in the future, but STILL KEEP ability for unauth’d reqs
+  it('doesn’t auth for catalog if token is absent', async () => {
+    const fetcher = createRestFetch(/* no token */);
     fetchMock.mock('path:/v1/test', 200);
     await fetcher({ endpoint: '/test', service: 'catalog' });
     const [, req] = fetchMock.lastCall() as any;

--- a/src/utils/restFetch.ts
+++ b/src/utils/restFetch.ts
@@ -27,17 +27,22 @@ export const createRestFetch = ({
   const url = `${endpoints[args.service]}${args.endpoint}`;
   const start = new Date();
 
-  while (!getAuthToken() && !hasExpired(start, wait)) {
+  // TODO: catalog should ALWAYS be able to fetch WITHOUT auth if needed,
+  // but this prevents the ability for it to auth altogether. We need both!
+  const isCatalog = args.service === 'catalog';
+
+  while (!getAuthToken() && !hasExpired(start, wait) && !isCatalog) {
     // eslint-disable-next-line no-await-in-loop
     await new Promise(resolve => setTimeout(resolve, 2000));
   }
 
-  if (!getAuthToken()) {
+  if (!getAuthToken() && !isCatalog) {
     return new Error('No auth token given');
   }
   try {
+    const token = isCatalog ? undefined : getAuthToken();
     const response = await fetch(url as string, {
-      ...withAuth(getAuthToken(), args.options),
+      ...withAuth(token, args.options),
       body: JSON.stringify(args.body),
     });
 

--- a/src/utils/restFetch.ts
+++ b/src/utils/restFetch.ts
@@ -31,18 +31,20 @@ export const createRestFetch = ({
   // but this prevents the ability for it to auth altogether. We need both!
   const isCatalog = args.service === 'catalog';
 
-  while (!getAuthToken() && !hasExpired(start, wait) && !isCatalog) {
-    // eslint-disable-next-line no-await-in-loop
-    await new Promise(resolve => setTimeout(resolve, 2000));
+  if (!isCatalog) {
+    while (!getAuthToken() && !hasExpired(start, wait)) {
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise(resolve => setTimeout(resolve, 2000));
+    }
+
+    if (!getAuthToken()) {
+      return new Error('No auth token given');
+    }
   }
 
-  if (!getAuthToken() && !isCatalog) {
-    return new Error('No auth token given');
-  }
   try {
-    const token = isCatalog ? undefined : getAuthToken();
     const response = await fetch(url as string, {
-      ...withAuth(token, args.options),
+      ...withAuth(getAuthToken(), args.options),
       body: JSON.stringify(args.body),
     });
 

--- a/stories/manifold-marketplace.stories.js
+++ b/stories/manifold-marketplace.stories.js
@@ -1,11 +1,9 @@
 import { storiesOf } from '@storybook/html';
 
 import markdown from '../docs/docs/components/manifold-marketplace.md';
-import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Marketplace', module)
   .addParameters({ readme: { sidebar: markdown } })
-  .addDecorator(manifoldConnectionDecorator)
   .add(
     'default',
     () =>

--- a/stories/manifold-plan-selector.stories.js
+++ b/stories/manifold-plan-selector.stories.js
@@ -1,11 +1,9 @@
 import { storiesOf } from '@storybook/html';
 
 import markdown from '../docs/docs/components/manifold-plan-selector.md';
-import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Plan Selector', module)
   .addParameters({ readme: { sidebar: markdown } })
-  .addDecorator(manifoldConnectionDecorator)
   .add(
     'Blitline',
     () => '<manifold-plan-selector product-label="blitline"></manifold-plan-selector>'

--- a/stories/manifold-plan.stories.js
+++ b/stories/manifold-plan.stories.js
@@ -8,7 +8,8 @@ storiesOf('Plan', module)
   .addDecorator(manifoldConnectionDecorator)
   .add(
     'ElegantCMS Free',
-    () => '<manifold-plan product-label="elegant-cms" plan-label="manifold-developer"></manifold-plan>'
+    () =>
+      '<manifold-plan product-label="elegant-cms" plan-label="manifold-developer"></manifold-plan>'
   )
   .add(
     'JawsDB Kitefin',

--- a/stories/manifold-product.stories.js
+++ b/stories/manifold-product.stories.js
@@ -1,11 +1,9 @@
 import { storiesOf } from '@storybook/html';
 
 import markdown from '../docs/docs/components/manifold-product.md';
-import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Product', module)
   .addParameters({ readme: { sidebar: markdown } })
-  .addDecorator(manifoldConnectionDecorator)
   .add(
     'JawsDB',
     () => `


### PR DESCRIPTION
## Reason for change
A [previous, large PR](#313) accidentally committed code that required all catalog components to authenticate. This broke [our dev server](https://ui.manifold.now.sh) as well as our docs (until they were mocked). This also broke partner integration, as these can no longer be used on marketing sites.

This doesn’t change the functionality of `restFetch`, but instead just doesn’t send the `authorization` header with a bad token.

This relates a bit to https://github.com/manifoldco/engineering/issues/8907, but doesn’t really solve the authenticated issue.

## Testing
Inspect **the Storybook (ZEIT now deployment) link in this PR**, and confirm all the catalog components (public-facing) work: `manifold-marketplace`, `manifold-product`, `manifold-plan-selector`, etc. etc.

⚠️ No seriously really look through Storybook please