### PR TITLE
Fixed: Disable provision button while provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed events firing twice for `<manifold-resource-rename>`, `<manifold-resource-sso>`, and `<manifold-resource-deprovision>` (#401)
+- Prevent provision button from being clicked multiple times.
 
 ### Changed
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1030,20 +1030,6 @@
         "@manifoldco/gql-zero": "^0.2.0",
         "@manifoldco/shadowcat": "^0.1.5",
         "@stencil/state-tunnel": "^1.0.1"
-      },
-      "dependencies": {
-        "@manifoldco/gql-zero": {
-          "version": "0.2.0",
-          "bundled": true
-        },
-        "@manifoldco/shadowcat": {
-          "version": "0.1.5",
-          "bundled": true
-        },
-        "@stencil/state-tunnel": {
-          "version": "1.0.1",
-          "bundled": true
-        }
       }
     },
     "@mikaelkristiansson/domready": {
@@ -5510,7 +5496,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5528,11 +5515,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5545,15 +5534,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5656,7 +5648,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5666,6 +5659,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5678,17 +5672,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5705,6 +5702,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5777,7 +5775,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5787,6 +5786,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5862,7 +5862,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5892,6 +5893,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5909,6 +5911,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5947,11 +5950,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -8547,7 +8552,8 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -8570,6 +8576,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "optional": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.spec.ts
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.spec.ts
@@ -290,18 +290,24 @@ describe('<manifold-data-provision-button>', () => {
         `,
       });
 
-      const instance = page.rootInstance as ManifoldDataProvisionButton;
-      instance.success.emit = jest.fn();
+      const success = jest.fn();
+      page.doc.addEventListener('manifold-provisionButton-success', success);
 
-      await instance.provision();
+      const button = page.doc.querySelector('button[type=submit]') as HTMLButtonElement;
+      button.click();
+      await page.waitForChanges();
 
       expect(fetchMock.called(`${connections.prod.gateway}/resource/`)).toBe(true);
-      expect(instance.success.emit).toHaveBeenCalledWith({
-        createdAt: GatewayResource.created_at,
-        message: 'test successfully provisioned',
-        resourceId: GatewayResource.id,
-        resourceLabel: GatewayResource.label,
-      });
+      expect(success).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: {
+            createdAt: GatewayResource.created_at,
+            message: 'test successfully provisioned',
+            resourceId: GatewayResource.id,
+            resourceLabel: GatewayResource.label,
+          },
+        })
+      );
     });
 
     it('will trigger a dom event on failed provision', async () => {

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
@@ -55,6 +55,7 @@ export class ManifoldDataProvisionButton {
   @Prop() regionId?: string = globalRegion.id;
   @State() planId?: string = '';
   @State() productId?: string = '';
+  @State() provisioning: boolean = false;
   @Event({ eventName: 'manifold-provisionButton-click', bubbles: true }) click: EventEmitter;
   @Event({ eventName: 'manifold-provisionButton-invalid', bubbles: true }) invalid: EventEmitter;
   @Event({ eventName: 'manifold-provisionButton-error', bubbles: true }) error: EventEmitter;
@@ -123,6 +124,7 @@ export class ManifoldDataProvisionButton {
     };
 
     try {
+      this.provisioning = true;
       const response = await this.restFetch<Gateway.Resource>({
         service: 'gateway',
         endpoint: `/resource/`,
@@ -141,8 +143,10 @@ export class ManifoldDataProvisionButton {
           resourceLabel: response.label,
         };
         this.success.emit(success);
+        this.provisioning = false;
       }
     } catch (error) {
+      this.provisioning = false;
       const e: ErrorMessage = {
         message: error.message,
         resourceLabel: this.resourceLabel,
@@ -204,7 +208,7 @@ export class ManifoldDataProvisionButton {
       <button
         type="submit"
         onClick={() => this.provision()}
-        disabled={!this.planId || !this.productId}
+        disabled={!this.planId || !this.productId || this.provisioning}
       >
         <slot />
       </button>


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->
## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
The provision button currently remains enabled while a provision is in progress, which allows the user to request a provision multiple times. This change disabled the button during provisioning so that only one provision can occur.

This was solved in the simplest manner possible: adding a `provisioning` state variable to the component and setting it at the appropriate times. It would sure be nice to have query/mutation components that would allow us to avoid cluttering up all of our data components with things like loading state.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

Pull down the branch and try it in the Render dashboard. When a provision is in progress, the provision button should be disabled.

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible

[docs]: https://ui.sandbox.manifold.co
