### PR TITLE
Don't use withAuth for public calls

### DIFF
--- a/src/utils/restFetch.spec.ts
+++ b/src/utils/restFetch.spec.ts
@@ -144,7 +144,7 @@ describe('The fetcher created by createRestFetch', () => {
       getAuthToken: () => '1234',
     });
     fetchMock.mock('path:/v1/test', {});
-    await fetcher({ endpoint: '/test', service: 'catalog' });
+    await fetcher({ endpoint: '/test', service: 'catalog', isPublic: false });
     const [, req] = fetchMock.lastCall() as any;
     expect(req.headers).toEqual({ authorization: 'Bearer 1234' });
   });

--- a/src/utils/restFetch.ts
+++ b/src/utils/restFetch.ts
@@ -34,7 +34,7 @@ export function createRestFetch({
     // TODO: catalog should ALWAYS be able to fetch WITHOUT auth if needed,
     // but this prevents the ability for it to auth altogether. We need both!
     const isCatalog = args.service === 'catalog';
-    const isPublic = isCatalog || args.isPublic;
+    const isPublic = (isCatalog && args.isPublic !== false) || args.isPublic;
 
     if (!isPublic) {
       while (!getAuthToken() && !hasExpired(start, wait)) {
@@ -48,9 +48,10 @@ export function createRestFetch({
       }
     }
 
+    const options = isPublic ? args.options : withAuth(getAuthToken(), args.options);
     const url = `${endpoints[args.service]}${args.endpoint}`;
     const response = await fetch(url as string, {
-      ...withAuth(getAuthToken(), args.options),
+      ...options,
       body: JSON.stringify(args.body),
     }).catch((e: Response) => {
       /* Handle unexpected errors */


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## TODO

- [ ] Update changelog

## Reason for change
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

We have a fallback in place to keep our Storybook site working for authenticated endpoints. This fallback allows you to manually set an API token in local storage, which it will use if no auth token is provided to `withAuth`.

This caused an issue in Render where endpoints that were supposed to be public would call `withAuth` with no auth token, and then the fallback would grab the value from local storage, which contained expiry information. That resulted in a malformatted token which triggered a 401 when calling the catalog.

## Testing
<!-- For someone unfamiliar with the issue, how should this be tested? -->

Before this change, you could observe the following in the Render dashboard:

1) Go to the New Addon page to see your resources
2) Refresh the page
3) Observe a 401 error when trying to retrieve resources

With this change, you can pull down the PR branch and try the following:

1) Run `npm run build` followed by `npm link`
2) Switch to your dashboard-render folder and run `npm link @manifoldco/ui`
3) Start dashboard-render with `npm run start-production`
4) Go to the New Addon page to see your resources
5) Refresh the page
6) No more 401 errors! Yay!

**Also important** to test Storybook to make sure the fallback still works for authenticated endpoints. Set an API token in local storage, refresh the page, and check any components that make authenticated calls. You shouldn't see any API errors.