### PR TITLE
Poll until resource rename complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated Stencil to v1.2.5
 
+### Fixed
+
+- Fixed issue where success event of `manifold-data-rename-resource` was emitted before renamed resource was ready.
+
 ## [v0.5.3]
 
 ### Fixed

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated Stencil to v1.2.5
 
+### Fixed
+
+- Fixed issue where success event of `manifold-data-rename-resource` was emitted before renamed resource was ready.
+
 ## [v0.5.3]
 
 ### Fixed

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1030,23 +1030,6 @@
         "@manifoldco/gql-zero": "^0.2.0",
         "@manifoldco/shadowcat": "^0.1.5",
         "@stencil/state-tunnel": "^1.0.1"
-      },
-      "dependencies": {
-        "@manifoldco/gql-zero": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/@manifoldco/gql-zero/-/gql-zero-0.2.0.tgz",
-          "integrity": "sha512-s0nPkp5PUzvqK8SaIQEMw5AYArC4slq+YQ9xL9lG8QImMO1NIWfnrvwJRVAO+Ns5dmeZeAdXACX+1g2k27I0Yg=="
-        },
-        "@manifoldco/shadowcat": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/@manifoldco/shadowcat/-/shadowcat-0.1.5.tgz",
-          "integrity": "sha512-d+UIi9vyUjExBVXFtnrqUpF1agupnqTrA4AVPCqADpGs6/XawKiAU7bJyKuW51k+AQHSZLygB1G1C7EFHW89AA=="
-        },
-        "@stencil/state-tunnel": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@stencil/state-tunnel/-/state-tunnel-1.0.1.tgz",
-          "integrity": "sha512-DYG8uROgL9hkjVTCtCfRBb0d3FwpiFB0muRrNZQ2X1Qo5hxMuNNji76/ILddqeq0AfgkKCW82xrMPDpy+rNIhQ=="
-        }
       }
     },
     "@mikaelkristiansson/domready": {

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
@@ -132,6 +132,14 @@ describe('<manifold-data-rename-button>', () => {
 
     it('will trigger a dom event on successful rename', async () => {
       fetchMock.mock(`${connections.prod.marketplace}/resources/${Resource.id}`, Resource);
+      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=test2`, [
+        {
+          ...Resource,
+          body: {
+            label: 'test2',
+          },
+        },
+      ]);
 
       const page = await newSpecPage({
         components: [ManifoldDataRenameButton],

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
@@ -130,7 +130,7 @@ export class ManifoldDataRenameButton {
     const { restFetch } = this;
     await new Promise(resolve => {
       const interval = window.setInterval(async () => {
-        const renamedResource: [Marketplace.Resource] | undefined = await restFetch({
+        const renamedResource = await restFetch<Marketplace.Resource[]>({
           service: 'marketplace',
           endpoint: `/resources/?me&label=${this.newLabel}`,
         });

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
@@ -126,6 +126,21 @@ export class ManifoldDataRenameButton {
       return Promise.reject(error);
     });
 
+    // Poll until rename complete
+    const { restFetch } = this;
+    await new Promise(resolve => {
+      const interval = window.setInterval(async () => {
+        const renamedResource: [Marketplace.Resource] | undefined = await restFetch({
+          service: 'marketplace',
+          endpoint: `/resources/?me&label=${this.newLabel}`,
+        });
+        if (renamedResource && renamedResource.length) {
+          window.clearInterval(interval);
+          resolve();
+        }
+      }, 100);
+    });
+
     const success: SuccessMessage = {
       message: `${this.resourceLabel} successfully renamed`,
       resourceLabel: this.resourceLabel || '',


### PR DESCRIPTION
## Reason for change

Polls resource endpoint until renamed resource is returned, then emits success event.

## Testing

New to Render work, so there's possibly a better way, but I...
1. Built UI locally
1. Copied `dist/` to `<render-dashboard>/node_modules/@manifoldco/ui/`
1. Provisioned a resource
1. Renamed the resource
