### PR TITLE
Fixed: Flash of 'No services found' on marketplace grid

### DIFF
--- a/docs/docs/components/manifold-marketplace.md
+++ b/docs/docs/components/manifold-marketplace.md
@@ -14,38 +14,23 @@ A list of all Manifold services.
 <manifold-marketplace></manifold-marketplace>
 ```
 
-## Catalog curation
+## Catalog Curation
 
-Our marketplace offers 2 options, either to show all services excluding a
-few, or manually specifying the products that should be shown. For either
-option there is either the `excludes` or `products` options—use either, but
-not both in the same instance.
-
-#### Excludes
-
-Excludes will start with **all products**, but let you specify which ones
-you’d like to hide:
-
-```html
-<manifold-marketplace excludes="manifold-provider"></manifold-marketplace>
-```
-
-#### Products
-
-Conversely, manually specifying products will start with **no products**, and
-let you manually specify every product that should be shown.
+Specifying products will start with **no products**, and let you manually specify every product that
+should be shown.
 
 A common usecase is using `products` in conjuction with `hide-categories` (below).
 
 ```html
-<manifold-marketplace products="aiven-redis,cloudamqp,iron_cache,iron_mq,memcachier-cache"></manifold-marketplace>
+<manifold-marketplace
+  products="aiven-redis,cloudamqp,iron_cache,iron_mq,memcachier-cache"
+></manifold-marketplace>
 ```
 
 ## Hide categories
 
-Hiding the categories is a great way to have a more compact display. It’s
-recommended to use this if you’re only displaying a few products via
-`products` (above):
+Hiding the categories is a great way to have a more compact display. It’s recommended to use this if
+you’re only displaying a few products via `products` (above):
 
 ```html
 <manifold-marketplace hide-categories></manifold-marketplace>
@@ -61,9 +46,8 @@ This hides the search bar (always shown by default).
 
 ## Hide template cards
 
-Add the `hide-templates` attribute to hide external service template cards
-(GitHub, Stripe, etc.). This will also hide their respective categories if no
-other products are using them.
+Add the `hide-templates` attribute to hide external service template cards (GitHub, Stripe, etc.).
+This will also hide their respective categories if no other products are using them.
 
 ```html
 <manifold-marketplace hide-templates></manifold-marketplace>
@@ -71,8 +55,7 @@ other products are using them.
 
 ## Featuring products
 
-You can add a “Featured” tag to select products by specifing a
-comma-separated list:
+You can add a “Featured” tag to select products by specifing a comma-separated list:
 
 ```html
 <manifold-marketplace featured="piio,zerosix"></manifold-marketplace>
@@ -80,10 +63,10 @@ comma-separated list:
 
 ## Events
 
-This component emits [custom
-events](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent)
-when it updates. To listen to those events, add an event listener either on
-the component itself, or `document`:
+This component emits
+[custom events](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent) when it
+updates. To listen to those events, add an event listener either on the component itself, or
+`document`:
 
 ```js
 document.addEventListener('manifold-marketplace-click', { detail } => {
@@ -94,15 +77,14 @@ document.addEventListener('manifold-marketplace-click', { detail } => {
 The following events are emitted:
 
 | Event Name                   | Description                                                                                              | Data                                       |
-|------------------------------|----------------------------------------------------------------------------------------------------------|--------------------------------------------|
+| ---------------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
 | `manifold-marketplace-click` | Fires whenever a user has clicked on a product.                                                          | `productId`, `productLabel`, `productName` |
 | `manifold-template-click`    | Fires whenever a user has clicked on a custom template (assuming it’s not hidden with `hide-templates`). | `category`                                 |
 
 ## Navigation
 
-By default, service cards will only emit the `manifold-marketplace-click`
-event (above). But it can also be turned into an `<a>` tag by specifying
-`product-link-format` and `template-link-format`:
+By default, service cards will only emit the `manifold-marketplace-click` event (above). But it can
+also be turned into an `<a>` tag by specifying `product-link-format` and `template-link-format`:
 
 ```html
 <manifold-marketplace
@@ -112,8 +94,7 @@ event (above). But it can also be turned into an `<a>` tag by specifying
 <!-- <a href="/product/jawsdb-mysql"> -->
 ```
 
-`:product` will be replaced with the url-friendly slug for the product, as
-will `:template` for custom resource templates.
+`:product` will be replaced with the url-friendly slug for the product, as will `:template` for
+custom resource templates.
 
-Note that this will disable the custom events unless `preserve-event` is
-passed as well.
+Note that this will disable the custom events unless `preserve-event` is passed as well.

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -290,10 +290,6 @@ export namespace Components {
   }
   interface ManifoldMarketplace {
     /**
-    * Comma-separated list of hidden products (labels)
-    */
-    'excludes'?: string;
-    /**
     * Comma-separated list of featured products (labels)
     */
     'featured'?: string;
@@ -331,7 +327,6 @@ export namespace Components {
     'templateLinkFormat'?: string;
   }
   interface ManifoldMarketplaceGrid {
-    'excludes'?: string[];
     'featured'?: string[];
     'freeProducts'?: string[];
     'hideCategories'?: boolean;
@@ -339,8 +334,8 @@ export namespace Components {
     'hideTemplates'?: boolean;
     'preserveEvent': boolean;
     'productLinkFormat'?: string;
-    'products'?: string[];
-    'services'?: Catalog.Product[];
+    'products': string[];
+    'services': Catalog.Product[];
     'skeleton'?: boolean;
     'templateLinkFormat'?: string;
   }
@@ -1335,10 +1330,6 @@ declare namespace LocalJSX {
   }
   interface ManifoldMarketplace extends JSXBase.HTMLAttributes<HTMLManifoldMarketplaceElement> {
     /**
-    * Comma-separated list of hidden products (labels)
-    */
-    'excludes'?: string;
-    /**
     * Comma-separated list of featured products (labels)
     */
     'featured'?: string;
@@ -1376,7 +1367,6 @@ declare namespace LocalJSX {
     'templateLinkFormat'?: string;
   }
   interface ManifoldMarketplaceGrid extends JSXBase.HTMLAttributes<HTMLManifoldMarketplaceGridElement> {
-    'excludes'?: string[];
     'featured'?: string[];
     'freeProducts'?: string[];
     'hideCategories'?: boolean;

--- a/src/components/manifold-marketplace-grid/manifold-marketplace-grid.e2e.ts
+++ b/src/components/manifold-marketplace-grid/manifold-marketplace-grid.e2e.ts
@@ -93,36 +93,6 @@ describe('<manifold-marketplace-grid>', () => {
   });
 
   describe('v0 API', () => {
-    it('[excludes] accepts exclusion list of products', async () => {
-      const excludes = ['service-messaging', 'service-optimization'];
-
-      const page = await newE2EPage({
-        html: `<manifold-marketplace-grid></manifold-marketplace-grid>`,
-      });
-      await page.$eval(
-        'manifold-marketplace-grid',
-        (elm: any, props: any) => {
-          elm.services = props.services;
-          elm.excludes = props.excludes;
-        },
-        { services, excludes }
-      );
-      await page.waitForChanges();
-
-      const notExcluded = testCategories
-        .map(category => `service-${category}`)
-        .filter(category => !excludes.includes(category));
-
-      const serviceCards = await page.findAll(
-        `manifold-marketplace-grid >>> manifold-service-card-view`
-      );
-      const productLabels = await Promise.all(
-        serviceCards.map(card => card.getProperty('productLabel'))
-      );
-
-      expect(productLabels).toEqual(notExcluded);
-    });
-
     it('[featured] features specified products', async () => {
       const featured = ['service-database', 'service-logging'];
 

--- a/src/components/manifold-marketplace-grid/manifold-marketplace-grid.tsx
+++ b/src/components/manifold-marketplace-grid/manifold-marketplace-grid.tsx
@@ -94,7 +94,10 @@ export class ManifoldMarketplaceGrid {
     }
 
     const services = this.products.length
-      ? this.services.filter(s => this.products.includes(s.body.label))
+      ? this.products.reduce<Catalog.Product[]>((all, p) => {
+          const s = this.services.find(s => s.body.label === p);
+          return s ? all.concat(s) : all;
+        }, [])
       : this.services;
 
     // Handle search

--- a/src/components/manifold-marketplace-grid/manifold-marketplace-grid.tsx
+++ b/src/components/manifold-marketplace-grid/manifold-marketplace-grid.tsx
@@ -18,7 +18,6 @@ import logger from '../../utils/logger';
 })
 export class ManifoldMarketplaceGrid {
   @Element() el: HTMLElement;
-  @Prop() excludes?: string[] = [];
   @Prop() featured?: string[] = [];
   @Prop() freeProducts?: string[] = [];
   @Prop() hideCategories?: boolean = false;
@@ -26,8 +25,8 @@ export class ManifoldMarketplaceGrid {
   @Prop() hideTemplates?: boolean = false;
   @Prop() preserveEvent: boolean = false;
   @Prop() productLinkFormat?: string;
-  @Prop() products?: string[] = [];
-  @Prop() services?: Catalog.Product[];
+  @Prop() products: string[] = [];
+  @Prop() services: Catalog.Product[] = [];
   @Prop() skeleton?: boolean = false;
   @Prop() templateLinkFormat?: string;
   @State() filter: string | null;
@@ -90,34 +89,17 @@ export class ManifoldMarketplaceGrid {
   }
 
   get filteredServices(): Catalog.Product[] {
-    let services: Catalog.Product[] = [];
-
-    // If not including, start out with all services
-    if (this.products && !this.products.length) {
-      services = this.services || []; // eslint-disable-line prefer-destructuring
+    if (this.skeleton) {
+      return this.services;
     }
 
-    // Handle includes
-    if (Array.isArray(this.products)) {
-      this.products.forEach(product => {
-        const service =
-          this.services && this.services.find(({ body: { label } }) => label === product);
-        if (service) {
-          services.push(service);
-        }
-      });
-    }
-
-    // Handle excludes
-    if (Array.isArray(this.excludes)) {
-      services = services.filter(
-        ({ body: { label } }) => this.excludes && !this.excludes.includes(label)
-      );
-    }
+    const services = this.products.length
+      ? this.services.filter(s => this.products.includes(s.body.label))
+      : this.services;
 
     // Handle search
     if (this.filter && this.filter.length) {
-      services = filteredServices(this.filter, services);
+      return filteredServices(this.filter, services);
     }
 
     return services;

--- a/src/components/manifold-marketplace-grid/manifold-marketplace-grid.tsx
+++ b/src/components/manifold-marketplace-grid/manifold-marketplace-grid.tsx
@@ -95,8 +95,8 @@ export class ManifoldMarketplaceGrid {
 
     const services = this.products.length
       ? this.products.reduce<Catalog.Product[]>((all, p) => {
-          const s = this.services.find(s => s.body.label === p);
-          return s ? all.concat(s) : all;
+          const service = this.services.find(s => s.body.label === p);
+          return service ? all.concat(service) : all;
         }, [])
       : this.services;
 

--- a/src/components/manifold-marketplace/manifold-marketplace.tsx
+++ b/src/components/manifold-marketplace/manifold-marketplace.tsx
@@ -11,8 +11,6 @@ export class ManifoldMarketplace {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() restFetch?: RestFetch;
-  /** Comma-separated list of hidden products (labels) */
-  @Prop() excludes?: string;
   /** Comma-separated list of featured products (labels) */
   @Prop() featured?: string;
   /** Hide categories & side menu? */
@@ -30,7 +28,6 @@ export class ManifoldMarketplace {
   /** Template format structure, with `:product` placeholder */
   @Prop() templateLinkFormat?: string;
   @State() freeProducts?: string[];
-  @State() parsedExcludes: string[] = [];
   @State() parsedFeatured: string[] = [];
   @State() parsedProducts: string[] = [];
   @State() services: Catalog.Product[] = [];
@@ -104,9 +101,6 @@ export class ManifoldMarketplace {
     if (typeof this.featured === 'string') {
       this.parsedFeatured = this.parse(this.featured);
     }
-    if (typeof this.excludes === 'string') {
-      this.parsedExcludes = this.parse(this.excludes);
-    }
     if (typeof this.products === 'string') {
       this.parsedProducts = this.parse(this.products);
     }
@@ -118,7 +112,6 @@ export class ManifoldMarketplace {
 
     return (
       <manifold-marketplace-grid
-        excludes={this.parsedExcludes}
         featured={this.parsedFeatured}
         freeProducts={this.freeProducts}
         hideCategories={this.hideCategories}


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
The marketplace grid was flashing the "No services found" message instead of displaying the skeleton. This tightens up the logic and makes sure that the `filteredServices` function returns the skeleton services when they're provided.

## Testing
<!-- For someone unfamiliar with the issue, how should this be tested? -->

Test this in dashboard-render and make sure you see the skeleton when loading the marketplace, and that the "No services found" message does not flash at any point. Also make sure to check Storybook and the docs site.