### PR TITLE
use our cdn for documentation

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -26,13 +26,13 @@ modern framework like React, Vue, or Angular.
   <link
     rel="stylesheet"
     type="text/css"
-    href="https://unpkg.com/@manifoldco/ui/dist/manifold/manifold.css"
+    href="https://js.cdn.manifold.co/@manifoldco/ui/dist/manifold/manifold.css"
   />
 </head>
 <body>
   <manifold-marketplace></manifold-marketplace>
   <script type="module">
-    import { defineCustomElements } from 'https://unpkg.com/@manifoldco/ui/dist/esm/es2017/manifold.define.js';
+    import { defineCustomElements } from 'https://js.cdn.manifold.co/@manifoldco/ui/dist/esm/es2017/manifold.define.js';
     defineCustomElements(window);
   </script>
 </body>
@@ -45,12 +45,12 @@ modern framework like React, Vue, or Angular.
   <link
     rel="stylesheet"
     type="text/css"
-    href="https://unpkg.com/@manifoldco/ui/dist/manifold/manifold.css"
+    href="https://js.cdn.manifold.co/@manifoldco/ui/dist/manifold/manifold.css"
   />
 </head>
 <body>
   <manifold-marketplace></manifold-marketplace>
-  <script src="https://unpkg.com/@manifoldco/ui/dist/manifold.js"></script>
+  <script src="https://js.cdn.manifold.co/@manifoldco/ui/dist/manifold.js"></script>
 </body>
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -30,13 +30,13 @@ npm i @manifoldco/ui
   <link
     rel="stylesheet"
     type="text/css"
-    href="https://unpkg.com/@manifoldco/ui/dist/manifold/manifold.css"
+    href="https://js.cdn.manifold.co/@manifoldco/ui/dist/manifold/manifold.css"
   />
 </head>
 <body>
   <manifold-marketplace></manifold-marketplace>
   <script type="module">
-    import { defineCustomElements } from 'https://unpkg.com/@manifoldco/ui/dist/esm/es2017/manifold.define.js';
+    import { defineCustomElements } from 'https://js.cdn.manifold.co/@manifoldco/ui/dist/esm/es2017/manifold.define.js';
     defineCustomElements(window);
   </script>
 </body>
@@ -49,12 +49,12 @@ npm i @manifoldco/ui
   <link
     rel="stylesheet"
     type="text/css"
-    href="https://unpkg.com/@manifoldco/ui/dist/manifold/manifold.css"
+    href="https://js.cdn.manifold.co/@manifoldco/ui/dist/manifold/manifold.css"
   />
 </head>
 <body>
   <manifold-marketplace></manifold-marketplace>
-  <script src="https://unpkg.com/@manifoldco/ui/dist/manifold.js"></script>
+  <script src="https://js.cdn.manifold.co/@manifoldco/ui/dist/manifold.js"></script>
 </body>
 ```
 


### PR DESCRIPTION
we us js.cdn.manifold.co for our cdn now.
so lets replace the documentation with it!