### PR TITLE
add conditional sync to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,10 @@ jobs:
   # Publish packages to js.cdn.manifold.co
   # this is always run after npm-publish so the ./pkg file will be available.
   cdn-publish:
+    parameters:
+      latest:
+        type: boolean
+        default: false
     docker:
       - image: google/cloud-sdk
     steps:
@@ -113,6 +117,10 @@ jobs:
       - run: echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
       - run: gsutil -m cp /home/circleci/project/pkg/* gs://manifold-js/@manifoldco/ui@${CIRCLE_TAG}
       - run: gsutil -m cp -r /home/circleci/project/pkg/dist gs://manifold-js/@manifoldco/ui@${CIRCLE_TAG}
+      - when:
+          condition: << parameters.latest >>
+          steps:
+            - run: gsutil -m rsync -r gs://manifold-js/@manifoldco/ui@${CIRCLE_TAG} gs://manifold-js/@manifoldco/ui
 
 workflows:
   version: 2
@@ -175,6 +183,7 @@ workflows:
             - test
             - vrt
       - cdn-publish:
+          latest: false
           context: gcp-cdn-auth
           filters:
             branches:
@@ -243,6 +252,7 @@ workflows:
           requires:
             - confirm
       - cdn-publish:
+          latest: true
           context: gcp-cdn-auth
           filters:
             branches:


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

enhances: manifoldco/engineering#9007

## Reason for change

we'd like @manifoldco/ui to point to our latest webcomponet build so that we can continue to use it in dev and examples.

## Testing

Yes! we can tag a prerelease and see this is not run. We will have to tag a release to see if the positive case is run but i can flip the bools for prerelease and see to it that works at least.

## Checklist

<!-- are all the steps completed? -->

n/a

