### PR TITLE
Expose the credentials buttons colors for more customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed the service card loading the free badge after rendering, which caused a jumpy UI.
 - Simplied `<manifold-service-card>` (data) and `<manifold-service-card-view>` (“dumb” view)
+- Added the ability to specify the colors of the `manifold-credentials`'s buttons;
 
 ## [v0.5.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed the service card loading the free badge after rendering, which caused a jumpy UI.
 - Simplied `<manifold-service-card>` (data) and `<manifold-service-card-view>` (“dumb” view)
-- Added the ability to specify the colors of the `manifold-credentials`'s buttons;
+- Added the ability to specify a slot on the `manifold-credentials` with a default manifold button if not set.
 
 ## [v0.5.3]
 

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed the service card loading the free badge after rendering, which caused a jumpy UI.
 - Simplied `<manifold-service-card>` (data) and `<manifold-service-card-view>` (“dumb” view)
-- Added the ability to specify the colors of the `manifold-credentials`'s buttons;
+- Added the ability to specify a slot on the `manifold-credentials` with a default manifold button if not set.
 
 ## [v0.5.3]
 

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed the service card loading the free badge after rendering, which caused a jumpy UI.
 - Simplied `<manifold-service-card>` (data) and `<manifold-service-card-view>` (“dumb” view)
+- Added the ability to specify the colors of the `manifold-credentials`'s buttons;
 
 ## [v0.5.3]
 

--- a/docs/docs/components/manifold-credentials.md
+++ b/docs/docs/components/manifold-credentials.md
@@ -1,7 +1,7 @@
 ---
 title: '🔒 Resource Credentials'
 path: '/components/credentials'
-example: '<manifold-credentials resource-name="cms-stage" show-button-color="pink"></manifold-credentials>'
+example: '<manifold-credentials resource-name="cms-stage"></manifold-credentials>'
 ---
 
 # 🔒 Credentials

--- a/docs/docs/components/manifold-credentials.md
+++ b/docs/docs/components/manifold-credentials.md
@@ -1,7 +1,7 @@
 ---
 title: '🔒 Resource Credentials'
 path: '/components/credentials'
-example: '<manifold-credentials resource-name="cms-stage"></manifold-credentials>'
+example: '<manifold-credentials resource-name="cms-stage" show-button-color="pink"></manifold-credentials>'
 ---
 
 # 🔒 Credentials

--- a/docs/docs/components/manifold-credentials.md
+++ b/docs/docs/components/manifold-credentials.md
@@ -14,13 +14,18 @@ The resource label needs to be provided for the component to be able to fetch th
 <manifold-credentials resource-label="my-resource"></manifold-credentials>
 ```
 
-## Button colors
+## Customizing the buttons
 
-The component supports all the colors available to the [`manifold-button`](/internal/manifold-button) component for the two buttons it renders.
+You can pass in your own button or link for the show and hide buttons of the component by passing in any element with `slot="show-button"` and `slot="hide-button"` as an attribute respectively. [Read more about slots][slot].
 
-Use the `showButtonColor` property for the color of the button during the default state and the `hideButtonColor` property for the color of the button once the credentials are shown.
-
-```html
-<manifold-credentials resource-label="my-resource" showButtonColor="orange" hideButtonColor="pink"></manifold-credentials>
+```jsx
+<manifold-credentials resource-label="my-resource">
+  <MyButton slot="show-button">
+    Show credentials
+  </MyButton>
+  <MyButton slot="hide-button">
+    Hide credentials
+  </MyButton>
+</manifold-credentials>
 ```
 

--- a/docs/docs/components/manifold-credentials.md
+++ b/docs/docs/components/manifold-credentials.md
@@ -14,3 +14,13 @@ The resource label needs to be provided for the component to be able to fetch th
 <manifold-credentials resource-label="my-resource"></manifold-credentials>
 ```
 
+## Button colors
+
+The component supports all the colors available to the [`manifold-button`](/internal/manifold-button) component for the two buttons it renders.
+
+Use the `showButtonColor` property for the color of the button during the default state and the `hideButtonColor` property for the color of the button once the credentials are shown.
+
+```html
+<manifold-credentials resource-label="my-resource" showButtonColor="orange" hideButtonColor="pink"></manifold-credentials>
+```
+

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1030,23 +1030,6 @@
         "@manifoldco/gql-zero": "^0.2.0",
         "@manifoldco/shadowcat": "^0.1.5",
         "@stencil/state-tunnel": "^1.0.1"
-      },
-      "dependencies": {
-        "@manifoldco/gql-zero": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/@manifoldco/gql-zero/-/gql-zero-0.2.0.tgz",
-          "integrity": "sha512-s0nPkp5PUzvqK8SaIQEMw5AYArC4slq+YQ9xL9lG8QImMO1NIWfnrvwJRVAO+Ns5dmeZeAdXACX+1g2k27I0Yg=="
-        },
-        "@manifoldco/shadowcat": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/@manifoldco/shadowcat/-/shadowcat-0.1.5.tgz",
-          "integrity": "sha512-d+UIi9vyUjExBVXFtnrqUpF1agupnqTrA4AVPCqADpGs6/XawKiAU7bJyKuW51k+AQHSZLygB1G1C7EFHW89AA=="
-        },
-        "@stencil/state-tunnel": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@stencil/state-tunnel/-/state-tunnel-1.0.1.tgz",
-          "integrity": "sha512-DYG8uROgL9hkjVTCtCfRBb0d3FwpiFB0muRrNZQ2X1Qo5hxMuNNji76/ILddqeq0AfgkKCW82xrMPDpy+rNIhQ=="
-        }
       }
     },
     "@mikaelkristiansson/domready": {

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -16,6 +16,9 @@ import {
   RestFetch,
 } from './utils/restFetch';
 import {
+  buttonColors,
+} from './components/manifold-button/manifold-button';
+import {
   GraphqlRequestBody,
   GraphqlResponseBody,
 } from './utils/graphqlFetch';
@@ -82,12 +85,14 @@ export namespace Components {
     'startingAt'?: boolean;
   }
   interface ManifoldCredentials {
+    'hideButtonColor': buttonColors;
     'resourceId'?: string;
     'resourceLabel': string;
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
     'restFetch'?: RestFetch;
+    'showButtonColor': buttonColors;
   }
   interface ManifoldDataDeprovisionButton {
     'loading'?: boolean;
@@ -497,11 +502,18 @@ export namespace Components {
     */
     'restFetch'?: RestFetch;
   }
-  interface ManifoldResourceCredentials {}
+  interface ManifoldResourceCredentials {
+    'data'?: Gateway.Resource;
+    'hideButtonColor': buttonColors;
+    'loading': boolean;
+    'showButtonColor': buttonColors;
+  }
   interface ManifoldResourceCredentialsView {
     'credentials'?: Marketplace.Credential[];
+    'hideButtonColor': buttonColors;
     'loading': boolean;
     'resourceLabel': string;
+    'showButtonColor': buttonColors;
   }
   interface ManifoldResourceDeprovision {
     'data'?: Gateway.Resource;
@@ -1104,12 +1116,14 @@ declare namespace LocalJSX {
     'startingAt'?: boolean;
   }
   interface ManifoldCredentials extends JSXBase.HTMLAttributes<HTMLManifoldCredentialsElement> {
+    'hideButtonColor'?: buttonColors;
     'resourceId'?: string;
     'resourceLabel'?: string;
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
     'restFetch'?: RestFetch;
+    'showButtonColor'?: buttonColors;
   }
   interface ManifoldDataDeprovisionButton extends JSXBase.HTMLAttributes<HTMLManifoldDataDeprovisionButtonElement> {
     'loading'?: boolean;
@@ -1543,12 +1557,19 @@ declare namespace LocalJSX {
     */
     'restFetch'?: RestFetch;
   }
-  interface ManifoldResourceCredentials extends JSXBase.HTMLAttributes<HTMLManifoldResourceCredentialsElement> {}
+  interface ManifoldResourceCredentials extends JSXBase.HTMLAttributes<HTMLManifoldResourceCredentialsElement> {
+    'data'?: Gateway.Resource;
+    'hideButtonColor'?: buttonColors;
+    'loading'?: boolean;
+    'showButtonColor'?: buttonColors;
+  }
   interface ManifoldResourceCredentialsView extends JSXBase.HTMLAttributes<HTMLManifoldResourceCredentialsViewElement> {
     'credentials'?: Marketplace.Credential[];
+    'hideButtonColor'?: buttonColors;
     'loading'?: boolean;
     'onCredentialsRequested'?: (event: CustomEvent<any>) => void;
     'resourceLabel'?: string;
+    'showButtonColor'?: buttonColors;
   }
   interface ManifoldResourceDeprovision extends JSXBase.HTMLAttributes<HTMLManifoldResourceDeprovisionElement> {
     'data'?: Gateway.Resource;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -16,9 +16,6 @@ import {
   RestFetch,
 } from './utils/restFetch';
 import {
-  buttonColors,
-} from './components/manifold-button/manifold-button';
-import {
   Marketplace,
 } from './types/marketplace';
 import {
@@ -85,21 +82,17 @@ export namespace Components {
     'startingAt'?: boolean;
   }
   interface ManifoldCredentials {
-    'hideButtonColor': buttonColors;
     'resourceId'?: string;
     'resourceLabel': string;
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
     'restFetch'?: RestFetch;
-    'showButtonColor': buttonColors;
   }
   interface ManifoldCredentialsView {
     'credentials'?: Marketplace.Credential[];
-    'hideButtonColor': buttonColors;
     'loading': boolean;
     'resourceLabel': string;
-    'showButtonColor': buttonColors;
   }
   interface ManifoldDataDeprovisionButton {
     'loading'?: boolean;
@@ -511,9 +504,7 @@ export namespace Components {
   }
   interface ManifoldResourceCredentials {
     'data'?: Gateway.Resource;
-    'hideButtonColor': buttonColors;
     'loading': boolean;
-    'showButtonColor': buttonColors;
   }
   interface ManifoldResourceDeprovision {
     'data'?: Gateway.Resource;
@@ -1116,22 +1107,18 @@ declare namespace LocalJSX {
     'startingAt'?: boolean;
   }
   interface ManifoldCredentials extends JSXBase.HTMLAttributes<HTMLManifoldCredentialsElement> {
-    'hideButtonColor'?: buttonColors;
     'resourceId'?: string;
     'resourceLabel'?: string;
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
     'restFetch'?: RestFetch;
-    'showButtonColor'?: buttonColors;
   }
   interface ManifoldCredentialsView extends JSXBase.HTMLAttributes<HTMLManifoldCredentialsViewElement> {
     'credentials'?: Marketplace.Credential[];
-    'hideButtonColor'?: buttonColors;
     'loading'?: boolean;
     'onCredentialsRequested'?: (event: CustomEvent<any>) => void;
     'resourceLabel'?: string;
-    'showButtonColor'?: buttonColors;
   }
   interface ManifoldDataDeprovisionButton extends JSXBase.HTMLAttributes<HTMLManifoldDataDeprovisionButtonElement> {
     'loading'?: boolean;
@@ -1567,9 +1554,7 @@ declare namespace LocalJSX {
   }
   interface ManifoldResourceCredentials extends JSXBase.HTMLAttributes<HTMLManifoldResourceCredentialsElement> {
     'data'?: Gateway.Resource;
-    'hideButtonColor'?: buttonColors;
     'loading'?: boolean;
-    'showButtonColor'?: buttonColors;
   }
   interface ManifoldResourceDeprovision extends JSXBase.HTMLAttributes<HTMLManifoldResourceDeprovisionElement> {
     'data'?: Gateway.Resource;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -19,12 +19,12 @@ import {
   buttonColors,
 } from './components/manifold-button/manifold-button';
 import {
+  Marketplace,
+} from './types/marketplace';
+import {
   GraphqlRequestBody,
   GraphqlResponseBody,
 } from './utils/graphqlFetch';
-import {
-  Marketplace,
-} from './types/marketplace';
 import {
   Option,
 } from './types/Select';
@@ -92,6 +92,13 @@ export namespace Components {
     * _(hidden)_ Passed by `<manifold-connection>`
     */
     'restFetch'?: RestFetch;
+    'showButtonColor': buttonColors;
+  }
+  interface ManifoldCredentialsView {
+    'credentials'?: Marketplace.Credential[];
+    'hideButtonColor': buttonColors;
+    'loading': boolean;
+    'resourceLabel': string;
     'showButtonColor': buttonColors;
   }
   interface ManifoldDataDeprovisionButton {
@@ -508,13 +515,6 @@ export namespace Components {
     'loading': boolean;
     'showButtonColor': buttonColors;
   }
-  interface ManifoldResourceCredentialsView {
-    'credentials'?: Marketplace.Credential[];
-    'hideButtonColor': buttonColors;
-    'loading': boolean;
-    'resourceLabel': string;
-    'showButtonColor': buttonColors;
-  }
   interface ManifoldResourceDeprovision {
     'data'?: Gateway.Resource;
     'loading': boolean;
@@ -680,6 +680,12 @@ declare global {
   var HTMLManifoldCredentialsElement: {
     prototype: HTMLManifoldCredentialsElement;
     new (): HTMLManifoldCredentialsElement;
+  };
+
+  interface HTMLManifoldCredentialsViewElement extends Components.ManifoldCredentialsView, HTMLStencilElement {}
+  var HTMLManifoldCredentialsViewElement: {
+    prototype: HTMLManifoldCredentialsViewElement;
+    new (): HTMLManifoldCredentialsViewElement;
   };
 
   interface HTMLManifoldDataDeprovisionButtonElement extends Components.ManifoldDataDeprovisionButton, HTMLStencilElement {}
@@ -874,12 +880,6 @@ declare global {
     new (): HTMLManifoldResourceCredentialsElement;
   };
 
-  interface HTMLManifoldResourceCredentialsViewElement extends Components.ManifoldResourceCredentialsView, HTMLStencilElement {}
-  var HTMLManifoldResourceCredentialsViewElement: {
-    prototype: HTMLManifoldResourceCredentialsViewElement;
-    new (): HTMLManifoldResourceCredentialsViewElement;
-  };
-
   interface HTMLManifoldResourceDeprovisionElement extends Components.ManifoldResourceDeprovision, HTMLStencilElement {}
   var HTMLManifoldResourceDeprovisionElement: {
     prototype: HTMLManifoldResourceDeprovisionElement;
@@ -1002,6 +1002,7 @@ declare global {
     'manifold-connection': HTMLManifoldConnectionElement;
     'manifold-cost-display': HTMLManifoldCostDisplayElement;
     'manifold-credentials': HTMLManifoldCredentialsElement;
+    'manifold-credentials-view': HTMLManifoldCredentialsViewElement;
     'manifold-data-deprovision-button': HTMLManifoldDataDeprovisionButtonElement;
     'manifold-data-has-resource': HTMLManifoldDataHasResourceElement;
     'manifold-data-manage-button': HTMLManifoldDataManageButtonElement;
@@ -1034,7 +1035,6 @@ declare global {
     'manifold-resource-card-view': HTMLManifoldResourceCardViewElement;
     'manifold-resource-container': HTMLManifoldResourceContainerElement;
     'manifold-resource-credentials': HTMLManifoldResourceCredentialsElement;
-    'manifold-resource-credentials-view': HTMLManifoldResourceCredentialsViewElement;
     'manifold-resource-deprovision': HTMLManifoldResourceDeprovisionElement;
     'manifold-resource-details': HTMLManifoldResourceDetailsElement;
     'manifold-resource-details-view': HTMLManifoldResourceDetailsViewElement;
@@ -1123,6 +1123,14 @@ declare namespace LocalJSX {
     * _(hidden)_ Passed by `<manifold-connection>`
     */
     'restFetch'?: RestFetch;
+    'showButtonColor'?: buttonColors;
+  }
+  interface ManifoldCredentialsView extends JSXBase.HTMLAttributes<HTMLManifoldCredentialsViewElement> {
+    'credentials'?: Marketplace.Credential[];
+    'hideButtonColor'?: buttonColors;
+    'loading'?: boolean;
+    'onCredentialsRequested'?: (event: CustomEvent<any>) => void;
+    'resourceLabel'?: string;
     'showButtonColor'?: buttonColors;
   }
   interface ManifoldDataDeprovisionButton extends JSXBase.HTMLAttributes<HTMLManifoldDataDeprovisionButtonElement> {
@@ -1563,14 +1571,6 @@ declare namespace LocalJSX {
     'loading'?: boolean;
     'showButtonColor'?: buttonColors;
   }
-  interface ManifoldResourceCredentialsView extends JSXBase.HTMLAttributes<HTMLManifoldResourceCredentialsViewElement> {
-    'credentials'?: Marketplace.Credential[];
-    'hideButtonColor'?: buttonColors;
-    'loading'?: boolean;
-    'onCredentialsRequested'?: (event: CustomEvent<any>) => void;
-    'resourceLabel'?: string;
-    'showButtonColor'?: buttonColors;
-  }
   interface ManifoldResourceDeprovision extends JSXBase.HTMLAttributes<HTMLManifoldResourceDeprovisionElement> {
     'data'?: Gateway.Resource;
     'loading'?: boolean;
@@ -1709,6 +1709,7 @@ declare namespace LocalJSX {
     'manifold-connection': ManifoldConnection;
     'manifold-cost-display': ManifoldCostDisplay;
     'manifold-credentials': ManifoldCredentials;
+    'manifold-credentials-view': ManifoldCredentialsView;
     'manifold-data-deprovision-button': ManifoldDataDeprovisionButton;
     'manifold-data-has-resource': ManifoldDataHasResource;
     'manifold-data-manage-button': ManifoldDataManageButton;
@@ -1741,7 +1742,6 @@ declare namespace LocalJSX {
     'manifold-resource-card-view': ManifoldResourceCardView;
     'manifold-resource-container': ManifoldResourceContainer;
     'manifold-resource-credentials': ManifoldResourceCredentials;
-    'manifold-resource-credentials-view': ManifoldResourceCredentialsView;
     'manifold-resource-deprovision': ManifoldResourceDeprovision;
     'manifold-resource-details': ManifoldResourceDetails;
     'manifold-resource-details-view': ManifoldResourceDetailsView;

--- a/src/components/manifold-button/manifold-button.tsx
+++ b/src/components/manifold-button/manifold-button.tsx
@@ -1,6 +1,8 @@
 import { h, Component, Prop, Event, EventEmitter } from '@stencil/core';
 import logger from '../../utils/logger';
 
+export type buttonColors = 'black' | 'gray' | 'orange' | 'pink' | 'white';
+
 @Component({
   tag: 'manifold-button',
   styleUrl: 'manifold-button.css',

--- a/src/components/manifold-credentials-view/manifold-credentials-view-happo.ts
+++ b/src/components/manifold-credentials-view/manifold-credentials-view-happo.ts
@@ -2,7 +2,7 @@ import credentials from '../../spec/mock/cms-stage/credentials.json';
 import fromJSON from '../../spec/mock/fromJSON';
 
 export const credsHidden = () => {
-  const creds = document.createElement('manifold-resource-credentials-view');
+  const creds = document.createElement('manifold-credentials-view');
   creds.resourceLabel = 'test';
 
   document.body.appendChild(creds);
@@ -11,7 +11,7 @@ export const credsHidden = () => {
 };
 
 export const credsShown = () => {
-  const creds = document.createElement('manifold-resource-credentials-view');
+  const creds = document.createElement('manifold-credentials-view');
   creds.resourceLabel = 'test';
   creds.credentials = fromJSON(credentials);
 
@@ -21,7 +21,7 @@ export const credsShown = () => {
 };
 
 export const resourceLoading = () => {
-  const creds = document.createElement('manifold-resource-credentials-view');
+  const creds = document.createElement('manifold-credentials-view');
   creds.loading = true;
 
   document.body.appendChild(creds);

--- a/src/components/manifold-credentials-view/manifold-credentials-view-happo.ts
+++ b/src/components/manifold-credentials-view/manifold-credentials-view-happo.ts
@@ -1,5 +1,6 @@
 import credentials from '../../spec/mock/cms-stage/credentials.json';
 import fromJSON from '../../spec/mock/fromJSON';
+import { buttonColors } from '../manifold-button/manifold-button';
 
 export const credsHidden = () => {
   const creds = document.createElement('manifold-credentials-view');
@@ -27,4 +28,43 @@ export const resourceLoading = () => {
   document.body.appendChild(creds);
 
   return creds.componentOnReady();
+};
+
+export const credsHiddenWithCustomColor = () => {
+  const container = document.createElement('div');
+  const promises = Promise.all(
+    ['black', 'gray', 'orange', 'pink', 'white'].map(color => {
+      const creds = document.createElement('manifold-credentials-view');
+      creds.resourceLabel = 'test';
+      creds.showButtonColor = color as buttonColors;
+
+      container.appendChild(creds);
+
+      return creds.componentOnReady();
+    })
+  );
+
+  document.body.appendChild(container);
+
+  return promises;
+};
+
+export const credsShownWithCustomColor = () => {
+  const container = document.createElement('div');
+  const promises = Promise.all(
+    ['black', 'gray', 'orange', 'pink', 'white'].map(color => {
+      const creds = document.createElement('manifold-credentials-view');
+      creds.resourceLabel = 'test';
+      creds.credentials = fromJSON(credentials);
+      creds.hideButtonColor = color as buttonColors;
+
+      container.appendChild(creds);
+
+      return creds.componentOnReady();
+    })
+  );
+
+  document.body.appendChild(container);
+
+  return promises;
 };

--- a/src/components/manifold-credentials-view/manifold-credentials-view-happo.ts
+++ b/src/components/manifold-credentials-view/manifold-credentials-view-happo.ts
@@ -1,6 +1,5 @@
 import credentials from '../../spec/mock/cms-stage/credentials.json';
 import fromJSON from '../../spec/mock/fromJSON';
-import { buttonColors } from '../manifold-button/manifold-button';
 
 export const credsHidden = () => {
   const creds = document.createElement('manifold-credentials-view');
@@ -30,41 +29,41 @@ export const resourceLoading = () => {
   return creds.componentOnReady();
 };
 
-export const credsHiddenWithCustomColor = () => {
+export const credsHiddenWithCustomButton = () => {
+  const creds = document.createElement('manifold-credentials-view');
+  creds.resourceLabel = 'test';
+
+  const button = document.createElement('manifold-button');
+  button.color = 'orange';
+  button.title = 'Show credentials';
+  button.appendChild(document.createTextNode('Show credentials'));
+
   const container = document.createElement('div');
-  const promises = Promise.all(
-    ['black', 'gray', 'orange', 'pink', 'white'].map(color => {
-      const creds = document.createElement('manifold-credentials-view');
-      creds.resourceLabel = 'test';
-      creds.showButtonColor = color as buttonColors;
+  container.slot = 'show-button';
+  container.appendChild(button);
 
-      container.appendChild(creds);
+  creds.appendChild(container);
+  document.body.appendChild(creds);
 
-      return creds.componentOnReady();
-    })
-  );
-
-  document.body.appendChild(container);
-
-  return promises;
+  return creds.componentOnReady();
 };
 
-export const credsShownWithCustomColor = () => {
+export const credsShownWithCustomButton = () => {
+  const creds = document.createElement('manifold-credentials-view');
+  creds.resourceLabel = 'test';
+  creds.credentials = fromJSON(credentials);
+
+  const button = document.createElement('manifold-button');
+  button.color = 'orange';
+  button.title = 'Hide credentials';
+  button.appendChild(document.createTextNode('Show credentials'));
+
   const container = document.createElement('div');
-  const promises = Promise.all(
-    ['black', 'gray', 'orange', 'pink', 'white'].map(color => {
-      const creds = document.createElement('manifold-credentials-view');
-      creds.resourceLabel = 'test';
-      creds.credentials = fromJSON(credentials);
-      creds.hideButtonColor = color as buttonColors;
+  container.slot = 'hide-button';
+  container.appendChild(button);
 
-      container.appendChild(creds);
+  creds.appendChild(container);
+  document.body.appendChild(creds);
 
-      return creds.componentOnReady();
-    })
-  );
-
-  document.body.appendChild(container);
-
-  return promises;
+  return creds.componentOnReady();
 };

--- a/src/components/manifold-credentials-view/manifold-credentials-view.css
+++ b/src/components/manifold-credentials-view/manifold-credentials-view.css
@@ -56,7 +56,7 @@
   font-size: var(--manifold-font-d1);
   transition: transform 250ms var(--manifold-ease-sharp), opacity 250ms linear;
 
-  & manifold-button {
+  & manifold-button, & > ::slotted(*) {
     margin-top: 1rem;
     transform: translateX(-50%);
   }

--- a/src/components/manifold-credentials-view/manifold-credentials-view.tsx
+++ b/src/components/manifold-credentials-view/manifold-credentials-view.tsx
@@ -3,6 +3,7 @@ import { eye, lock, loader } from '@manifoldco/icons';
 
 import { Marketplace } from '../../types/marketplace';
 import logger from '../../utils/logger';
+import { buttonColors } from '../manifold-button/manifold-button';
 
 @Component({
   tag: 'manifold-resource-credentials-view',
@@ -10,6 +11,8 @@ import logger from '../../utils/logger';
   shadow: true,
 })
 export class ManifoldResourceCredentials {
+  @Prop() showButtonColor: buttonColors = 'black';
+  @Prop() hideButtonColor: buttonColors = 'white';
   @Prop() credentials?: Marketplace.Credential[];
   @Prop() resourceLabel: string = '';
   @Prop() loading: boolean = false;
@@ -39,7 +42,11 @@ export class ManifoldResourceCredentials {
   render() {
     return [
       <menu class="secrets-menu" data-showing={!!this.credentials}>
-        <manifold-button color="white" size="small" stencilClickEvent={this.hideCredentials}>
+        <manifold-button
+          color={this.hideButtonColor}
+          size="small"
+          stencilClickEvent={this.hideCredentials}
+        >
           <manifold-icon marginRight icon={lock} />
           Hide credentials
         </manifold-button>
@@ -72,13 +79,16 @@ export class ManifoldResourceCredentials {
         )}
         <div class="hidden">
           {this.loading ? (
-            <manifold-button color="black" disabled>
+            <manifold-button color={this.showButtonColor} disabled>
               <span class="spin">
                 <manifold-icon icon={loader} />
               </span>
             </manifold-button>
           ) : (
-            <manifold-button color="black" stencilClickEvent={this.requestCredentials}>
+            <manifold-button
+              color={this.showButtonColor}
+              stencilClickEvent={this.requestCredentials}
+            >
               <manifold-icon marginRight icon={eye} /> Show credentials
             </manifold-button>
           )}

--- a/src/components/manifold-credentials-view/manifold-credentials-view.tsx
+++ b/src/components/manifold-credentials-view/manifold-credentials-view.tsx
@@ -1,9 +1,8 @@
-import { h, Component, Prop, Event, EventEmitter } from '@stencil/core';
+import { h, Component, Prop, Event, EventEmitter, Element } from '@stencil/core';
 import { eye, lock, loader } from '@manifoldco/icons';
 
 import { Marketplace } from '../../types/marketplace';
 import logger from '../../utils/logger';
-import { buttonColors } from '../manifold-button/manifold-button';
 
 @Component({
   tag: 'manifold-credentials-view',
@@ -11,12 +10,29 @@ import { buttonColors } from '../manifold-button/manifold-button';
   shadow: true,
 })
 export class ManifoldResourceCredentials {
-  @Prop() showButtonColor: buttonColors = 'black';
-  @Prop() hideButtonColor: buttonColors = 'white';
+  @Element() private el: HTMLElement;
   @Prop() credentials?: Marketplace.Credential[];
   @Prop() resourceLabel: string = '';
   @Prop() loading: boolean = false;
   @Event() credentialsRequested: EventEmitter;
+
+  showButtonEl?: Element;
+  hideButtonEl?: Element;
+
+  componentWillLoad() {
+    this.findNodes();
+    this.addListeners();
+  }
+
+  componentDidUpdate() {
+    this.removeListeners();
+    this.findNodes();
+    this.addListeners();
+  }
+
+  componentDidUnload() {
+    this.removeListeners();
+  }
 
   get lines() {
     // Returns # of lines for creds.
@@ -30,6 +46,36 @@ export class ManifoldResourceCredentials {
     );
   }
 
+  findNodes() {
+    this.el.childNodes.forEach(child => {
+      if ((child as HTMLElement).slot === 'show-button') {
+        this.showButtonEl =
+          (child as HTMLElement).querySelector(':not(manifold-forward-slot)') || undefined;
+      } else if ((child as HTMLElement).slot === 'hide-button') {
+        this.hideButtonEl =
+          (child as HTMLElement).querySelector(':not(manifold-forward-slot)') || undefined;
+      }
+    });
+  }
+
+  addListeners() {
+    if (this.showButtonEl) {
+      this.showButtonEl.addEventListener('click', this.requestCredentials);
+    }
+    if (this.hideButtonEl) {
+      this.hideButtonEl.addEventListener('click', this.hideCredentials);
+    }
+  }
+
+  removeListeners() {
+    if (this.showButtonEl) {
+      this.showButtonEl.removeEventListener('click', this.requestCredentials);
+    }
+    if (this.hideButtonEl) {
+      this.hideButtonEl.removeEventListener('click', this.hideCredentials);
+    }
+  }
+
   hideCredentials = () => {
     this.credentials = undefined;
   };
@@ -40,16 +86,24 @@ export class ManifoldResourceCredentials {
 
   @logger()
   render() {
+    const showButton = this.showButtonEl ? (
+      <slot name="show-button" />
+    ) : (
+      <manifold-button color="black" stencilClickEvent={this.requestCredentials}>
+        <manifold-icon marginRight icon={eye} /> Show credentials
+      </manifold-button>
+    );
+
     return [
       <menu class="secrets-menu" data-showing={!!this.credentials}>
-        <manifold-button
-          color={this.hideButtonColor}
-          size="small"
-          stencilClickEvent={this.hideCredentials}
-        >
-          <manifold-icon marginRight icon={lock} />
-          Hide credentials
-        </manifold-button>
+        {this.hideButtonEl ? (
+          <slot name="hide-button" />
+        ) : (
+          <manifold-button color="white" size="small" stencilClickEvent={this.hideCredentials}>
+            <manifold-icon marginRight icon={lock} />
+            Hide credentials
+          </manifold-button>
+        )}
       </menu>,
       <div
         class="credential"
@@ -79,18 +133,13 @@ export class ManifoldResourceCredentials {
         )}
         <div class="hidden">
           {this.loading ? (
-            <manifold-button color={this.showButtonColor} disabled>
+            <manifold-button color="black" disabled>
               <span class="spin">
                 <manifold-icon icon={loader} />
               </span>
             </manifold-button>
           ) : (
-            <manifold-button
-              color={this.showButtonColor}
-              stencilClickEvent={this.requestCredentials}
-            >
-              <manifold-icon marginRight icon={eye} /> Show credentials
-            </manifold-button>
+            showButton
           )}
         </div>
       </div>,

--- a/src/components/manifold-credentials-view/manifold-credentials-view.tsx
+++ b/src/components/manifold-credentials-view/manifold-credentials-view.tsx
@@ -6,7 +6,7 @@ import logger from '../../utils/logger';
 import { buttonColors } from '../manifold-button/manifold-button';
 
 @Component({
-  tag: 'manifold-resource-credentials-view',
+  tag: 'manifold-credentials-view',
   styleUrl: 'manifold-credentials-view.css',
   shadow: true,
 })

--- a/src/components/manifold-credentials/manifold-credentials.tsx
+++ b/src/components/manifold-credentials/manifold-credentials.tsx
@@ -69,9 +69,9 @@ export class ManifoldCredentials {
   @logger()
   render() {
     return (
-      <manifold-resource-credentials-view
+      <manifold-credentials-view
         showButtonColor={this.showButtonColor}
-        hideButtonColor={this.showButtonColor}
+        hideButtonColor={this.hideButtonColor}
         loading={this.loading}
         resourceLabel={this.resourceLabel}
         credentials={this.credentials}

--- a/src/components/manifold-credentials/manifold-credentials.tsx
+++ b/src/components/manifold-credentials/manifold-credentials.tsx
@@ -4,15 +4,12 @@ import { Marketplace } from '../../types/marketplace';
 import ConnectionTunnel from '../../data/connection';
 import { RestFetch } from '../../utils/restFetch';
 import logger from '../../utils/logger';
-import { buttonColors } from '../manifold-button/manifold-button';
 
 @Component({ tag: 'manifold-credentials' })
 export class ManifoldCredentials {
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() restFetch?: RestFetch;
   @Prop() resourceLabel: string = '';
-  @Prop() showButtonColor: buttonColors = 'black';
-  @Prop() hideButtonColor: buttonColors = 'white';
   @Prop({ mutable: true }) resourceId?: string = '';
   @State() loading?: boolean = false;
   @State() credentials?: Marketplace.Credential[];
@@ -70,13 +67,18 @@ export class ManifoldCredentials {
   render() {
     return (
       <manifold-credentials-view
-        showButtonColor={this.showButtonColor}
-        hideButtonColor={this.hideButtonColor}
         loading={this.loading}
         resourceLabel={this.resourceLabel}
         credentials={this.credentials}
         onCredentialsRequested={this.credentialsRequested}
-      />
+      >
+        <manifold-forward-slot slot="show-button">
+          <slot name="show-button" />
+        </manifold-forward-slot>
+        <manifold-forward-slot slot="hide-button">
+          <slot name="hide-button" />
+        </manifold-forward-slot>
+      </manifold-credentials-view>
     );
   }
 }

--- a/src/components/manifold-credentials/manifold-credentials.tsx
+++ b/src/components/manifold-credentials/manifold-credentials.tsx
@@ -4,12 +4,15 @@ import { Marketplace } from '../../types/marketplace';
 import ConnectionTunnel from '../../data/connection';
 import { RestFetch } from '../../utils/restFetch';
 import logger from '../../utils/logger';
+import { buttonColors } from '../manifold-button/manifold-button';
 
 @Component({ tag: 'manifold-credentials' })
 export class ManifoldCredentials {
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() restFetch?: RestFetch;
   @Prop() resourceLabel: string = '';
+  @Prop() showButtonColor: buttonColors = 'black';
+  @Prop() hideButtonColor: buttonColors = 'white';
   @Prop({ mutable: true }) resourceId?: string = '';
   @State() loading?: boolean = false;
   @State() credentials?: Marketplace.Credential[];
@@ -67,6 +70,8 @@ export class ManifoldCredentials {
   render() {
     return (
       <manifold-resource-credentials-view
+        showButtonColor={this.showButtonColor}
+        hideButtonColor={this.showButtonColor}
         loading={this.loading}
         resourceLabel={this.resourceLabel}
         credentials={this.credentials}

--- a/src/components/manifold-resource-credentials/manifold-resource-credentials.tsx
+++ b/src/components/manifold-resource-credentials/manifold-resource-credentials.tsx
@@ -1,21 +1,28 @@
-import { h, Component } from '@stencil/core';
+import { h, Component, Prop } from '@stencil/core';
 
-import ResourceTunnel, { ResourceState } from '../../data/resource';
+import ResourceTunnel from '../../data/resource';
 import logger from '../../utils/logger';
+import { Gateway } from '../../types/gateway';
+import { buttonColors } from '../manifold-button/manifold-button';
 
 @Component({ tag: 'manifold-resource-credentials' })
 export class ManifoldResourceCredentials {
+  @Prop() showButtonColor: buttonColors = 'black';
+  @Prop() hideButtonColor: buttonColors = 'white';
+  @Prop() data?: Gateway.Resource;
+  @Prop() loading: boolean = true;
+
   @logger()
   render() {
     return (
-      <ResourceTunnel.Consumer>
-        {(state: ResourceState) => (
-          <manifold-credentials
-            resourceLabel={state.data && state.data.label}
-            resourceId={state.data && state.data.id}
-          />
-        )}
-      </ResourceTunnel.Consumer>
+      <manifold-credentials
+        showButtonColor={this.showButtonColor}
+        hideButtonColor={this.showButtonColor}
+        resourceLabel={this.data && this.data.label}
+        resourceId={this.data && this.data.id}
+      />
     );
   }
 }
+
+ResourceTunnel.injectProps(ManifoldResourceCredentials, ['data', 'loading']);

--- a/src/components/manifold-resource-credentials/manifold-resource-credentials.tsx
+++ b/src/components/manifold-resource-credentials/manifold-resource-credentials.tsx
@@ -3,12 +3,9 @@ import { h, Component, Prop } from '@stencil/core';
 import ResourceTunnel from '../../data/resource';
 import logger from '../../utils/logger';
 import { Gateway } from '../../types/gateway';
-import { buttonColors } from '../manifold-button/manifold-button';
 
 @Component({ tag: 'manifold-resource-credentials' })
 export class ManifoldResourceCredentials {
-  @Prop() showButtonColor: buttonColors = 'black';
-  @Prop() hideButtonColor: buttonColors = 'white';
   @Prop() data?: Gateway.Resource;
   @Prop() loading: boolean = true;
 
@@ -16,11 +13,16 @@ export class ManifoldResourceCredentials {
   render() {
     return (
       <manifold-credentials
-        showButtonColor={this.showButtonColor}
-        hideButtonColor={this.hideButtonColor}
         resourceLabel={this.data && this.data.label}
         resourceId={this.data && this.data.id}
-      />
+      >
+        <manifold-forward-slot slot="show-button">
+          <slot name="show-button" />
+        </manifold-forward-slot>
+        <manifold-forward-slot slot="hide-button">
+          <slot name="hide-button" />
+        </manifold-forward-slot>
+      </manifold-credentials>
     );
   }
 }

--- a/src/components/manifold-resource-credentials/manifold-resource-credentials.tsx
+++ b/src/components/manifold-resource-credentials/manifold-resource-credentials.tsx
@@ -17,7 +17,7 @@ export class ManifoldResourceCredentials {
     return (
       <manifold-credentials
         showButtonColor={this.showButtonColor}
-        hideButtonColor={this.showButtonColor}
+        hideButtonColor={this.hideButtonColor}
         resourceLabel={this.data && this.data.label}
         resourceId={this.data && this.data.id}
       />

--- a/stories/manifold-resource-credentials.stories.js
+++ b/stories/manifold-resource-credentials.stories.js
@@ -3,16 +3,29 @@ import { storiesOf } from '@storybook/html';
 import markdown from '../docs/docs/components/manifold-credentials.md';
 import { manifoldConnectionDecorator } from './connectionDecorator';
 
-const credentialsView = `
-<manifold-resource-container resource-name="cms-stage">
-  <manifold-resource-credentials></manifold-resource-credentials>
-</manifold-resource-container>
-`;
-
 storiesOf('Resource Credentials 🔒', module)
   .addParameters({ readme: { sidebar: markdown } })
   .addDecorator(manifoldConnectionDecorator)
-  .add('default', () => {
-    window.localStorage.setItem('manifold_api_token', process.env.STORYBOOK_MANIFOLD_API_TOKEN);
-    return credentialsView;
-  });
+  .add(
+    'default',
+    () => `
+      <manifold-resource-container resource-name="cms-stage">
+        <manifold-resource-credentials></manifold-resource-credentials>
+      </manifold-resource-container>
+`
+  )
+  .add(
+    'custom buttons',
+    () => `
+      <manifold-resource-container resource-name="cms-stage">
+        <manifold-resource-credentials>
+          <manifold-button color="orange" slot="show-button">
+            Show credentials
+          </manifold-button>
+          <manifold-button color="orange" slot="hide-button">
+            Hide credentials
+          </manifold-button>
+        </manifold-resource-credentials>
+      </manifold-resource-container>
+`
+  );


### PR DESCRIPTION
Work is related to manifoldco/engineering#8940

## Reason for change
This gives platforms the ability to customize the credentials buttons to their theme without needing too many CSS variables. The prop is passed through all the wrapper components to the credentials view component.

![Capture d’écran 2019-08-12 à 10 23 22](https://user-images.githubusercontent.com/20424444/62872359-4b68b300-bceb-11e9-942a-d9927f26de92.png)

## Testing
Test with the docs and set the two properties manually in the dom.
