### PR TITLE
add information about our CDN in docs

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -19,6 +19,13 @@ npm i @manifoldco/ui
 Manifold UI can be used in any frameworkless project (“vanilla” JS), or any
 modern framework like React, Vue, or Angular.
 
+In any setup, you can use our CDN for UI:
+
+<!-- latest (beware of breaking changes!) -->
+<script src="https://js.cdn.manifold.co/@manifoldco/ui/dist/manifold.js"></script>
+<!-- specific version -->
+<script src="https://js.cdn.manifold.co/@manifoldco/ui@0.6.0/dist/manifold.js"></script>
+
 ### HTML (ES Modules)
 
 ```html
@@ -117,9 +124,3 @@ please refer to Stencil’s [docs on integration][stencil-framework].
 [tsconfig]: https://www.typescriptlang.org/docs/handbook/tsconfig-json.htm
 [ts-fix]: https://github.com/Microsoft/TypeScript/pull/26797
 [web-components]: https://www.webcomponents.org/introduction
-
-### Using our CDN
-
-Manifold UI is available at `https://js.cdn.manifold.co/@manifoldco/ui` on a highly available, fast CDN. We publish all our package versions there for fast and safe distribution.
-
-If you intend to use our CDN, please use a specific version such as: https://js.cdn.manifold.co/@manifoldco/ui@0.5.7

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -21,10 +21,12 @@ modern framework like React, Vue, or Angular.
 
 In any setup, you can use our CDN for UI:
 
+```html
 <!-- latest (beware of breaking changes!) -->
 <script src="https://js.cdn.manifold.co/@manifoldco/ui/dist/manifold.js"></script>
 <!-- specific version -->
 <script src="https://js.cdn.manifold.co/@manifoldco/ui@0.6.0/dist/manifold.js"></script>
+```
 
 ### HTML (ES Modules)
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -117,3 +117,9 @@ please refer to Stencil’s [docs on integration][stencil-framework].
 [tsconfig]: https://www.typescriptlang.org/docs/handbook/tsconfig-json.htm
 [ts-fix]: https://github.com/Microsoft/TypeScript/pull/26797
 [web-components]: https://www.webcomponents.org/introduction
+
+### Using our CDN
+
+Manifold UI is available at `https://js.cdn.manifold.co/@manifoldco/ui` on a highly available, fast CDN. We publish all our package versions there for fast and safe distribution.
+
+If you intend to use our CDN, please use a specific version such as: https://js.cdn.manifold.co/@manifoldco/ui@0.5.7

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,13 @@ npm i @manifoldco/ui
 | Vue                       |     ✅     |
 | Ember                     |     ✅     |
 
+In any setup, you can use our CDN for UI:
+
+<!-- latest (beware of breaking changes!) -->
+<script src="https://js.cdn.manifold.co/@manifoldco/ui/dist/manifold.js"></script>
+<!-- specific version -->
+<script src="https://js.cdn.manifold.co/@manifoldco/ui@0.6.0/dist/manifold.js"></script>
+
 ### HTML (ES Modules)
 
 ```html

--- a/readme.md
+++ b/readme.md
@@ -25,10 +25,12 @@ npm i @manifoldco/ui
 
 In any setup, you can use our CDN for UI:
 
+```html
 <!-- latest (beware of breaking changes!) -->
 <script src="https://js.cdn.manifold.co/@manifoldco/ui/dist/manifold.js"></script>
 <!-- specific version -->
 <script src="https://js.cdn.manifold.co/@manifoldco/ui@0.6.0/dist/manifold.js"></script>
+```
 
 ### HTML (ES Modules)
 

--- a/src/readme.md
+++ b/src/readme.md
@@ -280,6 +280,7 @@ and other CI tools.
 - New releases are available for download at `npm install @manifoldco/ui` (no
   tag). If the user doesn’t specify a version, they’ll download the most recent
   release.
+- New releases are also available on our cdn @ `https://js.cdn.manifold.co/@manifoldco/ui` If the user doesn’t specify a version such as `https://js.cdn.manifold.co/@manifoldco/ui@0.5.7`, they’ll download the most recent release.
 - Once published, **you can’t unpublish a version;** it’ll be available at
   that version forever. The only way to fix something is to push a new patch
   version.
@@ -299,6 +300,17 @@ and other CI tools.
 [tag-git]: https://git-scm.com/book/en/v2/Git-Basics-Tagging
 [tag-github]: https://github.com/manifoldco/ui/releases
 [swagger-to-ts]: https://www.npmjs.com/package/@manifoldco/swagger-to-ts
+
+### CDN
+
+We publish our UI package to our CDN: `https://js.cdn.manifold.co`.
+
+In any setup, you can use our CDN for UI:
+```
+https://js.cdn.manifold.co/@manifoldco/ui/       # latest (beware of breaking changes!)
+https://js.cdn.manifold.co/@manifoldco/ui@0.5.7/ # specific version
+https://js.cdn.manifold.co/@manifoldco/ui@0.5.7-alpha.0/ # specific version for alpha
+```
 
 ## 💁 Tips
 


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

We want to socialize to our developers they may use or suggest the usage of our CDN for ultra fast usage of our webcomponts.

## Testing

Someone read it and it made sense!

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible

[docs]: https://ui.sandbox.manifold.co
