### PR TITLE
Delay transitions until component render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Fixed resource card CTA slot from flashing while loading (#438)
-
 ### Added
 
 - When an expired auth token causes an API call to respond with a 401, the token will now refresh and
   the API call will retry.
+
+### Fixed
+
+- Fixed resource card CTA slot from flashing while loading (#438)
+- Hide credentials button no longer flashes when credentials component loads (#434)
 
 ### Changed
 

--- a/docs/docs/components/manifold-credentials.md
+++ b/docs/docs/components/manifold-credentials.md
@@ -8,8 +8,7 @@ example: '<manifold-credentials resource-name="cms-stage"></manifold-credentials
 
 Display credentials for a resource. 🔒 Requires authentication.
 
-The resource label needs to be provided for the component to be able to fetch the resource's
-credentials on demand.
+The resource label needs to be provided for the component to be able to fetch the resource's credentials on demand.
 
 ```html
 <manifold-credentials resource-label="my-resource"></manifold-credentials>
@@ -17,13 +16,16 @@ credentials on demand.
 
 ## Customizing the buttons
 
-You can pass in your own button or link for the show and hide buttons of the component by passing in
-any element with `slot="show-button"` and `slot="hide-button"` as an attribute respectively. [Read
-more about slots][slot].
+You can pass in your own button or link for the show and hide buttons of the component by passing in any element with `slot="show-button"` and `slot="hide-button"` as an attribute respectively. [Read more about slots][slot].
 
 ```jsx
 <manifold-credentials resource-label="my-resource">
-  <MyButton slot="show-button">Show credentials</MyButton>
-  <MyButton slot="hide-button">Hide credentials</MyButton>
+  <MyButton slot="show-button">
+    Show credentials
+  </MyButton>
+  <MyButton slot="hide-button">
+    Hide credentials
+  </MyButton>
 </manifold-credentials>
 ```
+

--- a/docs/docs/components/manifold-credentials.md
+++ b/docs/docs/components/manifold-credentials.md
@@ -8,7 +8,8 @@ example: '<manifold-credentials resource-name="cms-stage"></manifold-credentials
 
 Display credentials for a resource. 🔒 Requires authentication.
 
-The resource label needs to be provided for the component to be able to fetch the resource's credentials on demand.
+The resource label needs to be provided for the component to be able to fetch the resource's
+credentials on demand.
 
 ```html
 <manifold-credentials resource-label="my-resource"></manifold-credentials>
@@ -16,16 +17,13 @@ The resource label needs to be provided for the component to be able to fetch th
 
 ## Customizing the buttons
 
-You can pass in your own button or link for the show and hide buttons of the component by passing in any element with `slot="show-button"` and `slot="hide-button"` as an attribute respectively. [Read more about slots][slot].
+You can pass in your own button or link for the show and hide buttons of the component by passing in
+any element with `slot="show-button"` and `slot="hide-button"` as an attribute respectively. [Read
+more about slots][slot].
 
 ```jsx
 <manifold-credentials resource-label="my-resource">
-  <MyButton slot="show-button">
-    Show credentials
-  </MyButton>
-  <MyButton slot="hide-button">
-    Hide credentials
-  </MyButton>
+  <MyButton slot="show-button">Show credentials</MyButton>
+  <MyButton slot="hide-button">Hide credentials</MyButton>
 </manifold-credentials>
 ```
-

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build:storybook": "npm run build && build-storybook && npm run copy-changelog",
     "bundlesize": "npm run build && npx bundlesize",
     "copy-changelog": "node scripts/copy-changelog",
-    "dev": "npm run copy-changelog && concurrently 'stencil build --watch' 'wait-on dist/loader/index.cjs.js && cp .manifold-local.yml .manifold.yml && manifold run -- npm run storybook'",
+    "dev": "concurrently 'stencil build --watch' 'wait-on dist/loader/index.cjs.js && cp .manifold-local.yml .manifold.yml && manifold run -- npm run storybook'",
     "docs": "npm run prepare:docs && cd docs && npm start",
     "generate:gql": "graphql-codegen --config codegen.yml",
     "generate:specs": "npm run generate:specs:catalog && npm run generate:specs:gateway && npm run generate:specs:marketplace && npm run generate:specs:provisioning && npm run generate:specs:connector",

--- a/src/components/manifold-credentials-view/manifold-credentials-view.css
+++ b/src/components/manifold-credentials-view/manifold-credentials-view.css
@@ -56,7 +56,8 @@
   font-size: var(--manifold-font-d1);
   transition: transform 250ms var(--manifold-ease-sharp), opacity 250ms linear;
 
-  & manifold-button, & > ::slotted(*) {
+  & manifold-button,
+  & > ::slotted(*) {
     margin-top: 1rem;
     transform: translateX(-50%);
   }
@@ -99,11 +100,15 @@
   padding: 0;
   transform: translateY(100%);
   opacity: 0;
-  transition: transform 150ms var(--manifold-ease-sharp), opacity 150ms linear;
 
   &[data-showing] {
     transform: translateY(0);
     opacity: 1;
+  }
+
+  &[data-transitions] {
+    /* Hack to prevent the hide button from animating on load in Firefox */
+    transition: transform 150ms var(--manifold-ease-sharp), opacity 150ms linear;
   }
 }
 

--- a/src/components/manifold-credentials-view/manifold-credentials-view.tsx
+++ b/src/components/manifold-credentials-view/manifold-credentials-view.tsx
@@ -1,4 +1,4 @@
-import { h, Component, Prop, Event, EventEmitter, Element } from '@stencil/core';
+import { h, Component, Prop, Event, EventEmitter, Element, State } from '@stencil/core';
 import { eye, lock, loader } from '@manifoldco/icons';
 
 import { Marketplace } from '../../types/marketplace';
@@ -14,6 +14,7 @@ export class ManifoldResourceCredentials {
   @Prop() credentials?: Marketplace.Credential[];
   @Prop() resourceLabel: string = '';
   @Prop() loading: boolean = false;
+  @State() shouldTransition: boolean = false;
   @Event() credentialsRequested: EventEmitter;
 
   showButtonEl?: Element;
@@ -22,6 +23,13 @@ export class ManifoldResourceCredentials {
   componentWillLoad() {
     this.findNodes();
     this.addListeners();
+  }
+
+  componentDidLoad() {
+    // hack to prevent “Hide credentials” from being visible on load in Firefox
+    setTimeout(() => {
+      this.shouldTransition = true;
+    }, 250);
   }
 
   componentDidUpdate() {
@@ -95,7 +103,11 @@ export class ManifoldResourceCredentials {
     );
 
     return [
-      <menu class="secrets-menu" data-showing={!!this.credentials}>
+      <menu
+        class="secrets-menu"
+        data-showing={!!this.credentials || undefined}
+        data-transitions={this.shouldTransition || undefined}
+      >
         {this.hideButtonEl ? (
           <slot name="hide-button" />
         ) : (


### PR DESCRIPTION
## Reason for change

**Before** (hide credentials is visible on load)
![2019-08-23 08-50-12 2019-08-23 08_50_47](https://user-images.githubusercontent.com/1369770/63601886-88eafd00-c583-11e9-9151-28d2bb4c42d9.gif)

**After** (hide credentials is invisible on load AND animations are preserved)

![2019-08-23 08-46-44 2019-08-23 08_47_22](https://user-images.githubusercontent.com/1369770/63601907-930cfb80-c583-11e9-8904-752d4feea882.gif)

## Testing
Minor addition

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [x] **Prop changes**: [docs][docs] were updated
- [x] **Prop changes**: E2E tests were updated, testing from the highest level possible

[docs]: https://ui.sandbox.manifold.co
