### PR TITLE
Fix the service card title dynamic size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the deprovision button failing because the code expected a JSON return value.
 - Fixed the resource list not showing the status of provisioning or deprovisioning resources.
 - Fixed the resource card loading indicator - for a lack of a better word - wobbling around like its life depended on it.
+- Fixed the title of the `service-card` taking a dynamic amount of space and making the description look misaligned.
 
 ### Added
 - Added a `refetch-until-valid` property on the `resource-container` component to allow users to reload this component until the found resource exists and is of state `available`.

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a `refetch-until-valid` property on the `resource-container` component to allow users to reload this component until the found resource exists and is of state `available`.
 - Added the terms of service to the product page component.
 - Fixed the resource card loading indicator - for a lack of a better word - wobbling around like its life depended on it.
+- Fixed the title of the `service-card` taking a dynamic amount of space and making the description look misaligned.
 
 ## [v0.5.2]
 ### Added

--- a/src/components/manifold-service-card-view/manifold-service-card-view.css
+++ b/src/components/manifold-service-card-view/manifold-service-card-view.css
@@ -35,7 +35,7 @@
     'logo name'
     'info info'
     'tags tags';
-  grid-template-rows: min-content auto min-content;
+  grid-template-rows: 1.4rem auto min-content;
   grid-template-columns: var(--manifold-product-logo-s) auto;
   box-sizing: border-box;
   height: 100%;
@@ -66,7 +66,7 @@
     'logo name'
     'info info'
     'tags tags';
-  grid-template-rows: min-content auto min-content;
+  grid-template-rows: 1.4rem auto min-content;
   grid-template-columns: var(--manifold-product-logo-s) auto;
   box-sizing: border-box;
   height: 100%;

--- a/src/components/manifold-service-card-view/manifold-service-card-view.css
+++ b/src/components/manifold-service-card-view/manifold-service-card-view.css
@@ -35,8 +35,9 @@
     'logo name'
     'info info'
     'tags tags';
-  grid-template-rows: 1.4rem auto min-content;
+  grid-template-rows: auto 1fr auto;
   grid-template-columns: var(--manifold-product-logo-s) auto;
+  align-items: start;
   box-sizing: border-box;
   height: 100%;
   padding: var(--padding);
@@ -66,8 +67,9 @@
     'logo name'
     'info info'
     'tags tags';
-  grid-template-rows: 1.4rem auto min-content;
+  grid-template-rows: auto 1fr auto;
   grid-template-columns: var(--manifold-product-logo-s) auto;
+  align-items: start;
   box-sizing: border-box;
   height: 100%;
   padding: var(--padding);

--- a/stories/manifold-marketplace.stories.js
+++ b/stories/manifold-marketplace.stories.js
@@ -21,4 +21,9 @@ storiesOf('Marketplace', module)
     'compact',
     () =>
       '<manifold-marketplace hide-categories hide-search products="iron_cache,iron_mq,jawsdb-mysql,jawsdb-postgres,mailgun,logdna,iron_worker,zerosix"></manifold-marketplace>'
+  )
+  .add(
+    'curated',
+    () =>
+      '<manifold-marketplace hide-templates="" hide-search="" hide-categories="" products="logdna,scoutapp,timber-logging,cloudcube"></manifold-marketplace>'
   );


### PR DESCRIPTION
Work is related to manifoldco/engineering#8934

## Reason for change
The dynamic sizing the the service card's first row made it so that the description would often look misaligned when products with different a number of lines for the description were put next to each other. This adds a fixed width for the first row of the service card.

![Capture d’écran 2019-08-08 à 14 01 56](https://user-images.githubusercontent.com/20424444/62726575-9336c400-b9e5-11e9-984f-89c5451725f8.png)

## Testing
Test with storybook, a new story for the marketplace called "curated" shows the behavior we wanted to fix.
