### PR TITLE
Fix Critical Firefox bug (updates shadowcat)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed events firing twice for `<manifold-resource-rename>`, `<manifold-resource-sso>`, and `<manifold-resource-deprovision>` (#401)
 - Prevent provision button from being clicked multiple times.
-- Fixed a bug in Firefox with `<manifold-auth-token>`
+- Fixed a bug in Firefox with `<manifold-auth-token> (#429)`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed events firing twice for `<manifold-resource-rename>`, `<manifold-resource-sso>`, and `<manifold-resource-deprovision>` (#401)
 - Prevent provision button from being clicked multiple times.
+- Fixed a bug in Firefox with `<manifold-auth-token>`
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2095,9 +2095,9 @@
       "dev": true
     },
     "@manifoldco/shadowcat": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@manifoldco/shadowcat/-/shadowcat-0.1.5.tgz",
-      "integrity": "sha512-d+UIi9vyUjExBVXFtnrqUpF1agupnqTrA4AVPCqADpGs6/XawKiAU7bJyKuW51k+AQHSZLygB1G1C7EFHW89AA=="
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@manifoldco/shadowcat/-/shadowcat-0.1.6.tgz",
+      "integrity": "sha512-1a8oQ6tP7xwyrLV86dWzl3aSFYB2kdg/FxaE2Nn5HkwuB14w1z3HpvyIjjqdgM1kfH3Gq2mE6okWEHdqRP76aw=="
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   ],
   "dependencies": {
     "@manifoldco/gql-zero": "^0.2.0",
-    "@manifoldco/shadowcat": "^0.1.5",
+    "@manifoldco/shadowcat": "^0.1.6",
     "@stencil/state-tunnel": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Reason for change
Ships a new version of shadowcat that fixes a bug in Firefox (manifoldco/engineering#9089).

Locally I’ve tested this myself and confirmed it works in Render’s Dashboard, but would appreciate another set of eyes on it.

For the curious, here’s the actual change under the hood: https://github.com/manifoldco/shadowcat/pull/43

## Testing

- `npm run build && cp -r /local/path/to/manifoldco/dashboard-render/node_modules/@manifoldco/ui`
- Start the Render Dashboard, test it works perfectly with Firefox

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [x] **Prop changes**: [docs][docs] were updated
- [x] **Prop changes**: E2E tests were updated, testing from the highest level possible

[docs]: https://ui.sandbox.manifold.co
