### PR TITLE
Fixed: improved loading state for <manifold-resource-list>

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ commands:
           fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
 
 jobs:
-  # Run bundlesize
+  # Run bundlesize (generally the fastest, so this runs first)
   bundlesize:
     <<: *defaults
     steps:
@@ -99,51 +99,27 @@ workflows:
   # Normal workflow for untagged PRs
   branch:
     jobs:
-      - lint
-      - bundlesize:
+      - bundlesize
+      - lint:
           requires:
-            - lint
+            - bundlesize
       - test:
           requires:
-            - lint
+            - bundlesize
       - vrt:
           requires:
-            - lint
+            - bundlesize
 
   # Prerelease (only fires if Git tag contains hyphen + npm tag)
   prerelease:
     jobs:
-      - lint:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+-.*$/
       - bundlesize:
           filters: # the same filters are required on ALL jobs here
             branches:
               ignore: /.*/ # this is necessary along with tags for some reason
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+-.*$/
-          requires:
-            - lint
-      - test:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+-.*$/
-          requires:
-            - lint
-      - vrt:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+-.*$/
-          requires:
-            - lint
-      - npm-publish: # no approval needed for prerelease
+      - lint:
           filters:
             branches:
               ignore: /.*/
@@ -151,19 +127,36 @@ workflows:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+-.*$/
           requires:
             - bundlesize
+      - test:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+-.*$/
+          requires:
+            - bundlesize
+      - vrt:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+-.*$/
+          requires:
+            - bundlesize
+      - npm-publish: # no approval needed for prerelease
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+-.*$/
+          requires:
+            - lint
             - test
             - vrt
 
   # Final release (only fires if Git tag is a stable release)
   release:
     jobs:
-      - lint:
-          filters:
-            branches:
-              ignore:
-                - /.*/
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
       - bundlesize:
           filters: # the same filters are required on ALL jobs here
             branches:
@@ -171,8 +164,15 @@ workflows:
                 - /.*/
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      - lint:
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
           requires:
-            - lint
+            - bundlesize
       - test:
           filters:
             branches:
@@ -181,7 +181,7 @@ workflows:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
           requires:
-            - lint
+            - bundlesize
       - vrt:
           filters:
             branches:
@@ -190,7 +190,7 @@ workflows:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
           requires:
-            - lint
+            - bundlesize
       - confirm:
           type: approval # manual approval step mandatory for final release
           filters:
@@ -200,7 +200,7 @@ workflows:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
           requires:
-            - bundlesize
+            - lint
             - test
             - vrt
       - npm-publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ commands:
           fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
 
 jobs:
-  # Run bundlesize (Stencil build: ✅)
+  # Run bundlesize
   bundlesize:
     <<: *defaults
     steps:
@@ -58,7 +58,7 @@ jobs:
       - run: npm run bundlesize
       - save-build
 
-  # Lint (Stencil build: 🚫)
+  # Lint
   lint:
     <<: *defaults
     steps:
@@ -75,7 +75,7 @@ jobs:
       - run: npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
       - run: npm run publish
 
-  # Test (Stencil build: ✅)
+  # Test
   test:
     <<: *defaults
     steps:
@@ -85,7 +85,7 @@ jobs:
       - save-build
       - run: npx codecov
 
-  # Run visual regression tests (Stencil build: ✅)
+  # Run visual regression tests
   vrt:
     <<: *defaults
     steps:
@@ -99,38 +99,50 @@ workflows:
   # Normal workflow for untagged PRs
   branch:
     jobs:
-      - bundlesize
       - lint
-      - test
-      - vrt
+      - bundlesize:
+          requires:
+            - lint
+      - test:
+          requires:
+            - lint
+      - vrt:
+          requires:
+            - lint
 
   # Prerelease (only fires if Git tag contains hyphen + npm tag)
   prerelease:
     jobs:
-      - bundlesize:
-          filters: # the same filters are required on ALL jobs here
-            branches:
-              ignore: /.*/ # this is necessary along with tags for some reason
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+-.*$/
       - lint:
           filters:
             branches:
               ignore: /.*/
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+-.*$/
+      - bundlesize:
+          filters: # the same filters are required on ALL jobs here
+            branches:
+              ignore: /.*/ # this is necessary along with tags for some reason
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+-.*$/
+          requires:
+            - lint
       - test:
           filters:
             branches:
               ignore: /.*/
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+-.*$/
+          requires:
+            - lint
       - vrt:
           filters:
             branches:
               ignore: /.*/
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+-.*$/
+          requires:
+            - lint
       - npm-publish: # no approval needed for prerelease
           filters:
             branches:
@@ -139,20 +151,12 @@ workflows:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+-.*$/
           requires:
             - bundlesize
-            - lint
             - test
             - vrt
 
   # Final release (only fires if Git tag is a stable release)
   release:
     jobs:
-      - bundlesize:
-          filters: # the same filters are required on ALL jobs here
-            branches:
-              ignore:
-                - /.*/
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
       - lint:
           filters:
             branches:
@@ -160,6 +164,15 @@ workflows:
                 - /.*/
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      - bundlesize:
+          filters: # the same filters are required on ALL jobs here
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+          requires:
+            - lint
       - test:
           filters:
             branches:
@@ -167,6 +180,8 @@ workflows:
                 - /.*/
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+          requires:
+            - lint
       - vrt:
           filters:
             branches:
@@ -174,6 +189,8 @@ workflows:
                 - /.*/
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+          requires:
+            - lint
       - confirm:
           type: approval # manual approval step mandatory for final release
           filters:
@@ -184,7 +201,6 @@ workflows:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
           requires:
             - bundlesize
-            - lint
             - test
             - vrt
       - npm-publish:

--- a/docs/docs/components/manifold-resource-list.md
+++ b/docs/docs/components/manifold-resource-list.md
@@ -6,27 +6,27 @@ example: |
     <manifold-resource-list paused>
       <div slot="loading" style="display: grid;grid-area: services;grid-gap: var(--grid-s);grid-template-columns: repeat(2, 1fr);">
         <manifold-resource-card-view
-          label="my-resource" 
-          logo="https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png" 
-          resource-id="1234" 
+          label="my-resource"
+          logo="https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png"
+          resource-id="1234"
           resource-status="available"
         ></manifold-resource-card-view>
         <manifold-resource-card-view
-          label="my-resource-2" 
-          logo="https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png" 
-          resource-id="1234" 
+          label="my-resource-2"
+          logo="https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png"
+          resource-id="1234"
           resource-status="provision"
         ></manifold-resource-card-view>
         <manifold-resource-card-view
-          label="my-resource-3" 
-          logo="https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png" 
-          resource-id="1234" 
+          label="my-resource-3"
+          logo="https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png"
+          resource-id="1234"
           resource-status="resize"
         ></manifold-resource-card-view>
         <manifold-resource-card-view
-          label="my-resource-4" 
-          logo="https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png" 
-          resource-id="1234" 
+          label="my-resource-4"
+          logo="https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png"
+          resource-id="1234"
           resource-status="deprovision"
         ></manifold-resource-card-view>
       </div>
@@ -48,20 +48,21 @@ Creates a list of resource cards that lists all the resources the user owns dire
 
 ## Link format
 
-To navigate using a traditional `<a>` tag, specify a `resource-link-format`
-attribute, using `:resource` as a placeholder:
+To navigate using a traditional `<a>` tag, specify a `resource-link-format` attribute, using
+`:resource` as a placeholder:
 
 ```html
-<manifold-data-resource-list resource-link-format="/resource/:resource"></manifold-data-resource-list>
+<manifold-data-resource-list
+  resource-link-format="/resource/:resource"
+></manifold-data-resource-list>
 ```
 
-Note that this will disable the custom event unless `preserve-event` is
-passed as well.
+Note that this will disable the custom event unless `preserve-event` is passed as well.
 
 ## Pausing updates
 
-By default, this component will subscribe to updates from the server. To
-disable that, pass the `paused` attribute:
+By default, this component will subscribe to updates from the server. To disable that, pass the
+`paused` attribute:
 
 ```html
 <manifold-data-resource-list paused></manifold-data-resource-list>
@@ -69,26 +70,25 @@ disable that, pass the `paused` attribute:
 
 ## Loading state
 
-You can pass in your own loading state for the componenent
-by passing in any element with `slot="loading"` as an attribute. [Read more about
-slots][slot].
+By default, this component generates its own loading state with 4 placeholder cards, so loading is
+handled for you. But optionally, you can display a message below while loading by passing in a
+`slot="loading"` child ([docs][slot]):
 
-```jsx
+```html
 <manifold-resource-list>
-  <manifold-resource-card-view loading="" label="loading" slot="loading"></manifold-resource-card-view>
+  <div slot="loading">Loading…</div>
 </manifold-resource-list>
 ```
 
 ## No resources state
 
-You can pass in your own "no resources" state for the componenent
-by passing in any element with `slot="no-resources"` as an attribute. [Read more about
-slots][slot].
+You can pass in your own "no resources" state for the componenent by passing in any element with
+`slot="no-resources"` as an attribute. [Read more about slots][slot].
 
-```jsx
+```html
 <manifold-resource-list>
-  <div slot="no-resources">
-    No resources here
-  </div>
+  <div slot="no-resources">No resources here</div>
 </manifold-resource-list>
 ```
+
+[slot]: https://stenciljs.com/docs/templating-jsx/

--- a/docs/docs/components/manifold-resource-status.md
+++ b/docs/docs/components/manifold-resource-status.md
@@ -14,8 +14,6 @@ Displays an availability tag for a resource. Can be used standalone without any 
 
 ## Resource states
 
-You can use one of the four available resource states to display various statuses.
-
 ```html
   <manifold-resource-status-view state="available"></manifold-resource-product>
   <manifold-resource-status-view state="provision"></manifold-resource-product>
@@ -23,19 +21,16 @@ You can use one of the four available resource states to display various statuse
   <manifold-resource-status-view state="offline"></manifold-resource-product>
 ```
 
-## Different sizes
-
-The component is available in two different sizes, `small` and `medium`. Use the `size` attribute to set the component size.
+## Sizes
 
 ```html
+  <manifold-resource-status-view size="xsmall" state="available"></manifold-resource-product>
   <manifold-resource-status-view size="small" state="available"></manifold-resource-product>
+  <manifold-resource-status-view size="medium" state="available"></manifold-resource-product>
 ```
 
-## Loading
-
-The component can be set to a loading state.
+## Loading state
 
 ```html
-  <manifold-resource-status-view loading=""></manifold-resource-product>
+  <manifold-resource-status-view loading></manifold-resource-product>
 ```
-

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1030,6 +1030,23 @@
         "@manifoldco/gql-zero": "^0.2.0",
         "@manifoldco/shadowcat": "^0.1.5",
         "@stencil/state-tunnel": "^1.0.1"
+      },
+      "dependencies": {
+        "@manifoldco/gql-zero": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/@manifoldco/gql-zero/-/gql-zero-0.2.0.tgz",
+          "integrity": "sha512-s0nPkp5PUzvqK8SaIQEMw5AYArC4slq+YQ9xL9lG8QImMO1NIWfnrvwJRVAO+Ns5dmeZeAdXACX+1g2k27I0Yg=="
+        },
+        "@manifoldco/shadowcat": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/@manifoldco/shadowcat/-/shadowcat-0.1.5.tgz",
+          "integrity": "sha512-d+UIi9vyUjExBVXFtnrqUpF1agupnqTrA4AVPCqADpGs6/XawKiAU7bJyKuW51k+AQHSZLygB1G1C7EFHW89AA=="
+        },
+        "@stencil/state-tunnel": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@stencil/state-tunnel/-/state-tunnel-1.0.1.tgz",
+          "integrity": "sha512-DYG8uROgL9hkjVTCtCfRBb0d3FwpiFB0muRrNZQ2X1Qo5hxMuNNji76/ILddqeq0AfgkKCW82xrMPDpy+rNIhQ=="
+        }
       }
     },
     "@mikaelkristiansson/domready": {

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -551,12 +551,12 @@ export namespace Components {
   interface ManifoldResourceStatus {
     'data'?: Gateway.Resource;
     'loading': boolean;
-    'size'?: 'small' | 'medium';
+    'size'?: 'xsmall' | 'small' | 'medium';
   }
   interface ManifoldResourceStatusView {
     'loading'?: boolean;
     'resourceState'?: string;
-    'size'?: 'small' | 'medium';
+    'size'?: 'xsmall' | 'small' | 'medium';
   }
   interface ManifoldSelect {
     'defaultValue'?: string;
@@ -1611,12 +1611,12 @@ declare namespace LocalJSX {
   interface ManifoldResourceStatus extends JSXBase.HTMLAttributes<HTMLManifoldResourceStatusElement> {
     'data'?: Gateway.Resource;
     'loading'?: boolean;
-    'size'?: 'small' | 'medium';
+    'size'?: 'xsmall' | 'small' | 'medium';
   }
   interface ManifoldResourceStatusView extends JSXBase.HTMLAttributes<HTMLManifoldResourceStatusViewElement> {
     'loading'?: boolean;
     'resourceState'?: string;
-    'size'?: 'small' | 'medium';
+    'size'?: 'xsmall' | 'small' | 'medium';
   }
   interface ManifoldSelect extends JSXBase.HTMLAttributes<HTMLManifoldSelectElement> {
     'defaultValue'?: string;

--- a/src/components/manifold-resource-card-view/manifold-resource-card-view-happo.ts
+++ b/src/components/manifold-resource-card-view/manifold-resource-card-view-happo.ts
@@ -1,9 +1,9 @@
 export const skeleton = async () => {
   const card = document.createElement('manifold-resource-card-view');
-  card.label = 'my-resource';
+  card.label = 'loading';
   card.loading = true;
   card.logo = 'https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png';
-  card.name = 'my-resource';
+  card.name = 'loading';
 
   document.body.appendChild(card);
 
@@ -12,9 +12,11 @@ export const skeleton = async () => {
 
 export const logDNA = async () => {
   const card = document.createElement('manifold-resource-card-view');
-  card.label = 'my-resource';
+  card.label = 'custom-resource';
   card.logo = 'https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png';
-  card.name = 'my-resource';
+  card.name = 'logging';
+  card.resourceId = 'test';
+  card.resourceStatus = 'available';
 
   document.body.appendChild(card);
 
@@ -23,8 +25,10 @@ export const logDNA = async () => {
 
 export const logoPlaceholder = async () => {
   const card = document.createElement('manifold-resource-card-view');
-  card.label = 'my-resource';
-  card.name = 'my-resource';
+  card.label = 'custom-resource';
+  card.name = 'custom-resource';
+  card.resourceId = 'test';
+  card.resourceStatus = 'available';
 
   document.body.appendChild(card);
 

--- a/src/components/manifold-resource-card-view/manifold-resource-card-view-happo.ts
+++ b/src/components/manifold-resource-card-view/manifold-resource-card-view-happo.ts
@@ -1,0 +1,32 @@
+export const skeleton = async () => {
+  const card = document.createElement('manifold-resource-card-view');
+  card.label = 'my-resource';
+  card.loading = true;
+  card.logo = 'https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png';
+  card.name = 'my-resource';
+
+  document.body.appendChild(card);
+
+  return card.componentOnReady();
+};
+
+export const loaded = async () => {
+  const card = document.createElement('manifold-resource-card-view');
+  card.label = 'my-resource';
+  card.logo = 'https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png';
+  card.name = 'my-resource';
+
+  document.body.appendChild(card);
+
+  return card.componentOnReady();
+};
+
+export const noLogo = async () => {
+  const card = document.createElement('manifold-resource-card-view');
+  card.label = 'my-resource';
+  card.name = 'my-resource';
+
+  document.body.appendChild(card);
+
+  return card.componentOnReady();
+};

--- a/src/components/manifold-resource-card-view/manifold-resource-card-view-happo.ts
+++ b/src/components/manifold-resource-card-view/manifold-resource-card-view-happo.ts
@@ -10,7 +10,7 @@ export const skeleton = async () => {
   return card.componentOnReady();
 };
 
-export const loaded = async () => {
+export const logDNA = async () => {
   const card = document.createElement('manifold-resource-card-view');
   card.label = 'my-resource';
   card.logo = 'https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png';
@@ -21,7 +21,7 @@ export const loaded = async () => {
   return card.componentOnReady();
 };
 
-export const noLogo = async () => {
+export const logoPlaceholder = async () => {
   const card = document.createElement('manifold-resource-card-view');
   card.label = 'my-resource';
   card.name = 'my-resource';

--- a/src/components/manifold-resource-card-view/manifold-resource-card-view.css
+++ b/src/components/manifold-resource-card-view/manifold-resource-card-view.css
@@ -3,9 +3,9 @@
 @custom-media --viewport-l (min-width: 1080px);
 
 :host {
-  --manifold-product-logo-s: 0.5rem;
-  --manifold-product-logo-m: 1.25rem;
-  --manifold-product-logo-l: 1.5rem;
+  --manifold-product-logo-s: 1.5rem;
+  --manifold-product-logo-m: 1.5rem;
+  --manifold-product-logo-l: 1.625rem;
   --padding: 0.75rem;
 
   /* theme vars */
@@ -25,18 +25,19 @@
   --card-heading-font-family: var(--manifold-font-family-heading);
   --card-heading-font-weight: var(--manifold-font-weight-heading);
   --card-heading-text-color: var(--manifold-text-color-heading);
+
+  color: var(--manifold-text-color);
+  font-family: var(--manifold-font-family);
 }
 
 .wrapper {
-  position: relative;
   display: grid;
   grid-column-gap: var(--padding);
   grid-template-areas:
-    'logo name'
-    'info info'
-    'tags tags';
-  grid-template-rows: min-content auto min-content;
-  grid-template-columns: var(--manifold-product-logo-s) auto;
+    'name logo'
+    'status status';
+  grid-template-rows: auto min-content;
+  grid-template-columns: auto max-content;
   box-sizing: border-box;
   height: 100%;
   padding: var(--padding);
@@ -50,18 +51,6 @@
   cursor: pointer;
   transition: border-color 150ms linear, box-shadow 150ms linear;
 
-  @media (--viewport-s) {
-    grid-template-areas:
-      'name logo'
-      'availability logo';
-    grid-template-columns: auto var(--manifold-product-logo-m);
-  }
-
-  @media (--viewport-m) {
-    grid-template-columns: auto var(--manifold-product-logo-l);
-    padding: 0.875rem;
-  }
-
   &:focus,
   &:hover {
     background: var(--card-background-hover);
@@ -70,107 +59,8 @@
   }
 }
 
-.name {
-  grid-area: name;
-  align-self: start;
-  margin-top: 0;
-  margin-bottom: 0;
-  padding-right: 1em;
-  color: var(--card-heading-text-color);
-  font-weight: var(--card-heading-font-weight);
-  font-size: 1em;
-  font-family: var(--card-heading-font-family);
-  line-height: 1.2;
-
-  @media (--viewport-l) {
-    padding-left: 0;
-  }
-}
-
-.status-box {
-  display: flex;
-  flex-direction: column;
-  grid-area: availability;
-  padding-top: 0.25rem;
-  color: var(--manifold-text-color);
-  font-size: var(--manifold-font-d1);
-  font-family: var(--manifold-font-family);
-
-  @media (--viewport-m) {
-    padding-top: 0;
-  }
-
-  @media (--viewport-l) {
-    padding-left: 0;
-  }
-}
-
-.status {
-  --status-color: var(--manifold-color-success);
-
-  display: flex;
-  align-items: center;
-  margin-top: 0.75rem;
-  overflow: hidden;
-  color: var(--manifold-color-gray60);
-
-  &[data-status='provision'] {
-    --status-color: var(--manifold-color-info);
-  }
-
-  &[data-status='resize'] {
-    --status-color: var(--manifold-color-warn);
-  }
-
-  &[data-status='deprovision'], &[data-status='offline'] {
-    --status-color: var(--manifold-color-error);
-  }
-}
-
-.inner {
-  position: relative;
-  z-index: 2;
-  display: flex;
-  align-items: center;
-
-  &::before {
-    display: block;
-    width: 0.5rem;
-    height: 0.5rem;
-    margin-right: 0.5rem;
-    background: var(--status-color);
-    border-radius: 50%;
-    content: '';
-  }
-}
-
-.loading {
-  display: flex;
-  align-items: center;
-  margin-top: 0.75rem;
-  color: var(--manifold-grayscale-60);
-
-  & manifold-icon {
-    width: 0.75rem;
-    height: 0.75rem;
-    margin-right: 0.75rem;
-    transform-origin: 50% 50%;
-    animation-name: spin;
-    animation-duration: 1s;
-    animation-timing-function: linear;
-    animation-iteration-count: infinite;
-  }
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(1turn);
-  }
-}
-
 .logo {
   grid-area: logo;
-  align-content: start;
 
   & img {
     box-sizing: border-box;
@@ -198,4 +88,48 @@
       opacity: 1;
     }
   }
+}
+
+.logo-placeholder {
+  grid-area: logo;
+  color: var(--manifold-color-gray30);
+  background-color: var(--manifold-color-gray05);
+  border-radius: var(--manifold-radius);
+
+  & manifold-icon {
+    width: var(--manifold-product-logo-s);
+    height: var(--manifold-product-logo-s);
+
+    @media (--viewport-s) {
+      width: var(--manifold-product-logo-m);
+      height: var(--manifold-product-logo-m);
+    }
+
+    @media (--viewport-m) {
+      width: var(--manifold-product-logo-l);
+      height: var(--manifold-product-logo-l);
+    }
+  }
+}
+
+.name {
+  grid-area: name;
+  align-self: start;
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-right: 1em;
+  color: var(--card-heading-text-color);
+  font-weight: var(--card-heading-font-weight);
+  font-size: 1em;
+  font-family: var(--card-heading-font-family);
+  line-height: 1.2;
+
+  @media (--viewport-l) {
+    padding-left: 0;
+  }
+}
+
+.status {
+  grid-area: status;
+  padding-top: 0.25rem;
 }

--- a/src/components/manifold-resource-card-view/manifold-resource-card-view.e2e.ts
+++ b/src/components/manifold-resource-card-view/manifold-resource-card-view.e2e.ts
@@ -1,45 +1,27 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-/* eslint-disable no-param-reassign */
+/* eslint-disable no-param-reassign, @typescript-eslint/no-explicit-any */
 
-const label = 'my-resource';
-const name = 'my resource';
-const logo = 'https://cdn.manifold.co/providers/jawsdb/logos/80ca8b9113cf76fd.png';
+/**
+ * Tests not covered in this file:
+ * - Loading view (Happo VRT)
+ * - Name/Label/Logo (Happo VRT)
+ */
 
-describe('<manifold-resource-card>', () => {
-  it('displays name', async () => {
-    const page = await newE2EPage({
-      html: `<manifold-resource-card-view label="${label}" name="${name}" resource-id="test" />`,
+describe('<manifold-resource-card-view>', () => {
+  describe('v0 API', () => {
+    it('[resource-status]: displays status', async () => {
+      const page = await newE2EPage({
+        html: `<manifold-resource-card-view></manifold-resource-card-view>`,
+      });
+      page.$eval('manifold-resource-card-view', (elm: any) => {
+        elm.resourceStatus = 'provision';
+        elm.resourceId = 'test';
+      });
+      await page.waitForChanges();
+      const el = await page.find('manifold-resource-card-view >>> manifold-resource-status-view');
+      const status = el.shadowRoot.querySelector('[role="status"]');
+      expect(status && status.innerHTML).toBe('Provision');
     });
-    const el = await page.find('manifold-resource-card-view >>> [itemprop="name"]');
-
-    expect(el.innerText).toBe(name);
-  });
-
-  it('displays label', async () => {
-    const page = await newE2EPage({
-      html: `<manifold-resource-card-view label="${label}" resource-id="test" />`,
-    });
-    const el = await page.find('manifold-resource-card-view >>> [itemprop="name"]');
-
-    expect(el.innerText).toBe(label);
-  });
-
-  it('displays logo', async () => {
-    const page = await newE2EPage({
-      html: `<manifold-resource-card-view logo="${logo}" resource-id="test" />`,
-    });
-    const el = await page.find('manifold-resource-card-view >>> manifold-lazy-image');
-    const src = await el.getProperty('src');
-    expect(src).toBe(logo);
-  });
-
-  it('displays the given status', async () => {
-    const page = await newE2EPage({
-      html: `<manifold-resource-card-view resource-status="provision" resource-id="test" />`,
-    });
-    const el = await page.find('manifold-resource-card-view >>> [itemprop="status"]');
-
-    expect(el.innerText).toBe('Provisioning');
   });
 });

--- a/src/components/manifold-resource-card-view/manifold-resource-card-view.tsx
+++ b/src/components/manifold-resource-card-view/manifold-resource-card-view.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Event, EventEmitter, h, Prop, Watch } from '@stencil/core';
-import { refresh_cw } from '@manifoldco/icons';
+import { resource } from '@manifoldco/icons';
 
 import Tunnel from '../../data/connection';
 import { Marketplace } from '../../types/marketplace';
@@ -65,31 +65,6 @@ export class ManifoldResourceCardView {
     return this.resourceLinkFormat.replace(/:resource/gi, this.label);
   }
 
-  get status() {
-    if (
-      this.resourceStatus &&
-      [AVAILABLE, PROVISIONING, RESIZING, DEPROVISION].includes(this.resourceStatus)
-    ) {
-      return this.resourceStatus;
-    }
-    return OFFLINE;
-  }
-
-  get statusText() {
-    switch (this.resourceStatus) {
-      case AVAILABLE:
-        return statusToText[AVAILABLE];
-      case PROVISIONING:
-        return statusToText[PROVISIONING];
-      case RESIZING:
-        return statusToText[RESIZING];
-      case DEPROVISION:
-        return statusToText[DEPROVISION];
-      default:
-        return statusToText[OFFLINE];
-    }
-  }
-
   async fetchResourceId(resourceLabel: string) {
     if (!this.restFetch) {
       return;
@@ -135,15 +110,17 @@ export class ManifoldResourceCardView {
         <h3 class="name" itemprop="name">
           {this.name || this.label}
         </h3>
-        <div class="status-box">
-          <div class="status" data-status={this.status}>
-            <div class="inner" itemprop="status">
-              {this.statusText}
-            </div>
-          </div>
+        <div class="status">
+          <manifold-resource-status-view size="xsmall" resourceState={this.resourceStatus} />
         </div>
         <div class="logo">
-          {this.logo && <manifold-lazy-image src={this.logo} alt={this.label} itemprop="image" />}
+          {this.logo ? (
+            <manifold-lazy-image src={this.logo} alt={this.label} itemprop="image" />
+          ) : (
+            <div class="logo-placeholder">
+              <manifold-icon icon={resource} />
+            </div>
+          )}
         </div>
       </a>
     ) : (
@@ -153,10 +130,7 @@ export class ManifoldResourceCardView {
           <manifold-skeleton-text>{this.label}</manifold-skeleton-text>
         </h3>
         <div class="status-box">
-          <div class="loading" data-status={this.resourceStatus}>
-            <manifold-icon icon={refresh_cw} />
-            Loading
-          </div>
+          <manifold-skeleton-text>Loading resource</manifold-skeleton-text>
         </div>
         <div class="logo">
           <manifold-skeleton-img />

--- a/src/components/manifold-resource-card-view/manifold-resource-card-view.tsx
+++ b/src/components/manifold-resource-card-view/manifold-resource-card-view.tsx
@@ -12,20 +12,6 @@ interface EventDetail {
   resourceName?: string;
 }
 
-const AVAILABLE = 'available';
-const PROVISIONING = 'provision';
-const RESIZING = 'resize';
-const DEPROVISION = 'deprovision';
-const OFFLINE = 'offline';
-
-const statusToText = {
-  [AVAILABLE]: 'Available',
-  [PROVISIONING]: 'Provisioning',
-  [RESIZING]: 'Resizing',
-  [DEPROVISION]: 'Deprovisioning',
-  [OFFLINE]: 'Offline',
-};
-
 @Component({
   tag: 'manifold-resource-card-view',
   styleUrl: 'manifold-resource-card-view.css',
@@ -129,7 +115,7 @@ export class ManifoldResourceCardView {
         <h3 class="name">
           <manifold-skeleton-text>{this.label}</manifold-skeleton-text>
         </h3>
-        <div class="status-box">
+        <div class="status">
           <manifold-skeleton-text>Loading resource</manifold-skeleton-text>
         </div>
         <div class="logo">

--- a/src/components/manifold-resource-card/manifold-resource-card.tsx
+++ b/src/components/manifold-resource-card/manifold-resource-card.tsx
@@ -18,51 +18,42 @@ export class ManifoldResourceCard {
   @State() resource?: Gateway.Resource;
 
   @Watch('resourceId') resourceIdChange(newResourceId: string) {
-    this.fetchResourceId(newResourceId);
+    this.fetchResource({ id: newResourceId });
   }
   @Watch('label') resourceLabelChange(newlabel: string) {
-    this.fetchResourceLabel(newlabel);
+    this.fetchResource({ label: newlabel });
   }
 
   componentWillLoad() {
-    if (this.resourceId) {
-      this.fetchResourceId(this.resourceId);
-    } else if (this.label) {
-      this.fetchResourceLabel(this.label);
-    }
+    this.fetchResource({ id: this.resourceId, label: this.label });
   }
 
-  async fetchResourceId(resourceId: string) {
+  async fetchResource({ id, label }: { id?: string; label?: string }) {
     if (!this.restFetch) {
       return;
     }
 
-    const response = await this.restFetch<Gateway.Resource>({
-      service: 'gateway',
-      endpoint: `/resources/${resourceId}`,
-    });
+    if (id) {
+      const response = await this.restFetch<Gateway.Resource>({
+        service: 'gateway',
+        endpoint: `/resources/${id}`,
+      });
 
-    if (response instanceof Error) {
-      console.error(response);
-      return;
-    }
+      if (response instanceof Error) {
+        console.error(response);
+        return;
+      }
+      this.resource = response;
+    } else if (label) {
+      const response = await this.restFetch<Gateway.Resource[]>({
+        service: 'gateway',
+        endpoint: `/resources/me/${label}`,
+      });
 
-    this.resource = response;
-  }
-
-  async fetchResourceLabel(resourceName: string) {
-    if (!this.restFetch) {
-      return;
-    }
-
-    const response = await this.restFetch<Gateway.Resource[]>({
-      service: 'gateway',
-      endpoint: `/resources/me/${resourceName}`,
-    });
-
-    if (response && response.length) {
-      // eslint-disable-next-line prefer-destructuring
-      this.resource = response[0];
+      if (response && response.length) {
+        // eslint-disable-next-line prefer-destructuring
+        this.resource = response[0];
+      }
     }
   }
 

--- a/src/components/manifold-resource-list/manifold-resource-list.css
+++ b/src/components/manifold-resource-list/manifold-resource-list.css
@@ -37,5 +37,5 @@
   display: grid;
   grid-area: services;
   grid-gap: var(--grid-s);
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
 }

--- a/src/components/manifold-resource-list/manifold-resource-list.tsx
+++ b/src/components/manifold-resource-list/manifold-resource-list.tsx
@@ -201,34 +201,30 @@ export class ManifoldResourceList {
       return <slot name="no-resources" />;
     }
 
-    return Array.isArray(this.resources) ? (
+    return (
       <div class="wrapper">
-        {this.resources.map(resource => (
-          <manifold-resource-card-view
-            label={resource.label}
-            name={resource.name}
-            logo={resource.logo}
-            resourceId={resource.id}
-            resourceStatus={resource.status}
-            resourceLinkFormat={this.resourceLinkFormat}
-            preserveEvent={this.preserveEvent}
-          />
-        ))}
+        {Array.isArray(this.resources)
+          ? this.resources.map(resource => (
+              <manifold-resource-card-view
+                label={resource.label}
+                name={resource.name}
+                logo={resource.logo}
+                resourceId={resource.id}
+                resourceStatus={resource.status}
+                resourceLinkFormat={this.resourceLinkFormat}
+                preserveEvent={this.preserveEvent}
+              />
+            ))
+          : [1, 2, 3, 4].map(() => (
+              <manifold-resource-card-view
+                label="my-loading-resource"
+                loading={true}
+                logo="myresource.png"
+                name="my-loading-resource"
+              />
+            ))}
+        {!Array.isArray(this.resources) && <slot name="loading" />}
       </div>
-    ) : (
-      [
-        <div class="wrapper">
-          {[1, 2, 3, 4].map(() => (
-            <manifold-resource-card-view
-              label="my-loading-resource"
-              loading={true}
-              logo="myresource.png"
-              name="my-loading-resource"
-            />
-          ))}
-        </div>,
-        <slot name="loading" />,
-      ]
     );
   }
 }

--- a/src/components/manifold-resource-list/manifold-resource-list.tsx
+++ b/src/components/manifold-resource-list/manifold-resource-list.tsx
@@ -208,15 +208,27 @@ export class ManifoldResourceList {
             label={resource.label}
             name={resource.name}
             logo={resource.logo}
-            resource-id={resource.id}
-            resource-status={resource.status}
-            resource-link-format={this.resourceLinkFormat}
-            preserve-event={this.preserveEvent}
+            resourceId={resource.id}
+            resourceStatus={resource.status}
+            resourceLinkFormat={this.resourceLinkFormat}
+            preserveEvent={this.preserveEvent}
           />
         ))}
       </div>
     ) : (
-      <slot name="loading" />
+      [
+        <div class="wrapper">
+          {[1, 2, 3, 4].map(() => (
+            <manifold-resource-card-view
+              label="my-loading-resource"
+              loading={true}
+              logo="myresource.png"
+              name="my-loading-resource"
+            />
+          ))}
+        </div>,
+        <slot name="loading" />,
+      ]
     );
   }
 }

--- a/src/components/manifold-resource-status-view/manifold-resource-status-view-happo.tsx
+++ b/src/components/manifold-resource-status-view/manifold-resource-status-view-happo.tsx
@@ -17,6 +17,16 @@ export const availableSmall = () => {
   return status.componentOnReady();
 };
 
+export const availableXSmall = () => {
+  const status = document.createElement('manifold-resource-status-view');
+  status.resourceState = 'available';
+  status.size = 'xsmall';
+
+  document.body.appendChild(status);
+
+  return status.componentOnReady();
+};
+
 export const offline = () => {
   const status = document.createElement('manifold-resource-status-view');
 

--- a/src/components/manifold-resource-status-view/manifold-resource-status-view.css
+++ b/src/components/manifold-resource-status-view/manifold-resource-status-view.css
@@ -45,6 +45,17 @@
   color: var(--manifold-grayscale-60);
   border-radius: var(--manifold-tag-radius, var(--manifold-radius));
 
+  &::before {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background: var(--status-color);
+    opacity: 0.1;
+    content: '';
+  }
+
   &[data-size='small'] {
     height: 1.325rem;
     padding-right: 0.75rem;
@@ -57,15 +68,20 @@
     }
   }
 
-  &::before {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    background: var(--status-color);
-    opacity: 0.1;
-    content: '';
+  &[data-size='xsmall'] {
+    height: 1rem;
+    padding-left: 0;
+    padding-right: 0;
+    font-size: var(--manifold-font-d1);
+
+    &::before {
+      display: none;
+    }
+
+    & .inner::before {
+      width: 0.5rem;
+      height: 0.5rem;
+    }
   }
 }
 

--- a/src/components/manifold-resource-status-view/manifold-resource-status-view.css
+++ b/src/components/manifold-resource-status-view/manifold-resource-status-view.css
@@ -3,21 +3,32 @@
   font-family: var(--manifold-font-family);
 }
 
-.inner {
-  position: relative;
-  z-index: 2;
-  display: flex;
-  align-items: center;
-
-  &::before {
-    display: block;
-    width: 1rem;
-    height: 1rem;
-    margin-right: 0.5rem;
-    background: var(--status-color);
-    border-radius: 50%;
-    content: '';
+@keyframes spin {
+  to {
+    transform: rotate(1turn);
   }
+}
+
+.icon {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 0.5em;
+
+  & manifold-icon {
+    animation-name: spin;
+    animation-duration: 1s;
+    animation-timing-function: linear;
+    animation-iteration-count: infinite;
+  }
+}
+
+.icon-status {
+  display: block;
+  width: 0.625rem;
+  height: 0.625rem;
+  content: '';
+  border-radius: 50%;
+  background: var(--status-color);
 }
 
 .status {
@@ -31,6 +42,10 @@
     --status-color: var(--manifold-color-warn);
   }
 
+  &[data-status='loading'] {
+    --status-color: var(--manifold-grayscale-20);
+  }
+
   &[data-status='offline'] {
     --status-color: var(--manifold-color-error);
   }
@@ -41,11 +56,10 @@
   height: 2.75rem;
   padding-right: 1.5rem;
   padding-left: 1rem;
-  overflow: hidden;
   color: var(--manifold-grayscale-60);
-  border-radius: var(--manifold-tag-radius, var(--manifold-radius));
 
   &::before {
+    border-radius: var(--manifold-tag-radius, var(--manifold-radius));
     position: absolute;
     top: 0;
     right: 0;
@@ -56,20 +70,29 @@
     content: '';
   }
 
+  & .icon,
+  & .icon-status,
+  & manifold-icon {
+    width: 0.75rem;
+    height: 0.75rem;
+  }
+
   &[data-size='small'] {
-    height: 1.325rem;
+    height: 1.5rem;
     padding-right: 0.75rem;
     padding-left: 0.5rem;
     font-size: var(--manifold-font-d1);
 
-    & .inner::before {
+    & .icon,
+    & .icon-status,
+    & manifold-icon {
       width: 0.5rem;
       height: 0.5rem;
     }
   }
 
   &[data-size='xsmall'] {
-    height: 1rem;
+    height: 1.5rem;
     padding-left: 0;
     padding-right: 0;
     font-size: var(--manifold-font-d1);
@@ -78,45 +101,8 @@
       display: none;
     }
 
-    & .inner::before {
-      width: 0.5rem;
-      height: 0.5rem;
-    }
-  }
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(1turn);
-  }
-}
-
-.loading {
-  display: inline-flex;
-  align-items: center;
-  height: 2.75rem;
-  padding-right: 1.5rem;
-  padding-left: 1rem;
-  color: var(--manifold-grayscale-60);
-  background: var(--manifold-grayscale-10);
-  border-radius: var(--manifold-tag-radius, var(--manifold-radius));
-
-  & manifold-icon {
-    margin-top: 0.25rem;
-    margin-right: 0.75rem;
-    transform-origin: 50% 40%;
-    animation-name: spin;
-    animation-duration: 1s;
-    animation-timing-function: linear;
-    animation-iteration-count: infinite;
-  }
-
-  &[data-size='small'] {
-    height: 1.325rem;
-    padding-right: 0.75rem;
-    padding-left: 0.5rem;
-    font-size: var(--manifold-font-d1);
-
+    & .icon,
+    & .icon-status,
     & manifold-icon {
       width: 0.5rem;
       height: 0.5rem;

--- a/src/components/manifold-resource-status-view/manifold-resource-status-view.css
+++ b/src/components/manifold-resource-status-view/manifold-resource-status-view.css
@@ -26,9 +26,9 @@
   display: block;
   width: 0.625rem;
   height: 0.625rem;
-  content: '';
-  border-radius: 50%;
   background: var(--status-color);
+  border-radius: 50%;
+  content: '';
 }
 
 .status {
@@ -59,13 +59,13 @@
   color: var(--manifold-grayscale-60);
 
   &::before {
-    border-radius: var(--manifold-tag-radius, var(--manifold-radius));
     position: absolute;
     top: 0;
     right: 0;
     bottom: 0;
     left: 0;
     background: var(--status-color);
+    border-radius: var(--manifold-tag-radius, var(--manifold-radius));
     opacity: 0.1;
     content: '';
   }
@@ -93,8 +93,8 @@
 
   &[data-size='xsmall'] {
     height: 1.5rem;
-    padding-left: 0;
     padding-right: 0;
+    padding-left: 0;
     font-size: var(--manifold-font-d1);
 
     &::before {

--- a/src/components/manifold-resource-status-view/manifold-resource-status-view.tsx
+++ b/src/components/manifold-resource-status-view/manifold-resource-status-view.tsx
@@ -40,18 +40,13 @@ export class ManifoldResourceStatusView {
 
   @logger()
   render() {
-    if (this.loading) {
-      return (
-        <div class="loading" data-size={this.size} data-status={this.status(this.resourceState)}>
-          <manifold-icon icon={refresh_cw} />
-          Loading
-        </div>
-      );
-    }
-
+    const status = this.loading ? 'loading' : this.status(this.resourceState);
     return (
-      <div class="status" data-size={this.size} data-status={this.status(this.resourceState)}>
-        <div class="inner">{this.statusMessage(this.resourceState)}</div>
+      <div class="status" data-size={this.size} data-status={status}>
+        <div class="icon">
+          {this.loading ? <manifold-icon icon={refresh_cw} /> : <div class="icon-status" />}
+        </div>
+        {this.loading ? 'Loading' : this.statusMessage(this.resourceState)}
       </div>
     );
   }

--- a/src/components/manifold-resource-status-view/manifold-resource-status-view.tsx
+++ b/src/components/manifold-resource-status-view/manifold-resource-status-view.tsx
@@ -46,7 +46,9 @@ export class ManifoldResourceStatusView {
         <div class="icon">
           {this.loading ? <manifold-icon icon={refresh_cw} /> : <div class="icon-status" />}
         </div>
-        {this.loading ? 'Loading' : this.statusMessage(this.resourceState)}
+        <span role="status">
+          {this.loading ? 'Loading' : this.statusMessage(this.resourceState)}
+        </span>
       </div>
     );
   }

--- a/src/components/manifold-resource-status-view/manifold-resource-status-view.tsx
+++ b/src/components/manifold-resource-status-view/manifold-resource-status-view.tsx
@@ -22,7 +22,7 @@ const message: { [s: string]: string } = {
 export class ManifoldResourceStatusView {
   @Prop() loading?: boolean = false;
   @Prop() resourceState?: string = OFFLINE;
-  @Prop() size?: 'small' | 'medium' = 'medium';
+  @Prop() size?: 'xsmall' | 'small' | 'medium' = 'medium';
 
   status(resourceState = this.resourceState) {
     if (resourceState && message[resourceState]) {

--- a/src/components/manifold-resource-status/manifold-resource-status.tsx
+++ b/src/components/manifold-resource-status/manifold-resource-status.tsx
@@ -8,7 +8,7 @@ import { Gateway } from '../../types/gateway';
 export class ManifoldResourceStatus {
   @Prop() data?: Gateway.Resource;
   @Prop() loading: boolean = true;
-  @Prop() size?: 'small' | 'medium' = 'medium';
+  @Prop() size?: 'xsmall' | 'small' | 'medium' = 'medium';
 
   @logger()
   render() {

--- a/src/components/manifold-service-card-view/manifold-service-card-view.css
+++ b/src/components/manifold-service-card-view/manifold-service-card-view.css
@@ -31,7 +31,6 @@
 }
 
 .wrapper {
-  position: relative;
   display: block;
   box-sizing: border-box;
   height: 100%;

--- a/stories/manifold-resource-list.stories.js
+++ b/stories/manifold-resource-list.stories.js
@@ -3,25 +3,23 @@ import { storiesOf } from '@storybook/html';
 import markdown from '../docs/docs/components/manifold-resource-list.md';
 import { manifoldConnectionDecorator } from './connectionDecorator';
 
-storiesOf('Resource list 🔒', module)
+storiesOf('Resource List 🔒', module)
   .addParameters({ readme: { sidebar: markdown } })
   .addDecorator(manifoldConnectionDecorator)
   .add(
-    'Listing all resources',
+    'default',
     () => `
-      <manifold-resource-list />
+      <manifold-resource-list paused />
     `
   )
   .add(
-    'Loading resources',
+    'loading',
     () => `
-      <manifold-resource-list paused="">
-        <manifold-resource-card-view loading="" label="loading" slot="loading" />
-      </manifold-resource-list>
+      <manifold-resource-list paused></manifold-resource-list>
     `
   )
   .add(
-    'No resources',
+    'empty',
     () => `
       <manifold-resource-list label-filter="i-do-not-exists">
         <div slot="no-resources">

--- a/stories/manifold-resource-status.stories.js
+++ b/stories/manifold-resource-status.stories.js
@@ -3,13 +3,27 @@ import markdown from '../docs/docs/components/manifold-resource-status.md';
 
 storiesOf('Resource Status 🔒', module)
   .addParameters({ readme: { sidebar: markdown } })
-  .add('default', () => `
+  .add(
+    'default',
+    () => `
     <manifold-mock-resource>
       <manifold-resource-status></manifold-resource-status>
     </manifold-mock-resource>
-  `)
-  .add('small tag', () => `
+  `
+  )
+  .add(
+    'small',
+    () => `
     <manifold-mock-resource>
       <manifold-resource-status size="small"></manifold-resource-status>
     </manifold-mock-resource>
-  `);
+  `
+  )
+  .add(
+    'x-small',
+    () => `
+    <manifold-mock-resource>
+      <manifold-resource-status size="xsmall"></manifold-resource-status>
+    </manifold-mock-resource>
+  `
+  );


### PR DESCRIPTION
## Reason for change
Improves the animation & loading state of the resource list component. Handles the loading state internally rather than burdening the user with that.

![resource-loading](https://user-images.githubusercontent.com/1369770/63123348-01d7cc80-bf66-11e9-9d15-c1711c0f1f21.gif)

## Testing
Go to the **Storybook** preview link, click on **Resource List 🔒**. Inspect the components there (may have to set `localStorageSet('manifold_api_token', 'TOKEN')`)
