### PR TITLE
remove v from version upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,12 +115,12 @@ jobs:
           keys:
             - npmpkgcache-{{ .Revision }}
       - run: echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
-      - run: gsutil -m cp /home/circleci/project/pkg/* gs://manifold-js/@manifoldco/ui@${CIRCLE_TAG}
-      - run: gsutil -m cp -r /home/circleci/project/pkg/dist gs://manifold-js/@manifoldco/ui@${CIRCLE_TAG}
+      - run: gsutil -m cp /home/circleci/project/pkg/* gs://manifold-js/@manifoldco/ui@${CIRCLE_TAG//v}
+      - run: gsutil -m cp -r /home/circleci/project/pkg/dist gs://manifold-js/@manifoldco/ui@${CIRCLE_TAG//v}
       - when:
           condition: << parameters.latest >>
           steps:
-            - run: gsutil -m rsync -r gs://manifold-js/@manifoldco/ui@${CIRCLE_TAG} gs://manifold-js/@manifoldco/ui
+            - run: gsutil -m rsync -r gs://manifold-js/@manifoldco/ui@${CIRCLE_TAG//v} gs://manifold-js/@manifoldco/ui
 
 workflows:
   version: 2


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

In order to be consistent with NPM packages we don't want to have the letter v in our versions.
ie. we'd rather have ui@1.1.1 rather than ui@v1.1.1

## Testing

we can tag this branch and see if it publishes as we expect to our cdn