### PR TITLE
Improve auth docs

### DIFF
--- a/docs/docs/advanced/authentication.md
+++ b/docs/docs/advanced/authentication.md
@@ -142,16 +142,16 @@ If the token given to the component is invalid, endpoints will return a 401 erro
 be removed from the `manifold-connection`. Use the [error handling capabilities](/advanced/errors)
 of our web components to detect and act on such errors.
 
-### Authenticated requests timeout
+### OAuth timeout
 
-Any requests requiring authentication - which are sent by components locked (🔒) behind
-authentication - will wait on a valid token for up to 15 seconds. If this component does not inject
-a token into the connection after that time, an authentication error will be thrown.
+Any requests requiring authentication will wait on a valid token for up to 15 seconds. If this
+component does not inject a token into the connection after that time, an authentication error will
+be thrown.
 
-This timeout duration can be customized on the `manifold-connection` component.
+This timeout duration can be changed on the `manifold-connection` component:
 
 ```html
-<manifold-connection wait-time="time-in-ms">
+<manifold-connection wait-time="10000">
   <!-- Application -->
 </manifold-connection>
 ```

--- a/docs/docs/advanced/authentication.md
+++ b/docs/docs/advanced/authentication.md
@@ -37,10 +37,9 @@ here’s a general summary of how it works with UI, and what to expect:
 
 ### Step 1: `<manifold-auth-token>`
 
-To make our side of it easy, we provide a special token—`<manifold-auth-token>`—that handles the
-first part of the OAuth dance. It should be placed inside the [Connection][connection] component. It
-may appear anywhere in your app (but the higher it the DOM tree it appears, the better, so it can
-load sooner):
+To make it easy, we provide a special component—`<manifold-auth-token>`—that handles the first part
+of the OAuth dance. It should be placed inside the [Connection][connection] component. It may appear
+anywhere in your app (but the higher it the DOM tree it appears, the better, so it can load sooner):
 
 ```html
 <manifold-connection>
@@ -92,10 +91,13 @@ the token anywhere (covered under **Events**).
 
 To see our complete guide on authenticating with Manifold, see [docs.manifold.co][authentication].
 
-## Caching
+## Caching for performance
 
-Beyond the basic flow, you can speed up requests by caching tokens. Whenever a token is received,
-you can store it anywhere (doesn’t have to be `localStorage`; this is just an example):
+Sometimes the OAuth dance can take a couple seconds to complete. In that light, we strongly
+recommend caching the token somewhere so that new tokens are only requested when necessary.
+
+Tokens are set using the `manifold-token-receive` event (in this example we’re using `localStorage`,
+but you may place this anywhere that persists)
 
 ```js
 document.addEventListener('manifold-token-receive', ({ detail }) => {
@@ -109,21 +111,21 @@ document.addEventListener('manifold-token-receive', ({ detail }) => {
 });
 ```
 
-And feed the token back to `<manifold-auth-token>` on page reload:
+Once we have a token stored somewhere, we can pass it back to the `<manifold-auth-token>` component
+on page reload:
 
-```html
+```jsx
 <!-- Server-side -->
 <manifold-auth-token token="<?= $token ?>"></manifold-auth-token>
 <!-- JSX -->
 <manifold-auth-token token={localStorage.getItem('my-token')} />
 ```
 
-This will then try to re-use an existing token, which can speed up the user experience by saving an
-OAuth dance.
-
 In the case of an expired token, the component will try, silently fail, request a new one, and
 trigger the `manifold-token-receive` event which should update anything listening without any
-interruption on the user side.
+interruption on the user side. Nothing is required on your part for an expired token; if you have
+caching set up via the `manifold-token-receive` event listener, your cache will be updated whenever
+new tokens are received.
 
 ## Events
 

--- a/docs/docs/advanced/authentication.md
+++ b/docs/docs/advanced/authentication.md
@@ -152,9 +152,9 @@ document.addEventListener('manifold-token-receive', ({ detail }) => {
 
 ### Invalid token
 
-If the token given to the component is invalid, endpoints will return a 401 error and the token will
-be removed from the `manifold-connection`. Use the [error handling capabilities](/advanced/errors)
-of our web components to detect and act on such errors.
+If the token given to the component is invalid, endpoints will return a `401` error and the token
+will be refreshed automatically. Use the [error handling capabilities](/advanced/errors) of our web
+components to detect and act on such errors.
 
 ### OAuth timeout
 

--- a/docs/docs/advanced/authentication.md
+++ b/docs/docs/advanced/authentication.md
@@ -37,9 +37,10 @@ here’s a general summary of how it works with UI, and what to expect:
 
 ### Step 1: `<manifold-auth-token>`
 
-To make it easy, we provide a special component—`<manifold-auth-token>`—that handles the first part
-of the OAuth dance. It should be placed inside the [Connection][connection] component. It may appear
-anywhere in your app (but the higher it the DOM tree it appears, the better, so it can load sooner):
+To make it easy, we provide a special component—`<manifold-auth-token>`—that handles the first step
+of the OAuth dance necessary for platform users to authenticate with Manifold. It should be placed
+inside the [Connection][connection] component. It may appear anywhere in your app (but the higher it
+the DOM tree it appears, the better, so it can load sooner):
 
 ```html
 <manifold-connection>
@@ -178,8 +179,7 @@ refreshes).
 
 But for your needs, the `manifold-token-receive` event allows you to preemptively do anything you’d
 like to (such as, say, not passing the token to `<manifold-auth-token>` which could result in a
-minor performance boost for users by skipping what will be a `401` request before the token is
-refreshed).
+minor performance boost for users by skipping what will be a `401` before the token is refreshed).
 
 [authentication]: https://docs.manifold.co/docs/platforms-auth-AzsO1HvPT1Hnojsrsb10L
 [connection]: /connection

--- a/docs/docs/advanced/authentication.md
+++ b/docs/docs/advanced/authentication.md
@@ -113,7 +113,7 @@ And feed the token back to `<manifold-auth-token>` on page reload:
 
 ```html
 <!-- Server-side -->
-<manifold-auth-token token="<? $token ?>"></manifold-auth-token>
+<manifold-auth-token token="<?= $token ?>"></manifold-auth-token>
 <!-- JSX -->
 <manifold-auth-token token={localStorage.getItem('my-token')} />
 ```

--- a/docs/docs/advanced/authentication.md
+++ b/docs/docs/advanced/authentication.md
@@ -25,8 +25,15 @@ Everything else, though, will require auth. This guide will cover setting that u
 
 ## Setting up auth
 
+<manifold-toast>
+  <div>
+    View the complete authentication guide at <a href="https://docs.manifold.co/docs/platforms-auth-AzsO1HvPT1Hnojsrsb10L">docs.manifold.co</a>
+  </div>
+</manifold-toast>
+
 Everything else not related to product data—user provisions, user resources, account
-credentials—need auth. Follow these steps to set up auth for your app.
+credentials—need auth. The full auth docs can be found at [docs.manifold.co][authentication], but
+here’s a general summary of how it works with UI, and what to expect:
 
 ### Step 1: `<manifold-auth-token>`
 
@@ -80,6 +87,10 @@ This is what you should **send** back to the `redirect_uri`:
 Once that’s been received, we’ll send the token back to `<manifold-auth-token>` for our own
 endpoints to use. The `manifold-token-receive` event will also be triggered if you’d like to store
 the token anywhere (covered under **Events**).
+
+### Full guide
+
+To see our complete guide on authenticating with Manifold, see [docs.manifold.co][authentication].
 
 ## Caching
 
@@ -168,5 +179,6 @@ like to (such as, say, not passing the token to `<manifold-auth-token>` which co
 minor performance boost for users by skipping what will be a `401` request before the token is
 refreshed).
 
+[authentication]: https://docs.manifold.co/docs/platforms-auth-AzsO1HvPT1Hnojsrsb10L
 [connection]: /connection
 [oauth2]: https://www.oauth.com/oauth2-servers/access-tokens/authorization-code-request

--- a/docs/docs/advanced/performance.md
+++ b/docs/docs/advanced/performance.md
@@ -7,10 +7,9 @@ path: /advanced/performance
 
 ## Code splitting
 
-Arguably the biggest difference you can make speeding up your user experience
-is by using [dynamic imports][import] in your code. This splits out the web
-component loader into a lazy-loading chunk that doesn’t block your main
-bundle.
+Arguably the biggest difference you can make speeding up your user experience is by using [dynamic
+imports][import] in your code. This splits out the web component loader into a lazy-loading chunk
+that doesn’t block your main bundle.
 
 ```js
 // Before
@@ -23,60 +22,60 @@ import(/* webpackChunkName: manifold-ui */ '@manifoldco/ui/dist/loader').then(
 );
 ```
 
-> 💁 **Tip:** `webpackChunkName` is useful in webpack setups to ensure if you use
-> this code more than once, it’ll re-use the same chunk each time rather than
-> create multiple copies.
+> 💁 **Tip:** `webpackChunkName` is useful in webpack setups to ensure if you use this code more
+> than once, it’ll re-use the same chunk each time rather than create multiple copies.
 
-Though this may _technically_ delay the web components’ loading (because it’s
-fetching an async request to get the loader, rather than being bundled
-already by the time this is executed), overall this is generally a win for
-users, and lets you deliver a [first meaningful paint][fmp] sooner.
+Though this may _technically_ delay the web components’ loading (because it’s fetching an async
+request to get the loader, rather than being bundled already by the time this is executed), overall
+this is generally a win for users, and lets you deliver a [first meaningful paint][fmp] sooner.
 
-Lazy-loading _everything_ indiscriminately across your application would slow
-down the user experience, but when used strategically like this it can have
-big payoffs.
+Lazy-loading _everything_ indiscriminately across your application would slow down the user
+experience, but when used strategically like this it can have big payoffs.
 
-[fmp]: https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint
-[import]: https://webpack.js.org/guides/code-splitting/#dynamic-imports
-[stencil-browsers]: https://stenciljs.com/docs/browser-support
-[rtt]: https://developer.mozilla.org/en-US/docs/Glossary/Round_Trip_Time_(RTT)
+## Caching OAuth tokens
+
+Another opportunity to greatly speed up the user experience on page load is to cache the tokens from
+`<manifold-auth-token>`. For more information, see the **Caching** section in the [authentication
+guide][auth]
 
 ## Other Gotchas
 
-Though there’s nothing actionable in this section, it’s nice to have a
-general understanding of how Stencil is bundled as it affects your
-application.
+Though there’s nothing actionable in this section, it’s nice to have a general understanding of how
+Stencil is bundled as it affects your application.
 
 ### Efficient element loading
 
-Stencil splits up custom elements into their own chunks. For our UI bundle,
-if you only use `<manifold-product>` and `<manifold-plan-selector>` on a
-page, your users will download the JS to render those two, and only those
-two. That means **as Manifold UI scales and adds components, it comes at
-almost no cost to your users.**
+Stencil splits up custom elements into their own chunks. For our UI bundle, if you only use
+`<manifold-product>` and `<manifold-plan-selector>` on a page, your users will download the JS to
+render those two, and only those two. That means **as Manifold UI scales and adds components, it
+comes at almost no cost to your users.**
 
-To see this in action, open your **Network** tab in Chrome, and filter to
-**JS**. You should see things like `15.js` and `53.js`, each weighing only a
-few KB.
+To see this in action, open your **Network** tab in Chrome, and filter to **JS**. You should see
+things like `15.js` and `53.js`, each weighing only a few KB.
 
 ### Polyfill bloat
 
-Stencil’s web components work for more browsers than even have web component
-support [via a polyfill][stencil-browsers]. It’s great to have built-in
-support, but sometimes webpack can accidentally bundle the polyfill when it
-doesn’t need to. We’ve found the best fix to be **code splitting** (above).
+Stencil’s web components work for more browsers than even have web component support [via a
+polyfill][stencil-browsers]. It’s great to have built-in support, but sometimes webpack can
+accidentally bundle the polyfill when it doesn’t need to. We’ve found the best fix to be **code
+splitting** (above).
 
 ## Metrics
 
-[RTT][rtt] of endpoint calls are calculated and emitted as events - either from
-`document` or from an `EventEmitter` supplied by the component calling the
-endpoint.
+[RTT][rtt] of endpoint calls are calculated and emitted as events - either from `document` or from
+an `EventEmitter` supplied by the component calling the endpoint.
 
-A solution to listen for and log these events is currently left as an
-implementation detail on the platform side:
+A solution to listen for and log these events is currently left as an implementation detail on the
+platform side:
 
 ```js
 document.addEventListener('manifold-rest-fetch-duration', { detail } => {
   console.log(detail); // { endpoint: "/catalog/products", duration: 95 }
 });
 ```
+
+[auth]: /advanced/authentication
+[fmp]: https://developers.google.com/web/tools/lighthouse/audits/first-meaningful-paint
+[import]: https://webpack.js.org/guides/code-splitting/#dynamic-imports
+[rtt]: https://developer.mozilla.org/en-US/docs/Glossary/Round_Trip_Time_(RTT)
+[stencil-browsers]: https://stenciljs.com/docs/browser-support

--- a/docs/docs/data/manifold-auth-token.md
+++ b/docs/docs/data/manifold-auth-token.md
@@ -1,0 +1,81 @@
+---
+title: Auth Token
+path: /data/auth-token
+---
+
+# Auth Token
+
+This component handles [auth][auth] for our components. This is merely a list of options and events;
+to see the full picture please refer to the [guide][auth] on the subject.
+
+This component must be always be used inside [Connection][connection] like so:
+
+```html
+<manifold-connection>
+  <manifold-auth-token></manifold-auth-token>
+</manifold-connection>
+```
+
+We recommend **loading this as high up your DOM tree as possible** so it loads sooner (sometimes the
+OAuth dance can take a couple seconds, so the sooner this can start the faster it will be for
+users). We also recommend **only placing it on the page once** to avoid multiple token requests
+per-page.
+
+## Caching for performance
+
+Sometimes the OAuth dance can take a couple seconds to complete. In that light, we strongly
+recommend caching the token somewhere so that new tokens are only requested when necessary.
+
+Tokens are set using the `manifold-token-receive` event (in this example we’re using `localStorage`,
+but you may place this anywhere that persists):
+
+```js
+document.addEventListener('manifold-token-receive', ({ detail }) => {
+  if (detail.token) {
+    // set new token if received
+    localStorage.setItem('my-token', detail.token);
+  } else {
+    // if there was an error, clear saved token
+    localStorage.removeItem('my-token');
+  }
+});
+```
+
+Once we have a token stored somewhere, we can pass it back to the `<manifold-auth-token>` component
+on page reload:
+
+```jsx
+<!-- Server-side -->
+<manifold-auth-token token="<?= $token ?>"></manifold-auth-token>
+<!-- JSX -->
+<manifold-auth-token token={localStorage.getItem('my-token')} />
+```
+
+In the case of an expired token, the component will try, silently fail, request a new one, and
+trigger the `manifold-token-receive` event which should update anything listening without any
+interruption on the user side. Nothing is required on your part for an expired token; if you have
+caching set up via the `manifold-token-receive` event listener, your cache will be updated whenever
+new tokens are received.
+
+## Events
+
+The following custom events are emitted to `document`. You can listen for events like so:
+
+```js
+document.addEventListener('manifold-token-receive', ({ detail }) => {
+  console.log(detail);
+  // {
+  //   duration: 1450,
+  //   error: null,
+  //   expiry: 86400000,
+  //   token: "eyJhbGciOiJFUzI1NiI…"
+  // }
+});
+```
+
+| Event Name               | Description                              | Data                                   |
+| :----------------------- | :--------------------------------------- | :------------------------------------- |
+| `manifold-token-receive` | Emitted whenever a new token is received | `token`, `expiry`, `error`, `duration` |
+
+[connection]: /connection
+[auth]: /advanced/authentication

--- a/docs/src/components/Entry.tsx
+++ b/docs/src/components/Entry.tsx
@@ -104,6 +104,14 @@ const Readme = styled.div`
     line-height: 1.5;
   }
 
+  & ul,
+  & ol {
+    margin-top: 1.5em;
+    margin-bottom: 1.5em;
+    padding-left: 0;
+    font-size: 14px;
+  }
+
   /* highlight.js */
 
   & .hljs {


### PR DESCRIPTION
## Reason for change

Our authentication section was written before the implementation, and is more general than instructional. This change adds example code in a more usable way, and explains the OAuth dance a little better.

## Testing

Spellcheck, etc.

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible

[docs]: https://ui.sandbox.manifold.co
