### PR TITLE
Remove extra event emitters, add DOM tests

### DIFF
--- a/docs/docs/data/manifold-data-rename-button.md
+++ b/docs/docs/data/manifold-data-rename-button.md
@@ -21,19 +21,23 @@ Set the CTA text by adding anything between the opening and closing tags:
 </manifold-data-provision-button>
 ```
 
-`slot` can be attached to any HTML or JSX element. To read more about slots, see [Stencil’s Documentation][stencil-slot]
+`slot` can be attached to any HTML or JSX element. To read more about slots, see [Stencil’s
+Documentation][stencil-slot]
 
 ## Events
 
 For validation, error, and success messages, it will emit custom events.
 
 ```js
-document.addEventListener('manifold-renameButton-click', ({ detail: { resourceLabel, newLabel } }) =>
-  console.info(`⌛ Renaming ${resourceLabel} to ${newLabel} …`)
+document.addEventListener(
+  'manifold-renameButton-click',
+  ({ detail: { resourceLabel, newLabel } }) =>
+    console.info(`⌛ Renaming ${resourceLabel} to ${newLabel} …`)
 );
 document.addEventListener(
   'manifold-renameButton-success',
-  ({ detail: { resourceLabel, newLabel } }) => alert(`${resourceLabel} renamed to ${newLabel} successfully!`)
+  ({ detail: { resourceLabel, newLabel } }) =>
+    alert(`${resourceLabel} renamed to ${newLabel} successfully!`)
 );
 document.addEventListener('manifold-renameButton-error', ({ detail }) => console.log(detail));
 // {message: "bad_request: bad_request: No plan_id provided", resourceid: "1234", resourceLabel: "my-resource", newLabel: "new-name"}
@@ -41,20 +45,19 @@ document.addEventListener('manifold-renameButton-invalid', ({ detail }) => conso
 // {message: "bad_request: bad_request: No plan_id provided", resourceid: "1234", resourceLabel: "my-resource", newLabel: "new-name"}
 ```
 
-| Name                            |                       Returns                            | Description                                                                                                                 |
-| :-------------------------------| :------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------- |
-| `manifold-renameButton-click`   |       `resourceId`, `resourceLabel`, `newLabel`          | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
-| `manifold-renameButton-success` |   `message`, `resourceId`, `resourceLabel`, `newLabel`   | Successful renaming. Returns a resource ID and resource Label as well as a message and the new name for the resource.       |
-| `manifold-renameButton-error`   |   `message`, `resourceId`, `resourceLabel`, `newLabel`   | Erred rename, along with information on what went wrong.                                                                    |
-| `manifold-renameButton-error`   |   `message`, `resourceId`, `resourceLabel`, `newLabel`   | Invalid renaming, along with information on what went wrong.                                                                |
+| Name                            |                       Returns                        | Description                                                                                                                 |
+| :------------------------------ | :--------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------- |
+| `manifold-renameButton-click`   |      `resourceId`, `resourceLabel`, `newLabel`       | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
+| `manifold-renameButton-success` | `message`, `resourceId`, `resourceLabel`, `newLabel` | Successful renaming. Returns a resource ID and resource Label as well as a message and the new name for the resource.       |
+| `manifold-renameButton-error`   | `message`, `resourceId`, `resourceLabel`, `newLabel` | Erred rename, along with information on what went wrong.                                                                    |
+| `manifold-renameButton-invalid` | `message`, `resourceId`, `resourceLabel`, `newLabel` | Invalid renaming, along with information on what went wrong.                                                                |
 
 ## Styling
 
-Whereas other components in this system take advantage of [Shadow
-DOM][shadow-dom] encapsulation for ease of use, we figured this component
-should be customizable. As such, style it however you’d like! We recommend
-attaching styles to a parent element using any CSS-in-JS framework of your
-choice, or plain ol’ CSS.
+Whereas other components in this system take advantage of [Shadow DOM][shadow-dom] encapsulation for
+ease of use, we figured this component should be customizable. As such, style it however you’d like!
+We recommend attaching styles to a parent element using any CSS-in-JS framework of your choice, or
+plain ol’ CSS.
 
 [shadow-dom]: https://developers.google.com/web/fundamentals/web-components/shadowdom
 [stencil-slot]: https://stenciljs.com/docs/templating-jsx/

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1548,9 +1548,6 @@ declare namespace LocalJSX {
   interface ManifoldResourceDeprovision extends JSXBase.HTMLAttributes<HTMLManifoldResourceDeprovisionElement> {
     'data'?: Gateway.Resource;
     'loading'?: boolean;
-    'onManifold-deprovisionButton-click'?: (event: CustomEvent<any>) => void;
-    'onManifold-deprovisionButton-error'?: (event: CustomEvent<any>) => void;
-    'onManifold-deprovisionButton-success'?: (event: CustomEvent<any>) => void;
   }
   interface ManifoldResourceDetails extends JSXBase.HTMLAttributes<HTMLManifoldResourceDetailsElement> {}
   interface ManifoldResourceDetailsView extends JSXBase.HTMLAttributes<HTMLManifoldResourceDetailsViewElement> {
@@ -1586,17 +1583,10 @@ declare namespace LocalJSX {
     * The new label to give to the resource
     */
     'newLabel'?: string;
-    'onManifold-renameButton-click'?: (event: CustomEvent<any>) => void;
-    'onManifold-renameButton-error'?: (event: CustomEvent<any>) => void;
-    'onManifold-renameButton-invalid'?: (event: CustomEvent<any>) => void;
-    'onManifold-renameButton-success'?: (event: CustomEvent<any>) => void;
   }
   interface ManifoldResourceSso extends JSXBase.HTMLAttributes<HTMLManifoldResourceSsoElement> {
     'data'?: Gateway.Resource;
     'loading'?: boolean;
-    'onManifold-ssoButton-click'?: (event: CustomEvent<any>) => void;
-    'onManifold-ssoButton-error'?: (event: CustomEvent<any>) => void;
-    'onManifold-ssoButton-success'?: (event: CustomEvent<any>) => void;
   }
   interface ManifoldResourceStatus extends JSXBase.HTMLAttributes<HTMLManifoldResourceStatusElement> {
     'data'?: Gateway.Resource;

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
@@ -134,7 +134,7 @@ describe('<manifold-data-deprovision-button>', () => {
         html: `
           <manifold-data-deprovision-button
             resource-label="test"
-          >Provision</manifold-data-deprovision-button>
+          >Deprovision</manifold-data-deprovision-button>
         `,
       });
 
@@ -156,7 +156,7 @@ describe('<manifold-data-deprovision-button>', () => {
         html: `
           <manifold-data-deprovision-button
             resource-label="test"
-          >Provision</manifold-data-deprovision-button>
+          >Deprovision</manifold-data-deprovision-button>
         `,
       });
 
@@ -223,7 +223,7 @@ describe('<manifold-data-deprovision-button>', () => {
         html: `
           <manifold-data-deprovision-button
             resource-label="${resourceLabel}"
-          >Provision</manifold-data-deprovision-button>
+          >Deprovision</manifold-data-deprovision-button>
         `,
       });
 

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
@@ -193,10 +193,13 @@ describe('<manifold-data-deprovision-button>', () => {
         `,
       });
 
+      const button = page.root && page.root.querySelector('button');
+      if (!button) throw new Error('button not found in document');
+
       // listen for event and fire
       const mockClick = jest.fn();
       page.doc.addEventListener('manifold-deprovisionButton-click', mockClick);
-      page.root.querySelector('button').click();
+      button.click();
 
       expect(fetchMock.called(`${connections.prod.gateway}/id/resource/${Resource.id}`)).toBe(true);
       expect(mockClick).toHaveBeenCalledWith(
@@ -224,12 +227,15 @@ describe('<manifold-data-deprovision-button>', () => {
         `,
       });
 
+      const button = page.root && page.root.querySelector('button');
+      if (!button) throw new Error('button not found in document');
+
       const mockClick = jest.fn();
       await new Promise(resolve => {
         // listen for event and fire
         mockClick.mockImplementation(() => resolve());
         page.doc.addEventListener('manifold-deprovisionButton-error', mockClick);
-        page.root.querySelector('button').click();
+        button.click();
       });
 
       expect(fetchMock.called(`${connections.prod.gateway}/id/resource/${Resource.id}`)).toBe(true);
@@ -257,12 +263,15 @@ describe('<manifold-data-deprovision-button>', () => {
         `,
       });
 
+      const button = page.root && page.root.querySelector('button');
+      if (!button) throw new Error('button not found in document');
+
       const mockClick = jest.fn();
       await new Promise(resolve => {
         // listen for event and fire
         mockClick.mockImplementation(() => resolve());
         page.doc.addEventListener('manifold-deprovisionButton-success', mockClick);
-        page.root.querySelector('button').click();
+        button.click();
       });
 
       expect(fetchMock.called(`${connections.prod.gateway}/id/resource/${Resource.id}`)).toBe(true);

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
@@ -75,9 +75,7 @@ describe('<manifold-data-deprovision-button>', () => {
     it('will fetch the resource id', async () => {
       const resourceLabel = 'new-resource';
 
-      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`, [
-        Resource,
-      ]);
+      fetchMock.mock(/\/resources\/\?me/, [Resource]);
 
       const page = await newSpecPage({
         components: [ManifoldDataDeprovisionButton],
@@ -99,7 +97,7 @@ describe('<manifold-data-deprovision-button>', () => {
     it('will do nothing on a fetch error', async () => {
       const resourceLabel = 'new-resource';
 
-      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`, []);
+      fetchMock.mock(/\/resources\/\?me/, []);
 
       const page = await newSpecPage({
         components: [ManifoldDataDeprovisionButton],
@@ -128,68 +126,8 @@ describe('<manifold-data-deprovision-button>', () => {
       fetchMock.mock('path:/v1/resources/', [Resource]);
     });
 
-    it('will trigger a dom event on successful deprovision', async () => {
-      fetchMock.mock(`${connections.prod.gateway}/id/resource/${Resource.id}`, {
-        status: 202,
-      });
-
-      const page = await newSpecPage({
-        components: [ManifoldDataDeprovisionButton],
-        html: `
-          <manifold-data-deprovision-button
-            resource-label="test"
-          >Deprovision</manifold-data-deprovision-button>
-        `,
-      });
-
-      const instance = page.rootInstance as ManifoldDataDeprovisionButton;
-      instance.success.emit = jest.fn();
-
-      await instance.deprovision();
-
-      expect(fetchMock.called(`${connections.prod.gateway}/id/resource/${Resource.id}`)).toBe(true);
-      expect(instance.success.emit).toHaveBeenCalledWith({
-        message: 'test successfully deprovisioned',
-        resourceLabel: 'test',
-        resourceId: Resource.id,
-      });
-    });
-
-    it('will trigger a dom event on failed deprovision', async () => {
-      fetchMock.mock(`${connections.prod.gateway}/id/resource/${Resource.id}`, {
-        status: 500,
-        body: {
-          message: 'ohnoes',
-        },
-      });
-
-      const page = await newSpecPage({
-        components: [ManifoldDataDeprovisionButton],
-        html: `
-          <manifold-data-deprovision-button
-            resource-label="test"
-          >Provision</manifold-data-deprovision-button>
-        `,
-      });
-
-      const instance = page.rootInstance as ManifoldDataDeprovisionButton;
-      instance.error.emit = jest.fn();
-
-      expect.assertions(2);
-      return instance.deprovision().catch(() => {
-        expect(fetchMock.called(`${connections.prod.gateway}/id/resource/${Resource.id}`)).toBe(
-          true
-        );
-        expect(instance.error.emit).toHaveBeenCalledWith({
-          message: 'ohnoes',
-          resourceLabel: 'test',
-          resourceId: Resource.id,
-        });
-      });
-    });
-
     it('will do nothing if still loading', async () => {
-      fetchMock.mock(`${connections.prod.gateway}/id/resource/${Resource.id}`, 200);
+      fetchMock.mock(/\/id\/resource\//, 200);
 
       const page = await newSpecPage({
         components: [ManifoldDataDeprovisionButton],
@@ -211,7 +149,7 @@ describe('<manifold-data-deprovision-button>', () => {
     });
 
     it('will do nothing if no resourceId is provided', async () => {
-      fetchMock.mock(`${connections.prod.gateway}/id/resource/${Resource.id}`, 200);
+      fetchMock.mock(/\/id\/resource\//, 200);
 
       const page = await newSpecPage({
         components: [ManifoldDataDeprovisionButton],
@@ -229,6 +167,113 @@ describe('<manifold-data-deprovision-button>', () => {
 
       expect(fetchMock.called(`${connections.prod.gateway}/id/resource/${Resource.id}`)).toBe(
         false
+      );
+    });
+  });
+
+  describe('events', () => {
+    beforeEach(() => {
+      fetchMock.mock(/\/resources\/\?me/, [Resource]);
+    });
+    afterEach(() => {
+      fetchMock.restore();
+    });
+
+    it('click', async () => {
+      fetchMock.mock(/\/id\/resource\//, 202);
+
+      const resourceLabel = 'click-label';
+
+      const page = await newSpecPage({
+        components: [ManifoldDataDeprovisionButton],
+        html: `
+          <manifold-data-deprovision-button
+            resource-label="${resourceLabel}"
+          >Deprovision</manifold-data-deprovision-button>
+        `,
+      });
+
+      // listen for event and fire
+      const mockClick = jest.fn();
+      page.doc.addEventListener('manifold-deprovisionButton-click', mockClick);
+      page.root.querySelector('button').click();
+
+      expect(fetchMock.called(`${connections.prod.gateway}/id/resource/${Resource.id}`)).toBe(true);
+      expect(mockClick).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: {
+            resourceLabel,
+            resourceId: Resource.id,
+          },
+        })
+      );
+    });
+
+    it('error', async () => {
+      const message = 'ohnoes';
+
+      fetchMock.mock(/\/id\/resource\//, { status: 500, body: { message } });
+
+      const resourceLabel = 'error-label';
+      const page = await newSpecPage({
+        components: [ManifoldDataDeprovisionButton],
+        html: `
+          <manifold-data-deprovision-button
+            resource-label="${resourceLabel}"
+          >Provision</manifold-data-deprovision-button>
+        `,
+      });
+
+      const mockClick = jest.fn();
+      await new Promise(resolve => {
+        // listen for event and fire
+        mockClick.mockImplementation(() => resolve());
+        page.doc.addEventListener('manifold-deprovisionButton-error', mockClick);
+        page.root.querySelector('button').click();
+      });
+
+      expect(fetchMock.called(`${connections.prod.gateway}/id/resource/${Resource.id}`)).toBe(true);
+      expect(mockClick).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: {
+            message,
+            resourceLabel,
+            resourceId: Resource.id,
+          },
+        })
+      );
+    });
+
+    it('success', async () => {
+      fetchMock.mock(/\/id\/resource\//, 202);
+
+      const resourceLabel = 'success-label';
+      const page = await newSpecPage({
+        components: [ManifoldDataDeprovisionButton],
+        html: `
+          <manifold-data-deprovision-button
+            resource-label="${resourceLabel}"
+          >Deprovision</manifold-data-deprovision-button>
+        `,
+      });
+
+      const mockClick = jest.fn();
+      await new Promise(resolve => {
+        // listen for event and fire
+        mockClick.mockImplementation(() => resolve());
+        page.doc.addEventListener('manifold-deprovisionButton-success', mockClick);
+        page.root.querySelector('button').click();
+      });
+
+      expect(fetchMock.called(`${connections.prod.gateway}/id/resource/${Resource.id}`)).toBe(true);
+      expect(mockClick).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: {
+            message: `${resourceLabel} successfully deprovisioned`,
+            resourceLabel,
+            resourceId: Resource.id,
+          },
+        })
       );
     });
   });

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
@@ -22,15 +22,22 @@ proto.componentWillLoad = function() {
   }
 };
 
-describe('<manifold-data-rename-button>', () => {
-  it('fetches the resource id on load if not set', () => {
-    const resourceLabel = 'test-resource';
+// fetch calls for all tests (name a resource “error-*” to throw)
+fetchMock.mock(/\/id\/resource\//, { status: 200, body: {} });
+fetchMock.mock(/\/resources\/(?!\?me).*/, url =>
+  url.includes('error')
+    ? { status: 404, body: { message: 'resource not found' } }
+    : { status: 200, body: Resource }
+);
+fetchMock.mock(/\/resources\/\?me/, url =>
+  url.includes('error')
+    ? { status: 404, body: { message: 'no resources' } }
+    : { status: 200, body: [Resource] }
+);
 
-    const provisionButton = new ManifoldDataRenameButton();
-    provisionButton.fetchResourceId = jest.fn();
-    provisionButton.resourceLabel = resourceLabel;
-    provisionButton.componentWillLoad();
-    expect(provisionButton.fetchResourceId).toHaveBeenCalledWith(resourceLabel);
+describe('<manifold-data-rename-button>', () => {
+  beforeEach(() => {
+    fetchMock.resetHistory();
   });
 
   it('does not fetch the resource id on load if set', () => {
@@ -55,7 +62,7 @@ describe('<manifold-data-rename-button>', () => {
     expect(provisionButton.fetchResourceId).toHaveBeenCalledWith(resourceLabel);
   });
 
-  it('does not resource id on change if set', () => {
+  it('does not fetch resource id on change if set', () => {
     const resourceLabel = 'new-resource';
 
     const provisionButton = new ManifoldDataRenameButton();
@@ -68,16 +75,8 @@ describe('<manifold-data-rename-button>', () => {
   });
 
   describe('when created without a resource ID', () => {
-    afterEach(() => {
-      fetchMock.restore();
-    });
-
     it('will fetch the resource id', async () => {
-      const resourceLabel = 'new-resource';
-
-      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`, [
-        Resource,
-      ]);
+      const resourceLabel = 'test-label';
 
       const page = await newSpecPage({
         components: [ManifoldDataRenameButton],
@@ -97,9 +96,7 @@ describe('<manifold-data-rename-button>', () => {
     });
 
     it('will do nothing on a fetch error', async () => {
-      const resourceLabel = 'new-resource';
-
-      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${resourceLabel}`, []);
+      const resourceLabel = 'error-label';
 
       const page = await newSpecPage({
         components: [ManifoldDataRenameButton],
@@ -120,100 +117,13 @@ describe('<manifold-data-rename-button>', () => {
   });
 
   describe('When sending a request to rename', () => {
-    afterEach(() => {
-      fetchMock.restore();
-    });
-
-    beforeEach(() => {
-      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=${Resource.body.label}`, [
-        Resource,
-      ]);
-    });
-
-    it('will trigger a dom event on successful rename', async () => {
-      fetchMock.mock(`${connections.prod.marketplace}/resources/${Resource.id}`, Resource);
-      fetchMock.mock(`${connections.prod.marketplace}/resources/?me&label=test2`, [
-        {
-          ...Resource,
-          body: {
-            label: 'test2',
-          },
-        },
-      ]);
-
-      const page = await newSpecPage({
-        components: [ManifoldDataRenameButton],
-        html: `
-          <manifold-data-rename-button
-            resource-label="${Resource.body.label}"
-            new-label="test2"
-          >Rename</manifold-data-rename-button>
-        `,
-      });
-
-      const instance = page.rootInstance as ManifoldDataRenameButton;
-      instance.success.emit = jest.fn();
-
-      await instance.rename();
-
-      expect(fetchMock.called(`${connections.prod.marketplace}/resources/${Resource.id}`)).toBe(
-        true
-      );
-      expect(instance.success.emit).toHaveBeenCalledWith({
-        message: `${Resource.body.label} successfully renamed`,
-        resourceLabel: Resource.body.label,
-        newLabel: 'test2',
-        resourceId: Resource.id,
-      });
-    });
-
-    it('will trigger a dom event on failed rename', async () => {
-      fetchMock.mock(`${connections.prod.marketplace}/resources/${Resource.id}`, {
-        status: 500,
-        body: {
-          message: 'ohnoes',
-        },
-      });
-
-      const page = await newSpecPage({
-        components: [ManifoldDataRenameButton],
-        html: `
-          <manifold-data-rename-button
-            resource-label="${Resource.body.label}"
-            new-label="test2"
-          >Provision</manifold-data-rename-button>
-        `,
-      });
-
-      const instance = page.rootInstance as ManifoldDataRenameButton;
-      instance.error.emit = jest.fn();
-
-      try {
-        await instance.rename();
-      } catch {
-        expect(fetchMock.called(`${connections.prod.marketplace}/resources/${Resource.id}`)).toBe(
-          true
-        );
-        expect(instance.error.emit).toHaveBeenCalledWith({
-          message: 'ohnoes',
-          resourceLabel: Resource.body.label,
-          newLabel: 'test2',
-          resourceId: Resource.id,
-        });
-      }
-    });
-
     it('will do nothing if still loading', async () => {
-      fetchMock
-        .mock(`${connections.prod.gateway}/id/resource/${Resource.id}`, 200)
-        .mock(`${connections.prod.marketplace}/resources/?me&label=test`, []);
-
       const page = await newSpecPage({
         components: [ManifoldDataRenameButton],
         html: `
           <manifold-data-rename-button
             loading=""
-            resource-label="test"
+            resource-label="test-label"
           >Provision</manifold-data-rename-button>
         `,
       });
@@ -229,15 +139,11 @@ describe('<manifold-data-rename-button>', () => {
     });
 
     it('will do nothing if no resourceId is provided', async () => {
-      fetchMock
-        .mock(`${connections.prod.gateway}/id/resource/${Resource.id}`, 200)
-        .mock(`${connections.prod.marketplace}/resources/?me&label=test`, []);
-
       const page = await newSpecPage({
         components: [ManifoldDataRenameButton],
         html: `
           <manifold-data-rename-button
-            resource-label="test"
+            resource-label="test-label"
           >Provision</manifold-data-rename-button>
         `,
       });
@@ -249,6 +155,171 @@ describe('<manifold-data-rename-button>', () => {
 
       expect(fetchMock.called(`${connections.prod.gateway}/id/resource/${Resource.id}`)).toBe(
         false
+      );
+    });
+  });
+
+  describe('events', () => {
+    it('click', async () => {
+      const newLabel = 'success-next';
+      const resourceId = 'success-id';
+      const resourceLabel = 'success-label';
+
+      const mockClick = jest.fn();
+      const page = await newSpecPage({
+        components: [ManifoldDataRenameButton],
+        html: `
+            <manifold-data-rename-button
+              new-label="${newLabel}"
+              resource-id="${resourceId}"
+              resource-label="${resourceLabel}"
+            ></manifold-service-card-view>`,
+      });
+
+      // listen for event and fire
+      page.doc.addEventListener('manifold-renameButton-click', mockClick);
+      page.root.querySelector('button').click();
+
+      expect(mockClick).toBeCalledWith(
+        expect.objectContaining({ detail: { newLabel, resourceLabel, resourceId } })
+      );
+    });
+
+    it('invalid: too short', async () => {
+      const newLabel = 'x';
+      const resourceId = 'invalid-id';
+      const resourceLabel = 'invalid-label';
+
+      const page = await newSpecPage({
+        components: [ManifoldDataRenameButton],
+        html: `
+            <manifold-data-rename-button
+              new-label="${newLabel}"
+              resource-id="${resourceId}"
+              resource-label="${resourceLabel}"
+            ></manifold-service-card-view>`,
+      });
+
+      // listen for event and fire
+      const mockClick = jest.fn();
+      page.doc.addEventListener('manifold-renameButton-invalid', mockClick);
+      page.root.querySelector('button').click();
+
+      expect(mockClick).toBeCalledWith(
+        expect.objectContaining({
+          detail: {
+            message: 'Must be at least 3 characters',
+            newLabel,
+            resourceLabel,
+            resourceId,
+          },
+        })
+      );
+    });
+
+    it('invalid: invalid chars', async () => {
+      const newLabel = '🦞🦞🦞';
+      const resourceId = 'invalid-id';
+      const resourceLabel = 'invalid-label';
+
+      const page = await newSpecPage({
+        components: [ManifoldDataRenameButton],
+        html: `
+            <manifold-data-rename-button
+              new-label="${newLabel}"
+              resource-id="${resourceId}"
+              resource-label="${resourceLabel}"
+            ></manifold-service-card-view>`,
+      });
+
+      // listen for event and fire
+      const mockClick = jest.fn();
+      page.doc.addEventListener('manifold-renameButton-invalid', mockClick);
+      page.root.querySelector('button').click();
+
+      expect(mockClick).toBeCalledWith(
+        expect.objectContaining({
+          detail: {
+            message:
+              'Must start with a lowercase letter, and use only lowercase, numbers, and hyphens',
+            newLabel,
+            resourceLabel,
+            resourceId,
+          },
+        })
+      );
+    });
+
+    it('error', async () => {
+      const newLabel = 'error-next';
+      const resourceId = 'error-id';
+      const resourceLabel = 'error-label';
+
+      const page = await newSpecPage({
+        components: [ManifoldDataRenameButton],
+        html: `
+          <manifold-data-rename-button
+            new-label="${newLabel}"
+            resource-id="${resourceId}"
+            resource-label="${resourceLabel}"
+          >Provision</manifold-data-rename-button>
+        `,
+      });
+
+      const mockClick = jest.fn();
+      await new Promise(resolve => {
+        // listen for event and fire
+        mockClick.mockImplementation(() => resolve());
+        page.doc.addEventListener('manifold-renameButton-error', mockClick);
+        page.root.querySelector('button').click();
+      });
+
+      expect(fetchMock.called(`${connections.prod.marketplace}/resources/${resourceId}`)).toBe(
+        true
+      );
+      expect(mockClick).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: { message: 'resource not found', newLabel, resourceLabel, resourceId },
+        })
+      );
+    });
+
+    it('success', async () => {
+      const newLabel = 'success-next';
+      const resourceId = 'success-id';
+      const resourceLabel = 'success-label';
+
+      const page = await newSpecPage({
+        components: [ManifoldDataRenameButton],
+        html: `
+          <manifold-data-rename-button
+            new-label="${newLabel}"
+            resource-id="${resourceId}"
+            resource-label="${resourceLabel}"
+          >Provision</manifold-data-rename-button>
+        `,
+      });
+
+      const mockClick = jest.fn();
+      await new Promise(resolve => {
+        // listen for event and fire
+        mockClick.mockImplementation(() => resolve());
+        page.doc.addEventListener('manifold-renameButton-success', mockClick);
+        page.root.querySelector('button').click();
+      });
+
+      expect(fetchMock.called(`${connections.prod.marketplace}/resources/${resourceId}`)).toBe(
+        true
+      );
+      expect(mockClick).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: {
+            message: `${resourceLabel} renamed to ${newLabel}`,
+            newLabel,
+            resourceLabel,
+            resourceId,
+          },
+        })
       );
     });
   });

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
@@ -124,7 +124,7 @@ describe('<manifold-data-rename-button>', () => {
           <manifold-data-rename-button
             loading=""
             resource-label="test-label"
-          >Provision</manifold-data-rename-button>
+          >Rename</manifold-data-rename-button>
         `,
       });
 
@@ -144,7 +144,7 @@ describe('<manifold-data-rename-button>', () => {
         html: `
           <manifold-data-rename-button
             resource-label="test-label"
-          >Provision</manifold-data-rename-button>
+          >Rename</manifold-data-rename-button>
         `,
       });
 
@@ -271,7 +271,7 @@ describe('<manifold-data-rename-button>', () => {
             new-label="${newLabel}"
             resource-id="${resourceId}"
             resource-label="${resourceLabel}"
-          >Provision</manifold-data-rename-button>
+          >Rename</manifold-data-rename-button>
         `,
       });
 
@@ -308,7 +308,7 @@ describe('<manifold-data-rename-button>', () => {
             new-label="${newLabel}"
             resource-id="${resourceId}"
             resource-label="${resourceLabel}"
-          >Provision</manifold-data-rename-button>
+          >Rename</manifold-data-rename-button>
         `,
       });
 

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
@@ -176,9 +176,12 @@ describe('<manifold-data-rename-button>', () => {
             ></manifold-service-card-view>`,
       });
 
+      const button = page.root && page.root.querySelector('button');
+      if (!button) throw new Error('button not found in document');
+
       // listen for event and fire
       page.doc.addEventListener('manifold-renameButton-click', mockClick);
-      page.root.querySelector('button').click();
+      button.click();
 
       expect(mockClick).toBeCalledWith(
         expect.objectContaining({ detail: { newLabel, resourceLabel, resourceId } })
@@ -200,10 +203,13 @@ describe('<manifold-data-rename-button>', () => {
             ></manifold-service-card-view>`,
       });
 
+      const button = page.root && page.root.querySelector('button');
+      if (!button) throw new Error('button not found in document');
+
       // listen for event and fire
       const mockClick = jest.fn();
       page.doc.addEventListener('manifold-renameButton-invalid', mockClick);
-      page.root.querySelector('button').click();
+      button.click();
 
       expect(mockClick).toBeCalledWith(
         expect.objectContaining({
@@ -232,10 +238,13 @@ describe('<manifold-data-rename-button>', () => {
             ></manifold-service-card-view>`,
       });
 
+      const button = page.root && page.root.querySelector('button');
+      if (!button) throw new Error('button not found in document');
+
       // listen for event and fire
       const mockClick = jest.fn();
       page.doc.addEventListener('manifold-renameButton-invalid', mockClick);
-      page.root.querySelector('button').click();
+      button.click();
 
       expect(mockClick).toBeCalledWith(
         expect.objectContaining({
@@ -266,12 +275,15 @@ describe('<manifold-data-rename-button>', () => {
         `,
       });
 
+      const button = page.root && page.root.querySelector('button');
+      if (!button) throw new Error('button not found in document');
+
       const mockClick = jest.fn();
       await new Promise(resolve => {
         // listen for event and fire
         mockClick.mockImplementation(() => resolve());
         page.doc.addEventListener('manifold-renameButton-error', mockClick);
-        page.root.querySelector('button').click();
+        button.click();
       });
 
       expect(fetchMock.called(`${connections.prod.marketplace}/resources/${resourceId}`)).toBe(
@@ -300,12 +312,15 @@ describe('<manifold-data-rename-button>', () => {
         `,
       });
 
+      const button = page.root && page.root.querySelector('button');
+      if (!button) throw new Error('button not found in document');
+
       const mockClick = jest.fn();
       await new Promise(resolve => {
         // listen for event and fire
         mockClick.mockImplementation(() => resolve());
         page.doc.addEventListener('manifold-renameButton-success', mockClick);
-        page.root.querySelector('button').click();
+        button.click();
       });
 
       expect(fetchMock.called(`${connections.prod.marketplace}/resources/${resourceId}`)).toBe(

--- a/src/components/manifold-data-sso-button/manifold-data-sso-button.spec.ts
+++ b/src/components/manifold-data-sso-button/manifold-data-sso-button.spec.ts
@@ -152,17 +152,22 @@ describe('<manifold-data-sso-button>', () => {
     it('click', async () => {
       fetchMock.mock(`${connections.prod.connector}/sso`, authCode);
 
+      if (!page.root) throw new Error('<manifold-sso-button> not found in document');
+
       const resourceLabel = 'click-label';
       element.resourceLabel = resourceLabel;
       page.root.appendChild(element);
       await page.waitForChanges();
+
+      const button = element.querySelector('button');
+      if (!button) throw new Error('button not found in document');
 
       const onClick = jest.fn();
       await new Promise(resolve => {
         // listen for event and fire
         onClick.mockImplementation(() => resolve());
         element.addEventListener('manifold-ssoButton-click', onClick);
-        element.querySelector('button').click();
+        button.click();
       });
 
       expect(fetchMock.called(`${connections.prod.connector}/sso`)).toBe(true);
@@ -183,17 +188,22 @@ describe('<manifold-data-sso-button>', () => {
         body: { message },
       });
 
+      if (!page.root) throw new Error('<manifold-sso-button> not found in document');
+
       const resourceLabel = 'error-label';
       element.resourceLabel = resourceLabel;
       page.root.appendChild(element);
       await page.waitForChanges();
+
+      const button = element.querySelector('button');
+      if (!button) throw new Error('button not found in document');
 
       const onError = jest.fn();
       await new Promise(resolve => {
         // listen for event and fire
         onError.mockImplementation(() => resolve());
         element.addEventListener('manifold-ssoButton-error', onError);
-        element.querySelector('button').click();
+        button.click();
       });
 
       expect(fetchMock.called(`${connections.prod.connector}/sso`)).toBe(true);
@@ -211,17 +221,22 @@ describe('<manifold-data-sso-button>', () => {
     it('success', async () => {
       fetchMock.mock(`${connections.prod.connector}/sso`, authCode);
 
+      if (!page.root) throw new Error('<manifold-sso-button> not found in document');
+
       const resourceLabel = 'success-label';
       element.resourceLabel = resourceLabel;
       page.root.appendChild(element);
       await page.waitForChanges();
+
+      const button = element.querySelector('button');
+      if (!button) throw new Error('button not found in document');
 
       const onSuccess = jest.fn();
       await new Promise(resolve => {
         // listen for event and fire
         onSuccess.mockImplementation(() => resolve());
         element.addEventListener('manifold-ssoButton-success', onSuccess);
-        element.querySelector('button').click();
+        button.click();
       });
 
       expect(fetchMock.called(`${connections.prod.connector}/sso`)).toBe(true);

--- a/src/components/manifold-resource-deprovision/manifold-resource-deprovision.tsx
+++ b/src/components/manifold-resource-deprovision/manifold-resource-deprovision.tsx
@@ -1,4 +1,4 @@
-import { h, Component, Prop, Event, EventEmitter } from '@stencil/core';
+import { h, Component, Prop } from '@stencil/core';
 
 import ResourceTunnel from '../../data/resource';
 import { Gateway } from '../../types/gateway';
@@ -8,9 +8,6 @@ import logger from '../../utils/logger';
 export class ManifoldResourceDeprovision {
   @Prop() data?: Gateway.Resource;
   @Prop() loading: boolean = true;
-  @Event({ eventName: 'manifold-deprovisionButton-click', bubbles: true }) click: EventEmitter;
-  @Event({ eventName: 'manifold-deprovisionButton-error', bubbles: true }) error: EventEmitter;
-  @Event({ eventName: 'manifold-deprovisionButton-success', bubbles: true }) success: EventEmitter;
 
   @logger()
   render() {
@@ -19,9 +16,6 @@ export class ManifoldResourceDeprovision {
         resourceId={this.data && this.data.id}
         resourceLabel={this.data && this.data.label}
         loading={this.loading}
-        onManifold-deprovisionButton-click={this.click.emit}
-        onManifold-deprovisionButton-error={this.error.emit}
-        onManifold-deprovisionButton-success={this.success.emit}
       >
         <manifold-forward-slot>
           <slot />

--- a/src/components/manifold-resource-deprovision/manifold-resource-deprovision.tsx
+++ b/src/components/manifold-resource-deprovision/manifold-resource-deprovision.tsx
@@ -17,9 +17,7 @@ export class ManifoldResourceDeprovision {
         resourceLabel={this.data && this.data.label}
         loading={this.loading}
       >
-        <manifold-forward-slot>
-          <slot />
-        </manifold-forward-slot>
+        <slot />
       </manifold-data-deprovision-button>
     );
   }

--- a/src/components/manifold-resource-rename/manifold-resource-rename.tsx
+++ b/src/components/manifold-resource-rename/manifold-resource-rename.tsx
@@ -1,4 +1,4 @@
-import { h, Component, Prop, Event, EventEmitter } from '@stencil/core';
+import { h, Component, Prop } from '@stencil/core';
 
 import ResourceTunnel from '../../data/resource';
 import { Gateway } from '../../types/gateway';
@@ -10,10 +10,6 @@ export class ManifoldResourceRename {
   @Prop() loading: boolean = true;
   /** The new label to give to the resource */
   @Prop() newLabel: string = '';
-  @Event({ eventName: 'manifold-renameButton-click', bubbles: true }) click: EventEmitter;
-  @Event({ eventName: 'manifold-renameButton-invalid', bubbles: true }) invalid: EventEmitter;
-  @Event({ eventName: 'manifold-renameButton-error', bubbles: true }) error: EventEmitter;
-  @Event({ eventName: 'manifold-renameButton-success', bubbles: true }) success: EventEmitter;
 
   @logger()
   render() {
@@ -23,14 +19,8 @@ export class ManifoldResourceRename {
         resourceLabel={this.data && this.data.label}
         loading={this.loading}
         newLabel={this.newLabel}
-        onManifold-renameButton-click={this.click.emit}
-        onManifold-renameButton-invalid={this.invalid.emit}
-        onManifold-renameButton-error={this.error.emit}
-        onManifold-renameButton-success={this.success.emit}
       >
-        <manifold-forward-slot>
-          <slot />
-        </manifold-forward-slot>
+        <slot />
       </manifold-data-rename-button>
     );
   }

--- a/src/components/manifold-resource-sso/manifold-resource-sso.tsx
+++ b/src/components/manifold-resource-sso/manifold-resource-sso.tsx
@@ -1,4 +1,4 @@
-import { h, Component, Prop, Event, EventEmitter } from '@stencil/core';
+import { h, Component, Prop } from '@stencil/core';
 
 import ResourceTunnel from '../../data/resource';
 import { Gateway } from '../../types/gateway';
@@ -8,9 +8,6 @@ import logger from '../../utils/logger';
 export class ManifoldResourceSso {
   @Prop() data?: Gateway.Resource;
   @Prop() loading: boolean = true;
-  @Event({ eventName: 'manifold-ssoButton-click', bubbles: true }) click: EventEmitter;
-  @Event({ eventName: 'manifold-ssoButton-error', bubbles: true }) error: EventEmitter;
-  @Event({ eventName: 'manifold-ssoButton-success', bubbles: true }) success: EventEmitter;
 
   @logger()
   render() {
@@ -19,13 +16,8 @@ export class ManifoldResourceSso {
         resourceId={this.data && this.data.id}
         resourceLabel={this.data && this.data.label}
         loading={this.loading}
-        onManifold-ssoButton-click={this.click.emit}
-        onManifold-ssoButton-error={this.error.emit}
-        onManifold-ssoButton-success={this.success.emit}
       >
-        <manifold-forward-slot>
-          <slot />
-        </manifold-forward-slot>
+        <slot />
       </manifold-data-sso-button>
     );
   }


### PR DESCRIPTION
## Reason for change

We were firing the same events in certain instances from both parent and child, which was resulting in multiple components firing, say, a `success` event twice. Normally that wouldn’t be a huge problem, but when the parent fires it doesn’t have any of the data it needs.

That’s actually a huge problem, because if you have a `success` event, and you tell your application to redirect to `/addon/[resourceName]`, it’s going to redirect to `/addon/undefined` and other fun things like that.

Also, tests were rewritten to test the DOM + event name, rather than testing implementation details on the class. New tests were added when events weren’t being tested.

## Testing

Overall this is a fairly safe PR to merge as it only removes event emitting in 3 spots. It’s hard to test, but tests should pass. 90% of the changes were making the tests stronger by testing DOM clicks on buttons & waiting for events to fire, rather than testing class methods.

I did test this PR in Render Dashboard and it solves the intended problem of events firing twice.

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [x] **Prop changes**: [docs][docs] were updated
- [x] **Prop changes**: E2E tests were updated, testing from the highest level possible

[docs]: https://ui.sandbox.manifold.co
