### PR TITLE
Add happo wrapper module to provide auth token

### DIFF
--- a/.happo.js
+++ b/.happo.js
@@ -14,6 +14,7 @@ module.exports = {
   type: 'plain',
   prerender: false,
   setupScript: path.resolve(__dirname, 'happoSetup.js'),
+  renderWrapperModule: path.resolve(__dirname, 'happoRender.js'),
   stylesheets: [path.join(__dirname, 'dist/manifold/manifold.css')],
   plugins: [happoPluginTypeScript()],
 };

--- a/happoRender.js
+++ b/happoRender.js
@@ -1,0 +1,5 @@
+export default component => `
+<manifold-connection>
+  <manifold-auth-token token="something|${new Date(Date.now() + 6.04e8).getTime()}"/>
+  ${component}
+</manifold-connection>`;


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

Polling for the auth token was breaking the happo tests because there was no auth token given. This wraps every happo example inside a module that provides the auth token.

## Testing
<!-- For someone unfamiliar with the issue, how should this be tested? -->

Make sure the happo check still produces screenshots!