### PR TITLE
Add missing coverage for restFetch consumption points

### DIFF
--- a/src/components/manifold-connection/manifold-connection.tsx
+++ b/src/components/manifold-connection/manifold-connection.tsx
@@ -6,7 +6,7 @@ import logger from '../../utils/logger';
 const baseWait = 15000;
 
 @Component({ tag: 'manifold-connection' })
-export class ManiTunnel {
+export class ManifoldConnection {
   /** _(optional)_ Specify `env="stage"` for staging */
   @Prop() env: 'local' | 'stage' | 'prod' = 'prod';
   /** _(optional)_ Wait time for the fetch calls before it times out */
@@ -31,4 +31,4 @@ export class ManiTunnel {
   }
 }
 
-Tunnel.injectProps(ManiTunnel, ['setEnv', 'setWaitTime']);
+Tunnel.injectProps(ManifoldConnection, ['setEnv', 'setWaitTime']);

--- a/src/components/manifold-data-manage-button/manifold-data-manage-button.spec.ts
+++ b/src/components/manifold-data-manage-button/manifold-data-manage-button.spec.ts
@@ -1,7 +1,39 @@
+import fetchMock from 'fetch-mock';
+import { newSpecPage } from '@stencil/core/testing';
 import { ManifoldDataManageButton } from './manifold-data-manage-button';
+import { Resource } from '../../spec/mock/marketplace';
+import { createRestFetch } from '../../utils/restFetch';
+import { connections } from '../../utils/connections';
+
+async function setup(resourceLabel: string) {
+  const page = await newSpecPage({
+    components: [ManifoldDataManageButton],
+    html: '<div></div>',
+  });
+
+  const component = page.doc.createElement('manifold-data-manage-button');
+  component.resourceLabel = resourceLabel;
+  component.restFetch = createRestFetch({
+    getAuthToken: jest.fn(() => '1234'),
+    wait: 10,
+    setAuthToken: jest.fn(),
+  });
+
+  const root = page.root as HTMLDivElement;
+  root.appendChild(component);
+  await page.waitForChanges();
+
+  return { page, component };
+}
 
 describe('<manifold-data-manage-button>', () => {
-  it('fetches resource by name on load', () => {
+  it('fetches resource by name on load', async () => {
+    const resourceLabel = 'my-resource';
+    const url = `${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`;
+    fetchMock.mock(url, [Resource]);
+    await setup(resourceLabel);
+    expect(fetchMock.called(url)).toBe(true);
+    /*
     const resourceName = 'my-resource';
 
     const manageButton = new ManifoldDataManageButton();
@@ -9,6 +41,7 @@ describe('<manifold-data-manage-button>', () => {
     manageButton.resourceLabel = resourceName;
     manageButton.componentWillLoad();
     expect(manageButton.fetchResourceId).toHaveBeenCalledWith(resourceName);
+    */
   });
 
   it('fetches resource by name on change', () => {

--- a/src/components/manifold-data-resource-logo/manifold-data-resource-logo.spec.ts
+++ b/src/components/manifold-data-resource-logo/manifold-data-resource-logo.spec.ts
@@ -31,20 +31,22 @@ describe('<manifold-data-resource-logo>', () => {
   afterEach(() => {
     fetchMock.restore();
   });
-  
+
   it('fetches resource on load', async () => {
     const resourceLabel = 'my-resource';
-    fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`, [Resource]);
+    fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`, [
+      Resource,
+    ]);
     fetchMock.mock(`${connections.prod.catalog}/products/${Resource.body.product_id}`, [Product]);
 
     await setup(resourceLabel);
 
-    expect(fetchMock.called(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`)).toBe(
-      true
-    );
-    expect(fetchMock.called(`${connections.prod.catalog}/products/${Resource.body.product_id}`)).toBe(
-      true
-    );
+    expect(
+      fetchMock.called(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`)
+    ).toBe(true);
+    expect(
+      fetchMock.called(`${connections.prod.catalog}/products/${Resource.body.product_id}`)
+    ).toBe(true);
   });
 
   it('fetches resource on change', async () => {
@@ -54,18 +56,19 @@ describe('<manifold-data-resource-logo>', () => {
     const { page, component } = await setup(resourceLabel);
 
     const newResourceLabel = 'new-resource';
-    fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${newResourceLabel}`, [Resource]);
+    fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${newResourceLabel}`, [
+      Resource,
+    ]);
     fetchMock.mock(`${connections.prod.catalog}/products/${Resource.body.product_id}`, [Product]);
 
     component.resourceLabel = newResourceLabel;
     await page.waitForChanges();
 
-
-    expect(fetchMock.called(`${connections.prod.marketplace}/resources/?me&label=${newResourceLabel}`)).toBe(
-      true
-    );
-    expect(fetchMock.called(`${connections.prod.catalog}/products/${Resource.body.product_id}`)).toBe(
-      true
-    );
+    expect(
+      fetchMock.called(`${connections.prod.marketplace}/resources/?me&label=${newResourceLabel}`)
+    ).toBe(true);
+    expect(
+      fetchMock.called(`${connections.prod.catalog}/products/${Resource.body.product_id}`)
+    ).toBe(true);
   });
 });

--- a/src/components/manifold-data-resource-logo/manifold-data-resource-logo.spec.ts
+++ b/src/components/manifold-data-resource-logo/manifold-data-resource-logo.spec.ts
@@ -1,23 +1,71 @@
+import fetchMock from 'fetch-mock';
+import { newSpecPage } from '@stencil/core/testing';
 import { ManifoldDataResourceLogo } from './manifold-data-resource-logo';
+import { Resource } from '../../spec/mock/marketplace';
+import { Product } from '../../spec/mock/catalog';
+import { connections } from '../../utils/connections';
+import { createRestFetch } from '../../utils/restFetch';
 
-describe('<manifold-data-resource-logo>', () => {
-  it('fetches resource on load', () => {
-    const resourceLabel = 'my-resource';
-
-    const productLogo = new ManifoldDataResourceLogo();
-    productLogo.fetchResource = jest.fn();
-    productLogo.resourceLabel = resourceLabel;
-    productLogo.componentWillLoad();
-    expect(productLogo.fetchResource).toHaveBeenCalledWith(resourceLabel);
+async function setup(resourceLabel: string) {
+  const page = await newSpecPage({
+    components: [ManifoldDataResourceLogo],
+    html: '<div></div>',
   });
 
-  it('fetches resource on change', () => {
-    const newResource = 'new-resource';
+  const component = page.doc.createElement('manifold-data-resource-logo');
+  component.resourceLabel = resourceLabel;
+  component.restFetch = createRestFetch({
+    getAuthToken: jest.fn(() => '1234'),
+    wait: 10,
+    setAuthToken: jest.fn(),
+  });
 
-    const productLogo = new ManifoldDataResourceLogo();
-    productLogo.fetchResource = jest.fn();
-    productLogo.resourceLabel = 'old-resource';
-    productLogo.resourceChange(newResource);
-    expect(productLogo.fetchResource).toHaveBeenCalledWith(newResource);
+  const root = page.root as HTMLDivElement;
+  root.appendChild(component);
+  await page.waitForChanges();
+
+  return { page, component };
+}
+
+describe('<manifold-data-resource-logo>', () => {
+  afterEach(() => {
+    fetchMock.restore();
+  });
+  
+  it('fetches resource on load', async () => {
+    const resourceLabel = 'my-resource';
+    fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`, [Resource]);
+    fetchMock.mock(`${connections.prod.catalog}/products/${Resource.body.product_id}`, [Product]);
+
+    await setup(resourceLabel);
+
+    expect(fetchMock.called(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`)).toBe(
+      true
+    );
+    expect(fetchMock.called(`${connections.prod.catalog}/products/${Resource.body.product_id}`)).toBe(
+      true
+    );
+  });
+
+  it('fetches resource on change', async () => {
+    const resourceLabel = 'my-resource';
+    fetchMock.once('*', []);
+
+    const { page, component } = await setup(resourceLabel);
+
+    const newResourceLabel = 'new-resource';
+    fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${newResourceLabel}`, [Resource]);
+    fetchMock.mock(`${connections.prod.catalog}/products/${Resource.body.product_id}`, [Product]);
+
+    component.resourceLabel = newResourceLabel;
+    await page.waitForChanges();
+
+
+    expect(fetchMock.called(`${connections.prod.marketplace}/resources/?me&label=${newResourceLabel}`)).toBe(
+      true
+    );
+    expect(fetchMock.called(`${connections.prod.catalog}/products/${Resource.body.product_id}`)).toBe(
+      true
+    );
   });
 });

--- a/src/components/manifold-data-resource-logo/manifold-data-resource-logo.spec.ts
+++ b/src/components/manifold-data-resource-logo/manifold-data-resource-logo.spec.ts
@@ -37,7 +37,7 @@ describe('<manifold-data-resource-logo>', () => {
     fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`, [
       Resource,
     ]);
-    fetchMock.mock(`${connections.prod.catalog}/products/${Resource.body.product_id}`, [Product]);
+    fetchMock.mock(`${connections.prod.catalog}/products/${Resource.body.product_id}`, Product);
 
     await setup(resourceLabel);
 
@@ -59,7 +59,7 @@ describe('<manifold-data-resource-logo>', () => {
     fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${newResourceLabel}`, [
       Resource,
     ]);
-    fetchMock.mock(`${connections.prod.catalog}/products/${Resource.body.product_id}`, [Product]);
+    fetchMock.mock(`${connections.prod.catalog}/products/${Resource.body.product_id}`, Product);
 
     component.resourceLabel = newResourceLabel;
     await page.waitForChanges();

--- a/src/components/manifold-data-resource-logo/manifold-data-resource-logo.tsx
+++ b/src/components/manifold-data-resource-logo/manifold-data-resource-logo.tsx
@@ -39,16 +39,17 @@ export class ManifoldDataResourceLogo {
     if (resourceResp && resourceResp.length) {
       const resource: Marketplace.Resource = resourceResp[0];
       const productId = resource.body.product_id;
-      const productResp = await this.restFetch<Catalog.Product>({
+      const productResp = await this.restFetch<Catalog.Product[]>({
         service: 'catalog',
         endpoint: `/products/${productId}`,
       });
 
       if (productResp) {
         // NOTE: Temporary until GraphQL supports resources
+        const product = productResp[0];
         const newProduct = {
-          displayName: productResp.body.name,
-          logoUrl: productResp.body.logo_url,
+          displayName: product.body.name,
+          logoUrl: product.body.logo_url,
         };
         this.product = newProduct as Product;
       }

--- a/src/components/manifold-data-resource-logo/manifold-data-resource-logo.tsx
+++ b/src/components/manifold-data-resource-logo/manifold-data-resource-logo.tsx
@@ -39,14 +39,13 @@ export class ManifoldDataResourceLogo {
     if (resourceResp && resourceResp.length) {
       const resource: Marketplace.Resource = resourceResp[0];
       const productId = resource.body.product_id;
-      const productResp = await this.restFetch<Catalog.Product[]>({
+      const product = await this.restFetch<Catalog.Product>({
         service: 'catalog',
         endpoint: `/products/${productId}`,
       });
 
-      if (productResp) {
+      if (product) {
         // NOTE: Temporary until GraphQL supports resources
-        const product = productResp[0];
         const newProduct = {
           displayName: product.body.name,
           logoUrl: product.body.logo_url,

--- a/src/components/manifold-data-resource-logo/manifold-data-resource-logo.tsx
+++ b/src/components/manifold-data-resource-logo/manifold-data-resource-logo.tsx
@@ -45,7 +45,7 @@ export class ManifoldDataResourceLogo {
       });
 
       if (productResp) {
-        // NOTE: Temporary util GraphQL supports resources
+        // NOTE: Temporary until GraphQL supports resources
         const newProduct = {
           displayName: productResp.body.name,
           logoUrl: productResp.body.logo_url,

--- a/src/components/manifold-plan-selector/manifold-plan-selector.spec.ts
+++ b/src/components/manifold-plan-selector/manifold-plan-selector.spec.ts
@@ -1,43 +1,111 @@
+import { newSpecPage } from '@stencil/core/testing';
+import fetchMock from 'fetch-mock';
+import { createRestFetch } from '../../utils/restFetch';
 import { ManifoldPlanSelector } from './manifold-plan-selector';
+import { Product, ExpandedPlan } from '../../spec/mock/catalog';
+import { Resource } from '../../spec/mock/marketplace';
+import { connections } from '../../utils/connections';
+
+async function setup(productLabel?: string, resourceLabel?: string) {
+  const page = await newSpecPage({
+    components: [ManifoldPlanSelector],
+    html: '<div></div>',
+  });
+
+  const component = page.doc.createElement('manifold-plan-selector');
+  component.productLabel = productLabel;
+  component.resourceLabel = resourceLabel;
+  component.restFetch = createRestFetch({
+    getAuthToken: jest.fn(() => '1234'),
+    wait: 10,
+    setAuthToken: jest.fn(),
+  });
+
+  const root = page.root as HTMLDivElement;
+  root.appendChild(component);
+  await page.waitForChanges();
+
+  return { page, component };
+}
 
 describe('<manifold-plan-selector>', () => {
-  it('fetches product by label on load, if given', () => {
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
+  it('fetches product and plans by label on load, if given', async () => {
     const productLabel = 'test-label';
+    fetchMock.mock(`${connections.prod.catalog}/products/?label=${productLabel}`, [Product]);
+    fetchMock.mock(`${connections.prod.catalog}/plans/?product_id=${Product.id}`, [ExpandedPlan]);
 
-    const planSelector = new ManifoldPlanSelector();
-    planSelector.fetchProductByLabel = jest.fn();
-    planSelector.productLabel = productLabel;
-    planSelector.componentWillLoad();
-    expect(planSelector.fetchProductByLabel).toHaveBeenCalledWith(productLabel);
+    await setup(productLabel);
+
+    expect(fetchMock.called(`${connections.prod.catalog}/products/?label=${productLabel}`)).toBe(
+      true
+    );
+    expect(fetchMock.called(`${connections.prod.catalog}/plans/?product_id=${Product.id}`)).toBe(
+      true
+    );
   });
 
-  it('fetches new product by label on change, if given', () => {
+  it('fetches new product by label on change, if given', async () => {
     const newProduct = 'new-product';
+    fetchMock.once('*', []);
 
-    const planSelector = new ManifoldPlanSelector();
-    planSelector.fetchProductByLabel = jest.fn();
-    planSelector.productLabel = 'old-product';
-    planSelector.productChange(newProduct);
-    expect(planSelector.fetchProductByLabel).toHaveBeenCalledWith(newProduct);
+    const { component, page } = await setup('old-product');
+
+    fetchMock.mock(`${connections.prod.catalog}/products/?label=${newProduct}`, [Product]);
+    fetchMock.mock(`${connections.prod.catalog}/plans/?product_id=${Product.id}`, [ExpandedPlan]);
+    component.productLabel = newProduct;
+    await page.waitForChanges();
+
+    expect(fetchMock.called(`${connections.prod.catalog}/products/?label=${newProduct}`)).toBe(
+      true
+    );
+    expect(fetchMock.called(`${connections.prod.catalog}/plans/?product_id=${Product.id}`)).toBe(
+      true
+    );
   });
 
-  it('fetches resource on load by resource name, if given', () => {
+  it('fetches resource on load by resource name, if given', async () => {
     const resourceLabel = 'my-resource';
+    fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`, [
+      Resource,
+    ]);
+    fetchMock.mock(`${connections.prod.catalog}/plans/?product_id=${Resource.body.product_id}`, [
+      ExpandedPlan,
+    ]);
 
-    const planSelector = new ManifoldPlanSelector();
-    planSelector.fetchResource = jest.fn();
-    planSelector.resourceLabel = resourceLabel;
-    planSelector.componentWillLoad();
-    expect(planSelector.fetchResource).toHaveBeenCalledWith(resourceLabel);
+    await setup(undefined, resourceLabel);
+
+    expect(
+      fetchMock.called(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`)
+    ).toBe(true);
+    expect(
+      fetchMock.called(`${connections.prod.catalog}/plans/?product_id=${Resource.body.product_id}`)
+    ).toBe(true);
   });
 
-  it('fetches resource on change by resource name, if given', () => {
+  it('fetches resource on change by resource name, if given', async () => {
     const newResource = 'new-resource';
+    fetchMock.once('*', []);
 
-    const planSelector = new ManifoldPlanSelector();
-    planSelector.fetchResource = jest.fn();
-    planSelector.resourceLabel = 'old-resource';
-    planSelector.resourceChange(newResource);
-    expect(planSelector.fetchResource).toHaveBeenCalledWith(newResource);
+    const { component, page } = await setup(undefined, 'old-resource');
+
+    fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${newResource}`, [
+      Resource,
+    ]);
+    fetchMock.mock(`${connections.prod.catalog}/plans/?product_id=${Resource.body.product_id}`, [
+      ExpandedPlan,
+    ]);
+    component.resourceLabel = newResource;
+    await page.waitForChanges();
+
+    expect(
+      fetchMock.called(`${connections.prod.marketplace}/resources/?me&label=${newResource}`)
+    ).toBe(true);
+    expect(
+      fetchMock.called(`${connections.prod.catalog}/plans/?product_id=${Resource.body.product_id}`)
+    ).toBe(true);
   });
 });

--- a/src/components/manifold-product/manifold-product.spec.ts
+++ b/src/components/manifold-product/manifold-product.spec.ts
@@ -27,11 +27,14 @@ async function setup(productLabel: string) {
 }
 
 describe('<manifold-product>', () => {
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
   it('fetches the product by label on load', async () => {
     const productLabel = 'product-label';
     fetchMock.mock(`${connections.prod.catalog}/products/?label=${productLabel}`, [Product]);
     fetchMock.mock(`${connections.prod.catalog}/providers/${Product.body.provider_id}`, [
-      Product,
       Provider,
     ]);
 

--- a/src/components/manifold-product/manifold-product.spec.ts
+++ b/src/components/manifold-product/manifold-product.spec.ts
@@ -1,23 +1,41 @@
+import { newSpecPage } from '@stencil/core/testing';
+import fetchMock from 'fetch-mock';
 import { ManifoldProduct } from './manifold-product';
+import { connections } from '../../utils/connections';
+import { Product, Provider } from '../../spec/mock/catalog';
+import { stub } from '../../../test-utils/stub-rest-fetch';
 
 describe('<manifold-product>', () => {
-  it('fetches product by label on load', () => {
-    const productLabel = 'product-label';
-
-    const product = new ManifoldProduct();
-    product.fetchProduct = jest.fn();
-    product.productLabel = productLabel;
-    product.componentWillLoad();
-    expect(product.fetchProduct).toHaveBeenCalledWith(productLabel);
+  beforeEach(() => {
+    stub(ManifoldProduct, {
+      getAuthToken: jest.fn(() => '1234'),
+      wait: 10,
+      setAuthToken: jest.fn(),
+    });
   });
 
-  it('fetches product by label on change', () => {
-    const newProduct = 'new-label';
+  it('fetches the product by label on load', async () => {
+    const productLabel = 'product-label';
+    fetchMock.mock(`${connections.prod.catalog}/products/?label=${productLabel}`, [Product]);
+    fetchMock.mock(`${connections.prod.catalog}/providers/${Product.body.provider_id}`, [
+      Product,
+      Provider,
+    ]);
 
-    const product = new ManifoldProduct();
-    product.fetchProduct = jest.fn();
-    product.productLabel = 'old-product';
-    product.productChange(newProduct);
-    expect(product.fetchProduct).toHaveBeenCalledWith(newProduct);
+    await newSpecPage({
+      components: [ManifoldProduct],
+      html: `
+        <manifold-product
+          product-label="${productLabel}"
+        ></manifold-product>
+      `,
+    });
+
+    expect(fetchMock.called(`${connections.prod.catalog}/products/?label=${productLabel}`)).toBe(
+      true
+    );
+    expect(
+      fetchMock.called(`${connections.prod.catalog}/providers/${Product.body.provider_id}`)
+    ).toBe(true);
   });
 });

--- a/src/components/manifold-product/manifold-product.spec.ts
+++ b/src/components/manifold-product/manifold-product.spec.ts
@@ -34,9 +34,7 @@ describe('<manifold-product>', () => {
   it('fetches the product by label on load', async () => {
     const productLabel = 'product-label';
     fetchMock.mock(`${connections.prod.catalog}/products/?label=${productLabel}`, [Product]);
-    fetchMock.mock(`${connections.prod.catalog}/providers/${Product.body.provider_id}`, [
-      Provider,
-    ]);
+    fetchMock.mock(`${connections.prod.catalog}/providers/${Product.body.provider_id}`, [Provider]);
 
     await setup(productLabel);
 
@@ -56,16 +54,12 @@ describe('<manifold-product>', () => {
 
     const newLabel = 'new-product-label';
     fetchMock.mock(`${connections.prod.catalog}/products/?label=${newLabel}`, [Product]);
-    fetchMock.mock(`${connections.prod.catalog}/providers/${Product.body.provider_id}`, [
-      Provider,
-    ]);
+    fetchMock.mock(`${connections.prod.catalog}/providers/${Product.body.provider_id}`, [Provider]);
 
     component.productLabel = newLabel;
     await page.waitForChanges();
 
-    expect(fetchMock.called(`${connections.prod.catalog}/products/?label=${newLabel}`)).toBe(
-      true
-    );
+    expect(fetchMock.called(`${connections.prod.catalog}/products/?label=${newLabel}`)).toBe(true);
     expect(
       fetchMock.called(`${connections.prod.catalog}/providers/${Product.body.provider_id}`)
     ).toBe(true);

--- a/src/components/manifold-product/manifold-product.spec.ts
+++ b/src/components/manifold-product/manifold-product.spec.ts
@@ -47,4 +47,27 @@ describe('<manifold-product>', () => {
       fetchMock.called(`${connections.prod.catalog}/providers/${Product.body.provider_id}`)
     ).toBe(true);
   });
+
+  it('fetches the product by label on change', async () => {
+    const productLabel = 'product-label';
+    fetchMock.once('*', []);
+
+    const { component, page } = await setup(productLabel);
+
+    const newLabel = 'new-product-label';
+    fetchMock.mock(`${connections.prod.catalog}/products/?label=${newLabel}`, [Product]);
+    fetchMock.mock(`${connections.prod.catalog}/providers/${Product.body.provider_id}`, [
+      Provider,
+    ]);
+
+    component.productLabel = newLabel;
+    await page.waitForChanges();
+
+    expect(fetchMock.called(`${connections.prod.catalog}/products/?label=${newLabel}`)).toBe(
+      true
+    );
+    expect(
+      fetchMock.called(`${connections.prod.catalog}/providers/${Product.body.provider_id}`)
+    ).toBe(true);
+  });
 });

--- a/src/components/manifold-product/manifold-product.tsx
+++ b/src/components/manifold-product/manifold-product.tsx
@@ -35,7 +35,7 @@ export class ManifoldProduct {
       endpoint: `/products/?label=${productLabel}`,
     });
 
-    if (productResp) {
+    if (productResp && productResp.length) {
       this.product = productResp[0]; // eslint-disable-line prefer-destructuring
 
       this.provider = await this.restFetch<Catalog.Provider>({

--- a/src/utils/restFetch.ts
+++ b/src/utils/restFetch.ts
@@ -3,7 +3,7 @@ import { withAuth } from './auth';
 import { hasExpired } from './expiry';
 import { report } from './errorReport';
 
-interface CreateRestFetch {
+export interface CreateRestFetch {
   endpoints?: Connection;
   wait?: number;
   getAuthToken?: () => string | undefined;

--- a/test-utils/stub-rest-fetch.ts
+++ b/test-utils/stub-rest-fetch.ts
@@ -1,0 +1,9 @@
+import { createRestFetch, CreateRestFetch } from '../src/utils/restFetch';
+
+export function stub<T>(ctor: { new (): T }, options: CreateRestFetch) {
+  const oldCallback = ctor.prototype.componentWillLoad;
+  ctor.prototype.componentWillLoad = function() {
+    this.restFetch = createRestFetch(options);
+    oldCallback.call(this);
+  };
+}

--- a/test-utils/stub-rest-fetch.ts
+++ b/test-utils/stub-rest-fetch.ts
@@ -1,9 +1,0 @@
-import { createRestFetch, CreateRestFetch } from '../src/utils/restFetch';
-
-export function stub<T>(ctor: { new (): T }, options: CreateRestFetch) {
-  const oldCallback = ctor.prototype.componentWillLoad;
-  ctor.prototype.componentWillLoad = function() {
-    this.restFetch = createRestFetch(options);
-    oldCallback.call(this);
-  };
-}


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

A previous PR for reporting errors from `restFetch` left a lot of blocks with no test coverage. This PR adds tests for most of those uncovered areas.

## Testing
<!-- For someone unfamiliar with the issue, how should this be tested? -->

CI should still pass! This is only test code.
