### PR TITLE
invalidate cache on latest push for ui

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,7 @@ jobs:
           condition: << parameters.latest >>
           steps:
             - run: gsutil -m rsync -r gs://manifold-js/@manifoldco/ui@${CIRCLE_TAG//v} gs://manifold-js/@manifoldco/ui
+            - run: gcloud compute url-maps invalidate-cdn-cache manifold-js-cdn-urlmap --path "/@manifoldco/ui/*" --async
 
 workflows:
   version: 2


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

We want to have the freshes ui release on latest :) lets automate the process with invalidating the cache for this path.

Requires: [infrastructure/533](https://github.com/manifoldco/infrastructure/pull/533)

## Testing

See if the latest release is on that path by checking the changelog after a push of a release (we can do a manual run of the commands to check)

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible

[docs]: https://ui.sandbox.manifold.co
