### PR TITLE
Fixed: OAuth URL parsing

### DIFF
--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -29,7 +29,7 @@ export class ManifoldAuthToken {
     if (this.subscribe) {
       this.unsubscribe = this.subscribe((oldToken?: string, newToken?: string) => {
         if (oldToken && !newToken && this.oauthUrl) {
-          const url = new URL(this.oauthUrl);
+          const url = new URL(this.oauthUrl, window.location.href);
           url.searchParams.set('ts', new Date().getTime().toString());
           this.oauthUrl = url.href;
         }


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
The `manifold-auth-token` component attempts to construct a `URL` object from the supplied `oauthUrl`. However, the docs page was passing in a relative path for this, which would break the URL parsing. This change adds the `base` argument to the `URL` constructor to prevent that failure.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->
Docs page should now correctly display the marketplace.

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible

[docs]: https://ui.sandbox.manifold.co
