### PR TITLE
Emit metrics events from restFetch and graphqlFetch

### DIFF
--- a/docs/docs/advanced/performance.md
+++ b/docs/docs/advanced/performance.md
@@ -64,3 +64,12 @@ Stencil’s web components work for more browsers than even have web component
 support [via a polyfill][stencil-browsers]. It’s great to have built-in
 support, but sometimes webpack can accidentally bundle the polyfill when it
 doesn’t need to. We’ve found the best fix to be **code splitting** (above).
+
+## Metrics
+
+RTT of endpoint calls are calculated and emitted as events - either from
+`document` or from an `EventEmitter` supplied by the component calling the
+endpoint.
+
+A solution to listen for and log these events is currently left as an
+implementation detail on the platform side.

--- a/docs/docs/advanced/performance.md
+++ b/docs/docs/advanced/performance.md
@@ -39,6 +39,7 @@ big payoffs.
 [fmp]: https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint
 [import]: https://webpack.js.org/guides/code-splitting/#dynamic-imports
 [stencil-browsers]: https://stenciljs.com/docs/browser-support
+[rtt]: https://developer.mozilla.org/en-US/docs/Glossary/Round_Trip_Time_(RTT)
 
 ## Other Gotchas
 
@@ -67,9 +68,15 @@ doesn’t need to. We’ve found the best fix to be **code splitting** (above).
 
 ## Metrics
 
-RTT of endpoint calls are calculated and emitted as events - either from
+[RTT][rtt] of endpoint calls are calculated and emitted as events - either from
 `document` or from an `EventEmitter` supplied by the component calling the
 endpoint.
 
 A solution to listen for and log these events is currently left as an
-implementation detail on the platform side.
+implementation detail on the platform side:
+
+```js
+document.addEventListener('manifold-rest-fetch-duration', { detail } => {
+  console.log(detail); // { endpoint: "/catalog/products", duration: 95 }
+});
+```

--- a/src/utils/graphqlFetch.spec.ts
+++ b/src/utils/graphqlFetch.spec.ts
@@ -269,12 +269,12 @@ describe('graphqlFetch', () => {
       });
 
       let event: CustomEvent | undefined;
-      addEventListener('graphql-fetch-duration', e => {
+      window.addEventListener('graphql-fetch-duration', e => {
         event = e as CustomEvent;
       });
 
       await fetcher({ query: '' });
-      event && event.detail && expect(event.detail.duration).toBeDefined;
+      expect(event && event.detail && event.detail.duration).toBeDefined();
     });
     it('emits a metrics event from an EventEmitter when supplied', async () => {
       const body = {
@@ -291,7 +291,7 @@ describe('graphqlFetch', () => {
         body,
       });
 
-      let emitter: EventEmitter = {
+      const emitter: EventEmitter = {
         emit: jest.fn(),
       };
 

--- a/src/utils/graphqlFetch.spec.ts
+++ b/src/utils/graphqlFetch.spec.ts
@@ -269,7 +269,7 @@ describe('graphqlFetch', () => {
       });
 
       let event: CustomEvent | undefined;
-      window.addEventListener('graphql-fetch-duration', e => {
+      window.addEventListener('manifold-graphql-fetch-duration', e => {
         event = e as CustomEvent;
       });
 
@@ -297,7 +297,7 @@ describe('graphqlFetch', () => {
 
       await fetcher({ query: '', emitter });
       expect((emitter.emit as jest.Mock).mock.calls[0][0]).toMatchObject({
-        type: 'graphql-fetch-duration',
+        type: 'manifold-graphql-fetch-duration',
       });
     });
   });

--- a/src/utils/graphqlFetch.ts
+++ b/src/utils/graphqlFetch.ts
@@ -1,6 +1,6 @@
+import { EventEmitter } from '@stencil/core';
 import { hasExpired } from './expiry';
 import { report } from './errorReport';
-import { EventEmitter } from '@stencil/core';
 
 interface CreateGraphqlFetch {
   endpoint?: string;

--- a/src/utils/graphqlFetch.ts
+++ b/src/utils/graphqlFetch.ts
@@ -92,13 +92,13 @@ export function createGraphqlFetch({
     const fetchDuration = performance.now() - rttStart;
     if (emitter) {
       emitter.emit({
-        type: 'graphql-fetch-duration',
+        type: 'manifold-graphql-fetch-duration',
         request,
         duration: fetchDuration,
       });
     } else {
       document.dispatchEvent(
-        new CustomEvent('graphql-fetch-duration', {
+        new CustomEvent('manifold-graphql-fetch-duration', {
           bubbles: true,
           detail: { request, duration: fetchDuration },
         })

--- a/src/utils/graphqlFetch.ts
+++ b/src/utils/graphqlFetch.ts
@@ -34,6 +34,7 @@ export function createGraphqlFetch({
 }: CreateGraphqlFetch): GraphqlFetch {
   return async function graphqlFetch<T>(args: graphqlArgs): Promise<GraphqlResponseBody<T>> {
     const start = new Date();
+    const rttStart = performance.now();
     const { isPublic, emitter, ...request } = args;
 
     if (!isPublic) {
@@ -88,7 +89,7 @@ export function createGraphqlFetch({
       report(body.errors);
     }
 
-    const fetchDuration = new Date().getTime() - start.getTime();
+    const fetchDuration = performance.now() - rttStart;
     if (emitter) {
       emitter.emit({
         type: 'graphql-fetch-duration',
@@ -98,6 +99,7 @@ export function createGraphqlFetch({
     } else {
       document.dispatchEvent(
         new CustomEvent('graphql-fetch-duration', {
+          bubbles: true,
           detail: { request, duration: fetchDuration },
         })
       );

--- a/src/utils/restFetch.spec.ts
+++ b/src/utils/restFetch.spec.ts
@@ -166,12 +166,12 @@ describe('The fetcher created by createRestFetch', () => {
     fetchMock.mock('path:/v1/test', {});
 
     let event: CustomEvent | undefined;
-    addEventListener('rest-fetch-duration', e => {
+    window.addEventListener('rest-fetch-duration', e => {
       event = e as CustomEvent;
     });
 
     await fetcher({ endpoint: '/test', service: 'marketplace' });
-    event && event.detail && expect(event.detail.duration).toBeDefined;
+    expect(event && event.detail && event.detail.duration).toBeDefined();
   });
   it('emits a metrics event from an EventEmitter when supplied', async () => {
     const fetcher = createRestFetch({
@@ -180,7 +180,7 @@ describe('The fetcher created by createRestFetch', () => {
 
     fetchMock.mock('path:/v1/test', {});
 
-    let emitter: EventEmitter = {
+    const emitter: EventEmitter = {
       emit: jest.fn(),
     };
 

--- a/src/utils/restFetch.spec.ts
+++ b/src/utils/restFetch.spec.ts
@@ -166,7 +166,7 @@ describe('The fetcher created by createRestFetch', () => {
     fetchMock.mock('path:/v1/test', {});
 
     let event: CustomEvent | undefined;
-    window.addEventListener('rest-fetch-duration', e => {
+    window.addEventListener('manifold-rest-fetch-duration', e => {
       event = e as CustomEvent;
     });
 
@@ -186,7 +186,7 @@ describe('The fetcher created by createRestFetch', () => {
 
     await fetcher({ endpoint: '/test', service: 'marketplace', emitter });
     expect((emitter.emit as jest.Mock).mock.calls[0][0]).toMatchObject({
-      type: 'rest-fetch-duration',
+      type: 'manifold-rest-fetch-duration',
     });
   });
 });

--- a/src/utils/restFetch.ts
+++ b/src/utils/restFetch.ts
@@ -78,13 +78,13 @@ export function createRestFetch({
       const fetchDuration = performance.now() - rttStart;
       if (args.emitter) {
         args.emitter.emit({
-          type: 'rest-fetch-duration',
+          type: 'manifold-rest-fetch-duration',
           endpoint: args.endpoint,
           duration: fetchDuration,
         });
       } else {
         document.dispatchEvent(
-          new CustomEvent('rest-fetch-duration', {
+          new CustomEvent('manifold-rest-fetch-duration', {
             bubbles: true,
             detail: { endpoint: args.endpoint, duration: fetchDuration },
           })

--- a/src/utils/restFetch.ts
+++ b/src/utils/restFetch.ts
@@ -32,6 +32,7 @@ export function createRestFetch({
 }: CreateRestFetch): RestFetch {
   return async function restFetch<T>(args: RestFetchArguments): Promise<T | Success> {
     const start = new Date();
+    const rttStart = performance.now();
 
     // TODO: catalog should ALWAYS be able to fetch WITHOUT auth if needed,
     // but this prevents the ability for it to auth altogether. We need both!
@@ -74,7 +75,7 @@ export function createRestFetch({
 
     const body = await response.json();
     if (response.status >= 200 && response.status < 300) {
-      const fetchDuration = new Date().getTime() - start.getTime();
+      const fetchDuration = performance.now() - rttStart;
       if (args.emitter) {
         args.emitter.emit({
           type: 'rest-fetch-duration',
@@ -84,6 +85,7 @@ export function createRestFetch({
       } else {
         document.dispatchEvent(
           new CustomEvent('rest-fetch-duration', {
+            bubbles: true,
             detail: { endpoint: args.endpoint, duration: fetchDuration },
           })
         );


### PR DESCRIPTION
## Reason for change

This PR emits events to record duration of graphql and REST fetch calls. Event is emitted from optional EventEmitter and falls back to emitting from `document`.

## Testing

I tested by adding an event listener to a render-dashboard page and using this version of UI in render-dashboard. I had trouble testing this in storybook but there might be a way.
