### PR TITLE
Added: Update oauth URL to restart oauth when token is unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- When an expired auth token causes an API call to respond with a 401, the token will now refresh and
+  the API call will retry.
+
 ## [v0.5.7]
 
 ### Added

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -13,6 +13,9 @@ import {
   Gateway,
 } from './types/gateway';
 import {
+  Subscriber,
+} from './state/connection';
+import {
   RestFetch,
 } from './utils/restFetch';
 import {
@@ -34,11 +37,15 @@ export namespace Components {
     'selectedResource'?: Gateway.Resource;
   }
   interface ManifoldAuthToken {
-    'oauthUrl'?: string;
+    'oauthUrl': string;
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */
     'setAuthToken': (s: string) => void;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'subscribe': (s: Subscriber) => () => void;
     'token'?: string;
   }
   interface ManifoldBadge {}
@@ -1057,6 +1064,10 @@ declare namespace LocalJSX {
     * _(hidden)_ Passed by `<manifold-connection>`
     */
     'setAuthToken'?: (s: string) => void;
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'subscribe'?: (s: Subscriber) => () => void;
     'token'?: string;
   }
   interface ManifoldBadge extends JSXBase.HTMLAttributes<HTMLManifoldBadgeElement> {}

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -37,7 +37,7 @@ export namespace Components {
     'selectedResource'?: Gateway.Resource;
   }
   interface ManifoldAuthToken {
-    'oauthUrl': string;
+    'oauthUrl'?: string;
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
     */

--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -14,7 +14,7 @@ export class ManifoldAuthToken {
   @Prop() subscribe: (s: Subscriber) => () => void = () => () => {};
   /* Authorisation header token that can be used to authenticate the user in manifold */
   @Prop() token?: string;
-  @Prop() oauthUrl: string = 'https://login.manifold.co/signin/oauth/web';
+  @Prop() oauthUrl?: string = 'https://login.manifold.co/signin/oauth/web';
   @Event({ eventName: 'manifold-token-receive', bubbles: true })
   manifoldOauthTokenChange: EventEmitter;
 

--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -11,7 +11,7 @@ export class ManifoldAuthToken {
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() setAuthToken: (s: string) => void = () => {};
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() subscribe: (s: Subscriber) => () => void;
+  @Prop() subscribe: (s: Subscriber) => () => void = () => () => {};
   /* Authorisation header token that can be used to authenticate the user in manifold */
   @Prop() token?: string;
   @Prop() oauthUrl: string = 'https://login.manifold.co/signin/oauth/web';

--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -4,16 +4,21 @@ import { AuthToken } from '@manifoldco/shadowcat';
 import Tunnel from '../../data/connection';
 import logger from '../../utils/logger';
 import { isExpired } from '../../utils/auth';
+import { Subscriber } from '../../state/connection';
 
 @Component({ tag: 'manifold-auth-token' })
 export class ManifoldAuthToken {
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() setAuthToken: (s: string) => void = () => {};
+  /** _(hidden)_ Passed by `<manifold-connection>` */
+  @Prop() subscribe: (s: Subscriber) => () => void;
   /* Authorisation header token that can be used to authenticate the user in manifold */
   @Prop() token?: string;
-  @Prop() oauthUrl?: string;
+  @Prop() oauthUrl: string = 'https://login.manifold.co/signin/oauth/web';
   @Event({ eventName: 'manifold-token-receive', bubbles: true })
   manifoldOauthTokenChange: EventEmitter;
+
+  private unsubscribe = () => {};
 
   @Watch('token') tokenChange(newToken?: string) {
     this.setExternalToken(newToken);
@@ -21,6 +26,19 @@ export class ManifoldAuthToken {
 
   componentWillLoad() {
     this.setExternalToken(this.token);
+    if (this.subscribe) {
+      this.unsubscribe = this.subscribe((oldToken?: string, newToken?: string) => {
+        if (oldToken && !newToken && this.oauthUrl) {
+          const url = new URL(this.oauthUrl);
+          url.searchParams.set('ts', new Date().getTime().toString());
+          this.oauthUrl = url.href;
+        }
+      });
+    }
+  }
+
+  componentDidUnload() {
+    this.unsubscribe();
   }
 
   setExternalToken(token?: string) {
@@ -48,4 +66,4 @@ export class ManifoldAuthToken {
   }
 }
 
-Tunnel.injectProps(ManifoldAuthToken, ['setAuthToken']);
+Tunnel.injectProps(ManifoldAuthToken, ['setAuthToken', 'subscribe']);

--- a/src/state/connection.spec.ts
+++ b/src/state/connection.spec.ts
@@ -1,0 +1,23 @@
+import { ConnectionState } from './connection';
+
+describe('connection state', () => {
+  it('notifies subscribers of auth token changes', () => {
+    const state = new ConnectionState();
+    state.authToken = 'old-token';
+    const subscriber = jest.fn();
+    state.subscribe(subscriber);
+    state.setAuthToken('new-token');
+    expect(subscriber).toHaveBeenCalledWith('old-token', 'new-token');
+  });
+
+  it('will not notify after unsubscribing', () => {
+    const state = new ConnectionState();
+    state.authToken = 'old-token';
+    const subscription = jest.fn();
+    const unsubscribe = state.subscribe(subscription);
+    state.setAuthToken('new-token');
+    unsubscribe();
+    state.setAuthToken('old-token');
+    expect(subscription.mock.calls).toHaveLength(1);
+  });
+});

--- a/src/state/connection.ts
+++ b/src/state/connection.ts
@@ -53,6 +53,7 @@ export class ConnectionState {
     getAuthToken: this.getAuthToken,
     setAuthToken: this.setAuthToken,
     wait: this.waitTime,
+    retries: 1,
   });
 
   graphqlFetch = createGraphqlFetch({
@@ -60,5 +61,6 @@ export class ConnectionState {
     setAuthToken: this.setAuthToken,
     endpoint: connections[this.env].graphql,
     wait: this.waitTime,
+    retries: 1,
   });
 }

--- a/src/state/connection.ts
+++ b/src/state/connection.ts
@@ -4,6 +4,8 @@ import { createRestFetch } from '../utils/restFetch';
 
 const baseWait = 15000;
 
+export type Subscriber = (oldToken?: string, newToken?: string) => void;
+
 export class ConnectionState {
   /** _(optional)_ Specify `env="stage"` for staging */
   env: 'local' | 'stage' | 'prod' = 'prod';
@@ -11,6 +13,16 @@ export class ConnectionState {
   waitTime: number = baseWait;
 
   authToken?: string;
+
+  private subscribers: Subscriber[] = [];
+
+  subscribe = (s: Subscriber) => {
+    this.subscribers.push(s);
+
+    return () => {
+      this.subscribers.splice(this.subscribers.indexOf(s), 1);
+    };
+  };
 
   setEnv = (newValue: 'local' | 'stage' | 'prod') => {
     this.env = newValue;
@@ -21,6 +33,7 @@ export class ConnectionState {
   };
 
   setAuthToken = (token: string) => {
+    this.subscribers.forEach(s => s(this.authToken, token));
     this.authToken = token;
   };
 

--- a/src/utils/graphqlFetch.spec.ts
+++ b/src/utils/graphqlFetch.spec.ts
@@ -171,6 +171,21 @@ describe('graphqlFetch', () => {
       await fetcher({ query: '' });
       expect(setAuthToken).toHaveBeenCalledWith('');
     });
+
+    it('can retry on error', async () => {
+      const setAuthToken = jest.fn();
+      const fetcher = createGraphqlFetch({
+        endpoint: graphqlEndpoint,
+        getAuthToken: () => '1234',
+        setAuthToken,
+        retries: 1,
+      });
+
+      fetchMock.mock(graphqlEndpoint, { status: 401, body: {} });
+
+      await fetcher({ query: '' });
+      expect(fetchMock.calls.length).toBe(2);
+    });
   });
 
   // Note: we’re testing status codes ahead-of-time, to ensure handling of them doesn’t change

--- a/src/utils/graphqlFetch.ts
+++ b/src/utils/graphqlFetch.ts
@@ -70,6 +70,7 @@ export function createGraphqlFetch({
       // TODO trigger token refresh for manifold-auth-token
       setAuthToken('');
       report(response); // report unauthenticated
+      return graphqlFetch(args);
     }
 
     // handle non-GQL responses from errors

--- a/src/utils/graphqlFetch.ts
+++ b/src/utils/graphqlFetch.ts
@@ -10,7 +10,7 @@ interface CreateGraphqlFetch {
   setAuthToken?: (token: string) => void;
 }
 
-type graphqlArgs =
+type GraphqlArgs =
   | { mutation: string; variables?: object; isPublic?: boolean; emitter?: EventEmitter }
   | { query: string; variables?: object; isPublic?: boolean; emitter?: EventEmitter }; // require query or mutation, but not both
 
@@ -25,7 +25,7 @@ export interface GraphqlResponseBody<T> {
   errors?: GraphqlError[];
 }
 
-export type GraphqlFetch = <T>(args: graphqlArgs) => Promise<GraphqlResponseBody<T>>;
+export type GraphqlFetch = <T>(args: GraphqlArgs) => Promise<GraphqlResponseBody<T>>;
 
 export function createGraphqlFetch({
   endpoint = 'https://api.manifold.co/graphql',
@@ -34,9 +34,9 @@ export function createGraphqlFetch({
   getAuthToken = () => undefined,
   setAuthToken = () => {},
 }: CreateGraphqlFetch): GraphqlFetch {
-  return async function graphqlFetch<T>(
-    args: graphqlArgs,
-    attempts: number = 0
+  async function graphqlFetch<T>(
+    args: GraphqlArgs,
+    attempts: number
   ): Promise<GraphqlResponseBody<T>> {
     const start = new Date();
     const rttStart = performance.now();
@@ -115,5 +115,9 @@ export function createGraphqlFetch({
 
     // return everything to the user
     return body;
+  }
+
+  return function(args: GraphqlArgs) {
+    return graphqlFetch(args, 0);
   };
 }

--- a/src/utils/restFetch.spec.ts
+++ b/src/utils/restFetch.spec.ts
@@ -42,7 +42,7 @@ describe('The fetcher created by createRestFetch', () => {
     expect(result).toEqual(body);
   });
 
-  it('Will reset the auth token on an error', () => {
+  it('Will reset the auth token on a 401 error', () => {
     const setAuthToken = jest.fn();
     const fetcher = createRestFetch({
       getAuthToken: () => '1234',
@@ -64,6 +64,27 @@ describe('The fetcher created by createRestFetch', () => {
     });
   });
 
+  it('Can retry on a 401 error', () => {
+    const setAuthToken = jest.fn();
+    const fetcher = createRestFetch({
+      getAuthToken: () => '1234',
+      setAuthToken,
+      retries: 1,
+    });
+
+    fetchMock.mock('path:/v1/test', {
+      status: 401,
+      body: {},
+    });
+
+    expect.assertions(1);
+    return fetcher({
+      endpoint: '/test',
+      service: 'marketplace',
+    }).catch(() => {
+      expect(fetchMock.calls.length).toEqual(2);
+    });
+  });
   it('Will return an error if the fetch returned one', () => {
     const body = {
       message: 'oops',

--- a/src/utils/restFetch.ts
+++ b/src/utils/restFetch.ts
@@ -32,10 +32,7 @@ export function createRestFetch({
   getAuthToken = () => undefined,
   setAuthToken = () => {},
 }: CreateRestFetch): RestFetch {
-  return async function restFetch<T>(
-    args: RestFetchArguments,
-    attempts: number = 0
-  ): Promise<T | Success> {
+  async function restFetch<T>(args: RestFetchArguments, attempts: number): Promise<T | Success> {
     const start = new Date();
     const rttStart = performance.now();
 
@@ -106,5 +103,9 @@ export function createRestFetch({
     report(response);
     const message = Array.isArray(body) ? body[0].message : body.message;
     throw new Error(message);
+  }
+
+  return function(args: RestFetchArguments) {
+    return restFetch(args, 0);
   };
 }

--- a/src/utils/restFetch.ts
+++ b/src/utils/restFetch.ts
@@ -70,7 +70,7 @@ export function createRestFetch({
     if (response.status === 401) {
       setAuthToken('');
       report(response);
-      throw new Error('Auth token expired');
+      return restFetch(args);
     }
 
     const body = await response.json();


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

Currently, if we receive a 401 status from the API, an unhandled exception will be thrown, and users will have to refresh the page to obtain a new auth token.

With this change, a 401 will cause the token to be refreshed, and the API call will retry.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

Testing is tricky because tokens take a while to expire. You might want to [watch this video](https://manifoldco.slack.com/archives/CDW445F53/p1566568237455700) where @domenicrosati demonstrates this working with fast-expiring tokens.

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible

[docs]: https://ui.sandbox.manifold.co
