### PR TITLE
Mark plan cost API as public to prevent auth token polling

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1030,23 +1030,6 @@
         "@manifoldco/gql-zero": "^0.2.0",
         "@manifoldco/shadowcat": "^0.1.5",
         "@stencil/state-tunnel": "^1.0.1"
-      },
-      "dependencies": {
-        "@manifoldco/gql-zero": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/@manifoldco/gql-zero/-/gql-zero-0.2.0.tgz",
-          "integrity": "sha512-s0nPkp5PUzvqK8SaIQEMw5AYArC4slq+YQ9xL9lG8QImMO1NIWfnrvwJRVAO+Ns5dmeZeAdXACX+1g2k27I0Yg=="
-        },
-        "@manifoldco/shadowcat": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/@manifoldco/shadowcat/-/shadowcat-0.1.5.tgz",
-          "integrity": "sha512-d+UIi9vyUjExBVXFtnrqUpF1agupnqTrA4AVPCqADpGs6/XawKiAU7bJyKuW51k+AQHSZLygB1G1C7EFHW89AA=="
-        },
-        "@stencil/state-tunnel": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@stencil/state-tunnel/-/state-tunnel-1.0.1.tgz",
-          "integrity": "sha512-DYG8uROgL9hkjVTCtCfRBb0d3FwpiFB0muRrNZQ2X1Qo5hxMuNNji76/ILddqeq0AfgkKCW82xrMPDpy+rNIhQ=="
-        }
       }
     },
     "@mikaelkristiansson/domready": {

--- a/src/utils/plan.ts
+++ b/src/utils/plan.ts
@@ -320,6 +320,7 @@ export function planCost(
   return restFetch<Gateway.Price>({
     service: 'gateway',
     endpoint: `/id/plan/${planID}/cost`,
+    isPublic: true,
     body: { features },
     options: {
       method: 'POST',

--- a/src/utils/restFetch.ts
+++ b/src/utils/restFetch.ts
@@ -14,6 +14,7 @@ interface RestFetchArguments {
   endpoint: string;
   body?: object;
   options?: Omit<RequestInit, 'body'>;
+  isPublic?: boolean;
 }
 
 export type RestFetch = <T>(args: RestFetchArguments) => Promise<T | Error>;
@@ -30,8 +31,9 @@ export const createRestFetch = ({
   // TODO: catalog should ALWAYS be able to fetch WITHOUT auth if needed,
   // but this prevents the ability for it to auth altogether. We need both!
   const isCatalog = args.service === 'catalog';
+  const isPublic = isCatalog || args.isPublic;
 
-  if (!isCatalog) {
+  if (!isPublic) {
     while (!getAuthToken() && !hasExpired(start, wait)) {
       // eslint-disable-next-line no-await-in-loop
       await new Promise(resolve => setTimeout(resolve, 2000));


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

The plan selector currently won't work when not authenticated because the calls to get the plan cost are polling for the auth token. But this is a public API, so it should not stop the plan selector from working.

## Testing
<!-- For someone unfamiliar with the issue, how should this be tested? -->

Make sure the plan selector works in storybook with no authentication.