### PR TITLE
Removing padding above product component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Removed padding above `<manifold-product-page>`
+
 ## [v0.5.5]
 
 ### Fixed

--- a/src/components/manifold-product-page/manifold-product-page.css
+++ b/src/components/manifold-product-page/manifold-product-page.css
@@ -104,6 +104,7 @@
   max-width: 20rem;
   margin-right: auto;
   margin-left: auto;
+  top: var(--overlap);
 }
 
 .sidebar-cta {
@@ -119,7 +120,6 @@
 
 .sidebar-inner {
   position: sticky;
-  top: var(--overlap);
 }
 
 .sidebar-section {

--- a/src/components/manifold-product-page/manifold-product-page.css
+++ b/src/components/manifold-product-page/manifold-product-page.css
@@ -100,11 +100,10 @@
 }
 
 .sidebar {
-  position: relative;
-  top: var(--overlap);
   max-width: 20rem;
   margin-right: auto;
   margin-left: auto;
+  padding-top: var(--overlap);
 }
 
 .sidebar-cta {
@@ -116,10 +115,6 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-}
-
-.sidebar-inner {
-  position: sticky;
 }
 
 .sidebar-section {

--- a/src/components/manifold-product-page/manifold-product-page.css
+++ b/src/components/manifold-product-page/manifold-product-page.css
@@ -101,8 +101,8 @@
 
 .sidebar {
   position: relative;
-  max-width: 20rem;
   top: var(--overlap);
+  max-width: 20rem;
   margin-right: auto;
   margin-left: auto;
 }

--- a/src/components/manifold-product-page/manifold-product-page.css
+++ b/src/components/manifold-product-page/manifold-product-page.css
@@ -102,9 +102,9 @@
 .sidebar {
   position: relative;
   max-width: 20rem;
+  top: var(--overlap);
   margin-right: auto;
   margin-left: auto;
-  top: var(--overlap);
 }
 
 .sidebar-cta {

--- a/src/components/manifold-product-page/manifold-product-page.css
+++ b/src/components/manifold-product-page/manifold-product-page.css
@@ -119,7 +119,7 @@
 
 .sidebar-inner {
   position: sticky;
-  top: 3rem;
+  top: var(--overlap);
 }
 
 .sidebar-section {
@@ -225,8 +225,4 @@
       }
     }
   }
-}
-
-.wrapper {
-  padding-top: var(--overlap);
 }

--- a/src/components/manifold-product-page/manifold-product-page.tsx
+++ b/src/components/manifold-product-page/manifold-product-page.tsx
@@ -38,71 +38,62 @@ export class ManifoldProductPage {
       const gradient = `var(--manifold-g-${label}, var(--manifold-g-default))`;
 
       return (
-        <div class="wrapper" itemscope itemtype="http://schema.org/Product">
+        <div itemscope itemtype="http://schema.org/Product">
           <section class="grid">
             <aside class="sidebar">
-              <div class="sidebar-inner">
-                <div class="sidebar-card" style={{ '--background-gradient': gradient }}>
-                  <div class="product-logo">
-                    <img src={logo_url} alt={name} itemprop="logo" />
-                  </div>
-                  <h2 class="product-name" itemprop="name">
-                    {name}
-                  </h2>
-                  <p class="provider-name">
-                    {this.providerName && <span itemprop="brand">from {this.providerName}</span>}
-                  </p>
+              <div class="sidebar-card" style={{ '--background-gradient': gradient }}>
+                <div class="product-logo">
+                  <img src={logo_url} alt={name} itemprop="logo" />
                 </div>
-                <div class="sidebar-cta">
-                  <slot name="cta" />
+                <h2 class="product-name" itemprop="name">
+                  {name}
+                </h2>
+                <p class="provider-name">
+                  {this.providerName && <span itemprop="brand">from {this.providerName}</span>}
+                </p>
+              </div>
+              <div class="sidebar-cta">
+                <slot name="cta" />
+              </div>
+              {tags && (
+                <div class="sidebar-section">
+                  <h4>Category</h4>
+                  {tags.map(tag => (
+                    <div class="category" style={{ '--categoryColor': `var(--manifold-c-${tag})` }}>
+                      <manifold-icon
+                        icon={categoryIcon[tag] || categoryIcon.uncategorized}
+                        margin-right
+                      />
+                      {tag}
+                    </div>
+                  ))}
                 </div>
-                {tags && (
-                  <div class="sidebar-section">
-                    <h4>Category</h4>
-                    {tags.map(tag => (
-                      <div
-                        class="category"
-                        style={{ '--categoryColor': `var(--manifold-c-${tag})` }}
-                      >
-                        <manifold-icon
-                          icon={categoryIcon[tag] || categoryIcon.uncategorized}
-                          margin-right
-                        />
-                        {tag}
-                      </div>
-                    ))}
+              )}
+              <div class="sidebar-section">
+                <h4>Links</h4>
+                <div class="provider-link">
+                  <a href={documentation_url} target="_blank" rel="noopener noreferrer">
+                    <manifold-icon icon={book} margin-right />
+                    Docs
+                    <manifold-icon class="external-link-icon" icon={arrow_up_right} margin-left />
+                  </a>
+                </div>
+                <div class="provider-link">
+                  <a href={`mailto:${support_email}`} target="_blank" rel="noopener noreferrer">
+                    <manifold-icon icon={life_buoy} margin-right />
+                    Support
+                    <manifold-icon class="external-link-icon" icon={arrow_up_right} margin-left />
+                  </a>
+                </div>
+                {terms.provided && (
+                  <div class="provider-link">
+                    <a href={terms.url} target="_blank" rel="noopener noreferrer">
+                      <manifold-icon icon={file_text} margin-right />
+                      Terms of service
+                      <manifold-icon class="external-link-icon" icon={arrow_up_right} margin-left />
+                    </a>
                   </div>
                 )}
-                <div class="sidebar-section">
-                  <h4>Links</h4>
-                  <div class="provider-link">
-                    <a href={documentation_url} target="_blank" rel="noopener noreferrer">
-                      <manifold-icon icon={book} margin-right />
-                      Docs
-                      <manifold-icon class="external-link-icon" icon={arrow_up_right} margin-left />
-                    </a>
-                  </div>
-                  <div class="provider-link">
-                    <a href={`mailto:${support_email}`} target="_blank" rel="noopener noreferrer">
-                      <manifold-icon icon={life_buoy} margin-right />
-                      Support
-                      <manifold-icon class="external-link-icon" icon={arrow_up_right} margin-left />
-                    </a>
-                  </div>
-                  {terms.provided && (
-                    <div class="provider-link">
-                      <a href={terms.url} target="_blank" rel="noopener noreferrer">
-                        <manifold-icon icon={file_text} margin-right />
-                        Terms of service
-                        <manifold-icon
-                          class="external-link-icon"
-                          icon={arrow_up_right}
-                          margin-left
-                        />
-                      </a>
-                    </div>
-                  )}
-                </div>
               </div>
             </aside>
             <manifold-product-details product={this.product} />
@@ -117,32 +108,28 @@ export class ManifoldProductPage {
     } = skeletonProduct;
 
     return (
-      <div class="wrapper">
-        <section class="grid">
-          <aside class="sidebar">
-            <div class="sidebar-inner">
-              <div
-                class="sidebar-card"
-                style={{ '--background-gradient': 'var(--manifold-g-default)' }}
-              >
-                <div class="product-logo">
-                  <manifold-skeleton-img />
-                </div>
-                <h2 class="product-name" itemprop="name">
-                  <manifold-skeleton-text>{name}</manifold-skeleton-text>
-                </h2>
-              </div>
-              <div class="sidebar-section">
-                <h4>Category</h4>
-                <div class="category">
-                  <manifold-skeleton-text>Database</manifold-skeleton-text>
-                </div>
-              </div>
+      <section class="grid">
+        <aside class="sidebar">
+          <div
+            class="sidebar-card"
+            style={{ '--background-gradient': 'var(--manifold-g-default)' }}
+          >
+            <div class="product-logo">
+              <manifold-skeleton-img />
             </div>
-          </aside>
-          <manifold-product-details />
-        </section>
-      </div>
+            <h2 class="product-name" itemprop="name">
+              <manifold-skeleton-text>{name}</manifold-skeleton-text>
+            </h2>
+          </div>
+          <div class="sidebar-section">
+            <h4>Category</h4>
+            <div class="category">
+              <manifold-skeleton-text>Database</manifold-skeleton-text>
+            </div>
+          </div>
+        </aside>
+        <manifold-product-details />
+      </section>
     );
   }
 }


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change
This PR removes the padding visible in the Render dash's service modal by removing the padding on the `manifold-product-page` wrapper div.

It also changes the `.sidebar` `top` to align the top of the product logo with the top of the sidebar and removes the `.sidebar-inner` `top` to compensate for the change in height of the sidebar. 

Without this change:

<img width="971" alt="Screen Shot 2019-08-19 at 12 14 20 PM" src="https://user-images.githubusercontent.com/13300125/63288827-e547d700-c27a-11e9-8547-a80dcb6ac82a.png">

With this change: 

<img width="912" alt="Screen Shot 2019-08-19 at 12 11 34 PM" src="https://user-images.githubusercontent.com/13300125/63288691-8eda9880-c27a-11e9-9eaa-d9fd4d2da392.png">

If my CSS math is bad here please let me know! 😅 

## Testing
Load this branch of UI in the Render dashboard through `npm link` or copying the `dist` folder over and test it by clicking Addons > New Addon > selecting a product. Then check how it looks under "Product" in Storybook (`npm run storybook`) and in the docs (`npm run docs`).