### PR TITLE
Reset auth token if failed

### DIFF
--- a/src/components/manifold-auth-token/manifold-auth-token.spec.ts
+++ b/src/components/manifold-auth-token/manifold-auth-token.spec.ts
@@ -19,36 +19,6 @@ async function setup(token?: string) {
 }
 
 describe('<manifold-auth-token>', () => {
-  describe('when the token is received', () => {
-    it('emits an event', async () => {
-      const { component, page } = await setup();
-
-      const shadowcat = component.querySelector('manifold-oauth');
-      expect(shadowcat).toBeDefined();
-      if (shadowcat) {
-        /* This is what we expect our manifold-auth-token component to emit */
-        const callback = jest.fn();
-        component.addEventListener('manifold-token-receive', callback);
-
-        /* This simulates the shadowcat event that our manifold-auth-token component
-         * is listening for
-         */
-        const event = new CustomEvent('receiveManifoldToken', {
-          detail: {
-            token: '12345',
-            expiry: new Date().getTime() / 1000,
-            error: null,
-          },
-        });
-        shadowcat.dispatchEvent(event);
-
-        await page.waitForChanges();
-
-        expect(callback).toHaveBeenCalled();
-      }
-    });
-  });
-
   describe('when the token is not expired', () => {
     const expiry = new Date();
     expiry.setDate(expiry.getDate() + 1);
@@ -96,6 +66,34 @@ describe('<manifold-auth-token>', () => {
       await page.waitForChanges();
 
       expect(component.setAuthToken).not.toHaveBeenCalledWith();
+    });
+  });
+
+  describe('events', () => {
+    it('receive', async () => {
+      const { component } = await setup();
+
+      const shadowcat = component.querySelector('manifold-oauth');
+      expect(shadowcat).toBeDefined();
+      if (shadowcat) {
+        /* This is what we expect our manifold-auth-token component to emit */
+        const callback = jest.fn();
+        component.addEventListener('manifold-token-receive', callback);
+
+        /* This simulates the shadowcat event that our manifold-auth-token component
+         * is listening for
+         */
+        const event = new CustomEvent('receiveManifoldToken', {
+          detail: {
+            token: '12345',
+            expiry: new Date().getTime() / 1000,
+            error: null,
+          },
+        });
+        shadowcat.dispatchEvent(event);
+
+        expect(callback).toHaveBeenCalled();
+      }
     });
   });
 });

--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -24,10 +24,8 @@ export class ManifoldAuthToken {
   }
 
   setExternalToken(token?: string) {
-    if (token) {
-      if (!isExpired(token)) {
-        this.setAuthToken(token);
-      }
+    if (token && !isExpired(token)) {
+      this.setAuthToken(token);
     }
   }
 

--- a/src/utils/graphqlFetch.ts
+++ b/src/utils/graphqlFetch.ts
@@ -6,7 +6,7 @@ interface CreateGraphqlFetch {
   endpoint?: string;
   wait?: number;
   getAuthToken?: () => string | undefined;
-  setAuthToken?: (token: string) => void;
+  setAuthToken?: (token: string | null) => void;
 }
 
 type graphqlArgs =
@@ -67,8 +67,7 @@ export function createGraphqlFetch({
 
     // handle unauthenticated error
     if (response.status === 401) {
-      // TODO trigger token refresh for manifold-auth-token
-      setAuthToken('');
+      setAuthToken(null); // this will re-request a new token
       report(response); // report unauthenticated
     }
 

--- a/src/utils/restFetch.ts
+++ b/src/utils/restFetch.ts
@@ -8,7 +8,7 @@ export interface CreateRestFetch {
   endpoints?: Connection;
   wait?: number;
   getAuthToken?: () => string | undefined;
-  setAuthToken?: (token: string) => void;
+  setAuthToken?: (token: string | null) => void;
 }
 
 interface RestFetchArguments {
@@ -68,9 +68,8 @@ export function createRestFetch({
 
     /* Handle expected errors */
     if (response.status === 401) {
-      setAuthToken('');
+      setAuthToken(null); // this will re-request a new token
       report(response);
-      throw new Error('Auth token expired');
     }
 
     const body = await response.json();


### PR DESCRIPTION
## Reason for change

This re-calls the function if the auth token failed

TODO:
- [ ] tests

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible

[docs]: https://ui.sandbox.manifold.co
