### PR TITLE
Fix SSO button in loading card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed resource card CTA slot from flashing while loading (#438)
+
 ### Added
 
 - When an expired auth token causes an API call to respond with a 401, the token will now refresh and

--- a/src/components/manifold-resource-product/manifold-resource-product.tsx
+++ b/src/components/manifold-resource-product/manifold-resource-product.tsx
@@ -30,7 +30,11 @@ export class ManifoldResourceProduct {
         description="This is a loading product..."
         logo="loading.jpg"
         name="loading..."
-      />
+      >
+        <manifold-forward-slot slot="cta">
+          <slot name="cta" />
+        </manifold-forward-slot>
+      </manifold-service-card-view>
     );
   }
 }

--- a/src/components/manifold-service-card-view/manifold-service-card-view-happo.ts
+++ b/src/components/manifold-service-card-view/manifold-service-card-view-happo.ts
@@ -57,3 +57,32 @@ export const featured = async () => {
 
   return card.componentOnReady();
 };
+
+export const cta = async () => {
+  const card = document.createElement('manifold-service-card-view');
+  card.description = body.tagline;
+  card.logo = body.logo_url;
+  card.productId = id;
+  card.name = body.name;
+  card.productLabel = body.label;
+  card.innerHTML = `<button slot="cta">CTA Slot</button>`;
+
+  document.body.appendChild(card);
+
+  return card.componentOnReady();
+};
+
+export const skeletonWithCTA = async () => {
+  const card = document.createElement('manifold-service-card-view');
+  card.description = body.tagline;
+  card.logo = body.logo_url;
+  card.productId = id;
+  card.name = body.name;
+  card.productLabel = body.label;
+  card.skeleton = true;
+  card.innerHTML = `<button slot="cta">CTA Slot</button>`;
+
+  document.body.appendChild(card);
+
+  return card.componentOnReady();
+};

--- a/src/components/manifold-service-card-view/manifold-service-card-view.css
+++ b/src/components/manifold-service-card-view/manifold-service-card-view.css
@@ -145,6 +145,11 @@
   }
 }
 
+.loading-cta {
+  /* hide slot until not loaded */
+  display: none;
+}
+
 .tags {
   display: flex;
   flex-wrap: wrap;

--- a/src/components/manifold-service-card-view/manifold-service-card-view.tsx
+++ b/src/components/manifold-service-card-view/manifold-service-card-view.tsx
@@ -90,6 +90,9 @@ export class ManifoldServiceCardView {
           <h3 class="name">
             <manifold-skeleton-text>{this.name}</manifold-skeleton-text>
           </h3>
+          <div class="loading-cta">
+            <slot name="cta" />
+          </div>
           <div class="info">
             <p class="description">
               <manifold-skeleton-text>{this.description}</manifold-skeleton-text>

--- a/src/components/manifold-service-card/manifold-service-card.spec.ts
+++ b/src/components/manifold-service-card/manifold-service-card.spec.ts
@@ -99,7 +99,9 @@ describe('<manifold-service-card>', () => {
           logo="product.jpg"
           name="Awesome product"
           skeleton=""
-        ></manifold-service-card-view>
+        >
+          <manifold-forward-slot slot="cta"></manifold-forward-slot>
+        </manifold-service-card-view>
       `);
     });
   });

--- a/src/components/manifold-service-card/manifold-service-card.spec.ts
+++ b/src/components/manifold-service-card/manifold-service-card.spec.ts
@@ -80,7 +80,7 @@ describe('<manifold-service-card>', () => {
           productlabel="${Product.body.label}"
           productlinkformat="${card.productLinkFormat}"
         >
-          <manifold-forward-ref slot="cta"></manifold-forward-ref>
+          <manifold-forward-slot slot="cta"></manifold-forward-slot>
         </manifold-service-card-view>
       `);
     });
@@ -133,7 +133,7 @@ describe('<manifold-service-card>', () => {
           logo="${Product.body.logo_url}"
           name="${Product.body.name}"
         >
-          <manifold-forward-ref slot="cta"></manifold-forward-ref>
+          <manifold-forward-slot slot="cta"></manifold-forward-slot>
         </manifold-service-card-view>
       `);
     });

--- a/src/components/manifold-service-card/manifold-service-card.tsx
+++ b/src/components/manifold-service-card/manifold-service-card.tsx
@@ -118,9 +118,9 @@ export class ManifoldServiceCard {
         productLabel={this.product.body.label}
         productLinkFormat={this.productLinkFormat}
       >
-        <manifold-forward-ref slot="cta">
+        <manifold-forward-slot slot="cta">
           <slot name="cta" />
-        </manifold-forward-ref>
+        </manifold-forward-slot>
       </manifold-service-card-view>
     ) : (
       // ☠
@@ -129,7 +129,11 @@ export class ManifoldServiceCard {
         description="Awesome product description"
         logo="product.jpg"
         name="Awesome product"
-      />
+      >
+        <manifold-forward-slot slot="cta">
+          <slot name="cta" />
+        </manifold-forward-slot>
+      </manifold-service-card-view>
     );
   }
 }


### PR DESCRIPTION
## Reason for change

SSO button was visible on load, because the `slot="cta"` didn’t exist until load.

**Before**

![2019-08-23 12-21-59 2019-08-23 12_22_29](https://user-images.githubusercontent.com/1369770/63615235-11789600-c5a2-11e9-9525-8beda014aee6.gif)


**After**

![2019-08-23 12-30-50 2019-08-23 12_31_45](https://user-images.githubusercontent.com/1369770/63615237-150c1d00-c5a2-11e9-8831-c6498883f9c9.gif)

**Happo tests**

![Screen Shot 2019-08-23 at 13 00 00](https://user-images.githubusercontent.com/1369770/63617077-01fb4c00-c5a6-11e9-999b-f1f9ce9cc1ed.png)

![Screen Shot 2019-08-23 at 13 00 03](https://user-images.githubusercontent.com/1369770/63617091-04f63c80-c5a6-11e9-9c71-347667fafb02.png)

## Testing

Actually kinda difficult to test, but it’s best seen while provisioning a product in Render Dashboard.

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [x] **Prop changes**: [docs][docs] were updated
- [x] **Prop changes**: E2E tests were updated, testing from the highest level possible

[docs]: https://ui.sandbox.manifold.co
