### PR TITLE
npm run prepare:package

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint:js": "eslint --ext .js,.ts,.tsx src",
     "now-build": "npm run build:storybook",
     "prepare:docs": "npm run prepare:package && npm run copy-changelog",
-    "prepare:package": "npm run build && rm -rf pkg && mkdir pkg && cp -r dist pkg && cp package.json pkg/package.json",
+    "prepare:package": "npm run build && node scripts/prepublish",
     "publish": "npm run prepare:package && node scripts/publish",
     "storybook": "start-storybook -p 6006",
     "test": "stencil test --spec --e2e --maxWorkers=2",

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -1,0 +1,42 @@
+/**
+ * This prepares the pkg directory for npm
+ */
+const { mkdirSync, readFileSync, writeFileSync } = require('fs');
+const { resolve } = require('path');
+const { execSync } = require('child_process');
+const { copySync, removeSync } = require('fs-extra');
+const prettier = require('prettier');
+
+// Settings
+const WD = resolve(__dirname, '..', 'pkg'); // Working directory: pkg/
+const FILES_TO_COPY = ['readme.md', 'CHANGELOG.md', 'LICENSE.md']; // other files to copy to WD
+
+const oldDistDir = resolve(__dirname, '..', 'dist');
+const newDistDir = resolve(WD, 'dist');
+
+// 1. Use pkg/ for publishing because it’s a clean working directory (don’t have to manage .npmignore)
+removeSync(WD);
+mkdirSync(WD);
+copySync(oldDistDir, newDistDir);
+FILES_TO_COPY.forEach(file => copySync(resolve(__dirname, '..', file), resolve(WD, file)));
+
+// 2. Read Git tag
+let version;
+try {
+  version = execSync('git describe --abbrev=0 --tags --exact-match')
+    .toString()
+    .replace('v', '')
+    .replace('\n', '');
+} catch (e) {
+  console.error(`❌ Build failed: ${e.message}`);
+}
+
+// 3. Copy package.json, and add version
+const packageJSON = JSON.parse(readFileSync(resolve(__dirname, '..', 'package.json'), 'utf8'));
+const newPackageJSON = { ...packageJSON, version };
+delete newPackageJSON.scripts; // Don’t need this on npm
+delete newPackageJSON.files; // Ship all files in pkg/
+writeFileSync(
+  resolve(WD, 'package.json'),
+  prettier.format(JSON.stringify(newPackageJSON), { parser: 'json' })
+);

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -4,47 +4,25 @@
  * v1.2.3-alpha.0 -> tag “alpha”
  * v1.2.3-rc.0    -> tag “rc”
  */
-const { existsSync, mkdirSync, readFileSync, writeFileSync } = require('fs');
-const { resolve } = require('path');
 const { execSync } = require('child_process');
-const { copySync, emptyDirSync } = require('fs-extra');
-const prettier = require('prettier');
-
-// Settings
-const WD = resolve(__dirname, '..', 'pkg'); // Working directory: pkg/
-const FILES_TO_COPY = ['readme.md', 'CHANGELOG.md', 'LICENSE.md']; // other files to copy to WD
 
 /* eslint-disable no-console */
 
 const timeStart = process.hrtime();
-
 const SELECT_FLAG = /-.*/; // Selects anything after a hyphen, or nothing
-const oldDistDir = resolve(__dirname, '..', 'dist');
-const newDistDir = resolve(WD, 'dist');
 
-// 1. Use pkg/ for publishing because it’s a clean working directory (don’t have to manage .npmignore)
-if (existsSync(WD)) {
-  emptyDirSync(WD);
-} else {
-  mkdirSync(WD);
-}
-copySync(oldDistDir, newDistDir);
-FILES_TO_COPY.forEach(file => copySync(resolve(__dirname, '..', file), resolve(WD, file)));
-console.log(`[1/3] 🧹 Cleaning up…`);
-
-// 2. Read Git tag
+// 1. Read Git tag
 let version;
 try {
   version = execSync('git describe --abbrev=0 --tags --exact-match')
     .toString()
     .replace('v', '')
     .replace('\n', '');
-  console.log(`[2/3] 📦 Publishing ${version} to npm…`);
 } catch (e) {
   console.error(`❌ Publish failed: ${e.message}`);
 }
 
-// 3. Determine if @latest or @[other]
+// 2. Determine if @latest or @[other]
 let npmTag = 'latest'; // default (“public”)
 const flag = SELECT_FLAG.exec(version); // If no hyphen, this is a “private“ release
 if (flag && flag[0].length > 1) {
@@ -52,21 +30,13 @@ if (flag && flag[0].length > 1) {
   npmTag = flagClean.includes('.') ? flagClean.split('.')[0] : flagClean;
 }
 
-// 4. Copy package.json, and add version
-const packageJSON = JSON.parse(readFileSync(resolve(__dirname, '..', 'package.json'), 'utf8'));
-const newPackageJSON = { ...packageJSON, version };
-delete newPackageJSON.scripts; // Don’t need this on npm
-delete newPackageJSON.files; // Ship all files in pkg/
-writeFileSync(
-  resolve(WD, 'package.json'),
-  prettier.format(JSON.stringify(newPackageJSON), { parser: 'json' })
-);
+console.log(`📦 Publishing ${version} to npm…`);
 
-// 5. Publish to npm
+// 3. Publish to npm
 execSync(`npm publish ../pkg --tag ${npmTag}`, {
   cwd: __dirname, // run the command from this folder (so it can run anywhere)
 });
 
 const timeEnd = process.hrtime(timeStart);
 const time = timeEnd[0] + Math.round(timeEnd[1] / 100000000) / 10;
-console.log(`[3/3] 🚀 Deployed ${version} in ${time}s`);
+console.log(`🚀 Deployed ${version} in ${time}s`);


### PR DESCRIPTION
## Reason for change

Creates a new command for package prep: `npm run prepare:package`. This can now be run on its own to prepare a build.

⚠️ this will fail if there’s no tag to get a version from.

## Testing

Tag this PR with a prerelease version, and make sure it publishes to npm. Also Storybook & Docs should obviously deploy correctly.

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible

[docs]: https://ui.sandbox.manifold.co
