### PR TITLE
Add add-auth attribute for manifold-marketplace

### DIFF
--- a/docs/docs/components/manifold-marketplace.md
+++ b/docs/docs/components/manifold-marketplace.md
@@ -63,10 +63,8 @@ You can add a “Featured” tag to select products by specifing a comma-separat
 
 ## Events
 
-This component emits
-[custom events](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent) when it
-updates. To listen to those events, add an event listener either on the component itself, or
-`document`:
+This component emits [custom events][custom-events] when it updates. To listen to those events, add
+an event listener either on the component itself, or `document`:
 
 ```js
 document.addEventListener('manifold-marketplace-click', { detail } => {
@@ -98,3 +96,15 @@ also be turned into an `<a>` tag by specifying `product-link-format` and `templa
 custom resource templates.
 
 Note that this will disable the custom events unless `preserve-event` is passed as well.
+
+## Authentication
+
+By default, `<manifold-marketplace>` is a public component. However, when used in conjunction with
+[Authentication][auth], you can request to authenticate with `with-auth`:
+
+```html
+<manifold-marketplace with-auth></manifold-marketplace>
+```
+
+[auth]: /advanced/authentication
+[custom-events]: (https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -325,6 +325,10 @@ export namespace Components {
     * Template format structure, with `:product` placeholder
     */
     'templateLinkFormat'?: string;
+    /**
+    * Use auth?
+    */
+    'useAuth'?: boolean;
   }
   interface ManifoldMarketplaceGrid {
     'featured'?: string[];
@@ -1365,6 +1369,10 @@ declare namespace LocalJSX {
     * Template format structure, with `:product` placeholder
     */
     'templateLinkFormat'?: string;
+    /**
+    * Use auth?
+    */
+    'useAuth'?: boolean;
   }
   interface ManifoldMarketplaceGrid extends JSXBase.HTMLAttributes<HTMLManifoldMarketplaceGridElement> {
     'featured'?: string[];

--- a/src/components/manifold-marketplace/manifold-marketplace.spec.ts
+++ b/src/components/manifold-marketplace/manifold-marketplace.spec.ts
@@ -1,0 +1,26 @@
+import { ManifoldMarketplace } from './manifold-marketplace';
+
+const restFetch = jest.fn();
+restFetch.mockImplementation(() => Promise.resolve([]));
+const marketplace = new ManifoldMarketplace();
+marketplace.restFetch = restFetch;
+
+describe('<manifold-marketplace>', () => {
+  describe('v0 API', () => {
+    beforeEach(() => restFetch.mockClear());
+
+    it('[use-auth]: uses auth if specified', async () => {
+      // TODO: do this with newSpecPage
+      marketplace.useAuth = true;
+      await marketplace.fetchProducts();
+      expect(restFetch).toHaveBeenCalledWith(expect.objectContaining({ isPublic: false }));
+    });
+
+    it('[use-auth]: skips auth by default', async () => {
+      // TODO: do this with newSpecPage
+      marketplace.useAuth = undefined;
+      await marketplace.fetchProducts();
+      expect(restFetch).toHaveBeenCalledWith(expect.objectContaining({ isPublic: true }));
+    });
+  });
+});

--- a/src/components/manifold-marketplace/manifold-marketplace.tsx
+++ b/src/components/manifold-marketplace/manifold-marketplace.tsx
@@ -25,6 +25,8 @@ export class ManifoldMarketplace {
   @Prop() productLinkFormat?: string;
   /** Comma-separated list of shown products (labels) */
   @Prop() products?: string;
+  /** Use auth? */
+  @Prop() useAuth?: boolean = false;
   /** Template format structure, with `:product` placeholder */
   @Prop() templateLinkFormat?: string;
   @State() freeProducts?: string[];
@@ -49,6 +51,7 @@ export class ManifoldMarketplace {
     const response = await this.restFetch<Catalog.ExpandedProduct[]>({
       service: 'catalog',
       endpoint: `/products`,
+      isPublic: !this.useAuth,
     });
 
     if (response) {
@@ -75,6 +78,7 @@ export class ManifoldMarketplace {
             const plansResp = await this.restFetch<Catalog.ExpandedPlan[]>({
               service: 'catalog',
               endpoint: `/plans/?product_id=${id}`,
+              isPublic: !this.useAuth,
             });
 
             if (plansResp instanceof Error) {

--- a/stories/manifold-marketplace.stories.js
+++ b/stories/manifold-marketplace.stories.js
@@ -1,9 +1,11 @@
 import { storiesOf } from '@storybook/html';
 
 import markdown from '../docs/docs/components/manifold-marketplace.md';
+import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Marketplace', module)
   .addParameters({ readme: { sidebar: markdown } })
+  .addDecorator(manifoldConnectionDecorator)
   .add(
     'default',
     () =>
@@ -39,10 +41,12 @@ storiesOf('Marketplace', module)
   .add(
     'curated',
     () => `
-      <manifold-marketplace
-        hide-templates
-        hide-search
-        hide-categories
-        products="logdna,scoutapp,timber-logging,cloudcube"
-      ></manifold-marketplace>`
-  );
+        <manifold-marketplace
+          hide-templates
+          hide-search
+          hide-categories
+          products="logdna,scoutapp,timber-logging,cloudcube"
+        ></manifold-marketplace>
+      `
+  )
+  .add('with auth', () => `<manifold-marketplace with-auth></manifold-marketplace>`);


### PR DESCRIPTION
## Reason for change

For components that use catalog, it’s difficult to determine whether or not they need to wait for auth. Since most consumers **aren’t** using it, let’s do that by default, but allow a `use-auth` prop that gets passed in for cases they need it. 

This was based on some discussions we had, and the logic around when to wait (or not) was overly complex. But by passing the responsibility to the consumer on what to use, we can be more certain we’re handling that usecase. As a result we can simplify the auth code in UI.

## Testing

- [ ] In Storybook, `manifold-marketplace` doesn’t use auth by default
- [ ] (eventually, we’ll remove the `catalog` check in restFetch so for now the “with auth“ story doesn’t authenticate, but the plan is once all these components use this, remove the catalog-specific check)

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [x] **Prop changes**: [docs][docs] were updated
- [x] **Prop changes**: E2E tests were updated, testing from the highest level possible

[docs]: https://ui.sandbox.manifold.co
