### PR TITLE
Remove a forgotten console call and stop ignoring them

### DIFF
--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
@@ -5,8 +5,6 @@ import { Marketplace } from '../../types/marketplace';
 import { RestFetch } from '../../utils/restFetch';
 import logger from '../../utils/logger';
 
-/* eslint-disable no-console */
-
 interface SuccessMessage {
   message: string;
   resourceLabel: string;

--- a/src/components/manifold-data-manage-button/manifold-data-manage-button.tsx
+++ b/src/components/manifold-data-manage-button/manifold-data-manage-button.tsx
@@ -7,8 +7,6 @@ import { Marketplace } from '../../types/marketplace';
 import { RestFetch } from '../../utils/restFetch';
 import logger from '../../utils/logger';
 
-/* eslint-disable no-console */
-
 interface SuccessMessage {
   features?: Gateway.FeatureMap;
   resourceLabel: string;

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
@@ -9,8 +9,6 @@ import { GraphqlRequestBody, GraphqlResponseBody } from '../../utils/graphqlFetc
 import { RestFetch } from '../../utils/restFetch';
 import logger from '../../utils/logger';
 
-/* eslint-disable no-console */
-
 interface SuccessMessage {
   createdAt: string;
   resourceLabel: string;

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
@@ -5,8 +5,6 @@ import { Marketplace } from '../../types/marketplace';
 import { RestFetch } from '../../utils/restFetch';
 import logger from '../../utils/logger';
 
-/* eslint-disable no-console */
-
 interface ClickMessage {
   newLabel: string;
   resourceLabel: string;

--- a/src/components/manifold-data-sso-button/manifold-data-sso-button.tsx
+++ b/src/components/manifold-data-sso-button/manifold-data-sso-button.tsx
@@ -6,8 +6,6 @@ import { Connector } from '../../types/connector';
 import { RestFetch } from '../../utils/restFetch';
 import logger from '../../utils/logger';
 
-/* eslint-disable no-console */
-
 interface ClickMessage {
   resourceLabel: string;
   resourceId: string;
@@ -53,7 +51,6 @@ export class ManifoldDataSsoButton {
   }
 
   sso = async () => {
-    console.log('Attempting to SSO', this.restFetch, this.loading);
     if (!this.restFetch || this.loading) {
       return;
     }


### PR DESCRIPTION
One console call was forgotten in the SSO button which led to some unnecessary logging. To prevent that kind of error in the future, all files that explicitly ignored console will now rely on eslint.
