### PR TITLE
Provision button event data + tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added an events queue to `<manifold-performance>` to capture any performance events emitted before DataDog is ready.
+- Added more event data & testing for `<manifold-data-provision-button>`.
 
 ### Fixed
 
 - Fixed a typo in manifold-data-deprovision-button documentation
 
-
 ### Changed
 
 - Changed the docs fetch mocking to now wait for the real request duration. This duration is obtained at build time from the manifold APIs.
-
 
 ## [v0.5.8]
 

--- a/docs/docs/data/manifold-data-provision-button.md
+++ b/docs/docs/data/manifold-data-provision-button.md
@@ -23,7 +23,7 @@ An unstyled button for provisioning resources. 🔒 Requires authentication.
 ## Using with Plan Selector
 
 This component needs a lot of information to do its job. For that reason, we recommend relying on
-listening from events from the [plan selector](#manifold-plan-selector) component. You could do that
+listening for events from the [plan selector](#manifold-plan-selector) component. You could do that
 like so:
 
 ```js

--- a/docs/docs/data/manifold-data-provision-button.md
+++ b/docs/docs/data/manifold-data-provision-button.md
@@ -27,7 +27,7 @@ listening from events from the [plan selector](#manifold-plan-selector) componen
 like so:
 
 ```js
-const userId = ''; // optional, but providing will save a request
+const userId = ''; // Note: Can be omitted, will be fetched automatically.
 const resourceLabel = ''; // Can be obtained from your own input
 
 function updateButton({ detail: { features, planLabel, productLabel, regionId } }) {

--- a/docs/docs/data/manifold-data-provision-button.md
+++ b/docs/docs/data/manifold-data-provision-button.md
@@ -9,6 +9,10 @@ example: |
   </manifold-data-provision-button>
 ---
 
+# 🔒 Provision Button
+
+An unstyled button for provisioning resources. 🔒 Requires authentication.
+
 <manifold-toast alert-type="warning">
   <div><code>resource-name</code> has been deprecated in favor of <code>resource-label</code> starting in version 0.4.0.</div>
 </manifold-toast>
@@ -16,18 +20,14 @@ example: |
   <div><code>region-name</code> has been deprecated in favor of <code>region-id</code> starting in version 0.5.1.</div>
 </manifold-toast>
 
-# 🔒 Provision Button
-
-An unstyled button for provisioning resources. 🔒 Requires authentication.
-
 ## Using with Plan Selector
 
-This component needs a lot of information to do its job. For that reason, we
-recommend relying on listening from events from the [plan
-selector](#manifold-plan-selector) component. You could do that like so:
+This component needs a lot of information to do its job. For that reason, we recommend relying on
+listening from events from the [plan selector](#manifold-plan-selector) component. You could do that
+like so:
 
 ```js
-const userId = ''; // Note: Can be omitted, will be fetch automatically.
+const userId = ''; // optional, but providing will save a request
 const resourceLabel = ''; // Can be obtained from your own input
 
 function updateButton({ detail: { features, planLabel, productLabel, regionId } }) {
@@ -57,41 +57,57 @@ Set the CTA text by adding anything between the opening and closing tags:
 </manifold-data-provision-button>
 ```
 
-`slot` can be attached to any HTML or JSX element. To read more about slots, see [Stencil’s Documentation][stencil-slot]
+`slot` can be attached to any HTML or JSX element. To read more about slots, see [Stencil’s
+docs][slot].
 
 ## Events
 
 For validation, error, and success messages, it will emit custom events.
 
 ```js
-document.addEventListener('manifold-provisionButton-click', ({ detail: { resourceLabel } }) =>
-  console.info(`⌛ Provisioning ${resourceLabel} …`)
-);
-document.addEventListener(
-  'manifold-provisionButton-success',
-  ({ detail: { createdAt, resourceLabel } }) =>
-    alert(`🚀 ${resourceLabel} provisioned successfully on ${createdAt}!`)
-);
+document.addEventListener('manifold-provisionButton-click', ({ detail }) => console.log(detail));
+// {
+//   planId: '2358fw1rfjtjv0ubty0waymvd204c',
+//   productLabel: 'logdna',
+//   resourceName: 'my-resource'
+// }
+document.addEventListener('manifold-provisionButton-success', ({ detail }) => console.log(detail));
+// {
+//   createdAt: '2019-01-01 00:00:00',
+//   planId: '2358fw1rfjtjv0ubty0waymvd204c',
+//   message: 'my-resource succesfully provisioned',
+//   planId: '2358fw1rfjtjv0ubty0waymvd204c',
+//   productLabel: 'logdna',
+//   resourceId: '2358fw1rfjtjv0ubty0waymvd204c',
+//   resourceName: 'my-resource'
+// }
 document.addEventListener('manifold-provisionButton-error', ({ detail }) => console.log(detail));
-// {message: "bad_request: bad_request: No plan_id provided", resourceName: "auauau"}
+// {
+//   message: 'bad_request: No plan_id provided',
+//   productLabel: 'lodgna',
+//   planId: undefined,
+//   resourceLabel: 'my-resource'
+// }}
 document.addEventListener('manifold-provisionButton-invalid', ({ detail }) => console.log(detail));
-// {resourceLabel: "MyResourceName", message: "Must start with a lowercase letter, and use only lowercase, numbers, and hyphens."}
+// {
+//   resourceLabel: 'MyResourceName',
+//   message: 'Must start with a lowercase letter, and use only lowercase, numbers, and hyphens.'
+// }
 ```
 
-| Name                               | Returns                                               | Description                                                                                                                 |
-|------------------------------------|-------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
-| `manifold-provisionButton-click`   | `resourceLabel`                                       | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
-| `manifold-provisionButton-success` | `message`, `resourceLabel`, `resourceId`, `createdAt` | Successful provision. Returns name, along with a resource ID                                                                |
-| `manifold-provisionButton-error`   | `message`, `resourceLabel`                            | Erred provision, along with information on what went wrong.                                                                 |
-| `manifold-provisionButton-invalid` | `message`, `resourceLabel`                            | Fires if the resource name isn’t named properly.                                                                            |
+| Name                               | Returns                                                                        | Description                                                                                                                 |
+| ---------------------------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| `manifold-provisionButton-click`   | `resourceLabel`, `productLabel`, `planId`                                      | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
+| `manifold-provisionButton-success` | `message`, `resourceLabel`, `resourceId`, `productLabel`, `planId` `createdAt` | Successful provision. Returns name, along with a resource ID                                                                |
+| `manifold-provisionButton-error`   | `message`, `resourceLabel`, `productLabel`, `planId`                           | Erred provision, along with information on what went wrong.                                                                 |
+| `manifold-provisionButton-invalid` | `message`, `resourceLabel`, `productLabel`, `planId`                           | Fires if the resource name isn’t named properly.                                                                            |
 
 ## Styling
 
-Whereas other components in this system take advantage of [Shadow
-DOM][shadow-dom] encapsulation for ease of use, we figured this component
-should be customizable. As such, style it however you’d like! We recommend
-attaching styles to a parent element using any CSS-in-JS framework of your
-choice, or plain ol’ CSS.
+Whereas other components in this system take advantage of [Shadow DOM][shadow-dom] encapsulation for
+ease of use, we figured this component should be customizable. As such, style it however you’d like!
+We recommend attaching styles to a parent element using any CSS-in-JS framework of your choice, or
+plain ol’ CSS.
 
 [shadow-dom]: https://developers.google.com/web/fundamentals/web-components/shadowdom
-[stencil-slot]: https://stenciljs.com/docs/templating-jsx/
+[slot]: https://stenciljs.com/docs/templating-jsx/

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.spec.ts
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.spec.ts
@@ -27,7 +27,6 @@ async function setup({
     setAuthToken: jest.fn(),
   }),
   resourceLabel,
-  useAuth = false,
 }: {
   ownerId?: string;
   productLabel?: string;
@@ -35,7 +34,6 @@ async function setup({
   graphqlFetch?: any;
   resourceLabel?: string;
   restFetch?: any;
-  useAuth?: boolean;
 }) {
   const page = await newSpecPage({
     components: [ManifoldDataProvisionButton],

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.spec.ts
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.spec.ts
@@ -125,179 +125,179 @@ describe('<manifold-data-provision-button>', () => {
       root.appendChild(element);
       expect(fetchMock.called(/\/products\//)).toBe(false);
     });
-  });
 
-  describe('events', () => {
-    it('click', async () => {
-      const productLabel = 'click-product';
-      const resourceLabel = 'click-resource';
+    describe('events', () => {
+      it('click', async () => {
+        const productLabel = 'click-product';
+        const resourceLabel = 'click-resource';
 
-      const mockClick = jest.fn();
-      element.ownerId = 'owner-id';
-      element.productLabel = productLabel;
-      element.resourceLabel = resourceLabel;
-      const root = page.root as HTMLElement;
-      root.appendChild(element);
-      await page.waitForChanges();
+        const mockClick = jest.fn();
+        element.ownerId = 'owner-id';
+        element.productLabel = productLabel;
+        element.resourceLabel = resourceLabel;
+        const root = page.root as HTMLElement;
+        root.appendChild(element);
+        await page.waitForChanges();
 
-      const button = root.querySelector('button');
-      if (!button) {
-        throw new Error('button not found in document');
-      }
+        const button = root.querySelector('button');
+        if (!button) {
+          throw new Error('button not found in document');
+        }
 
-      // listen for event and fire
-      page.doc.addEventListener('manifold-provisionButton-click', mockClick);
-      button.click();
-
-      expect(mockClick).toBeCalledWith(
-        expect.objectContaining({
-          detail: {
-            planId: ExpandedPlan.id,
-            productLabel,
-            resourceLabel,
-          },
-        })
-      );
-    });
-
-    it('invalid: too short', async () => {
-      const productLabel = 'click-product';
-      const resourceLabel = 'x';
-
-      const mockClick = jest.fn();
-      element.ownerId = 'owner-id';
-      element.productLabel = productLabel;
-      element.resourceLabel = resourceLabel;
-      const root = page.root as HTMLElement;
-      root.appendChild(element);
-      await page.waitForChanges();
-
-      const button = root.querySelector('button');
-      if (!button) {
-        throw new Error('button not found in document');
-      }
-
-      // listen for event and fire
-      page.doc.addEventListener('manifold-provisionButton-invalid', mockClick);
-      button.click();
-
-      expect(mockClick).toBeCalledWith(
-        expect.objectContaining({
-          detail: {
-            message: 'Must be at least 3 characters',
-            planId: ExpandedPlan.id,
-            productLabel,
-            resourceLabel,
-          },
-        })
-      );
-    });
-
-    it('invalid: bad characters', async () => {
-      const resourceLabel = '🦞🦞🦞';
-      const productLabel = 'click-product';
-
-      const mockClick = jest.fn();
-      element.ownerId = 'owner-id';
-      element.productLabel = productLabel;
-      element.resourceLabel = resourceLabel;
-      const root = page.root as HTMLElement;
-      root.appendChild(element);
-      await page.waitForChanges();
-
-      const button = root.querySelector('button');
-      if (!button) {
-        throw new Error('button not found in document');
-      }
-
-      // listen for event and fire
-      page.doc.addEventListener('manifold-provisionButton-invalid', mockClick);
-      button.click();
-
-      expect(mockClick).toBeCalledWith(
-        expect.objectContaining({
-          detail: {
-            message:
-              'Must start with a lowercase letter, and use only lowercase, numbers, and hyphens',
-            planId: ExpandedPlan.id,
-            productLabel,
-            resourceLabel,
-          },
-        })
-      );
-    });
-
-    it('error', async () => {
-      const resourceLabel = 'error-resource';
-      const productLabel = 'error-product';
-      element.ownerId = 'owner-id';
-      element.productLabel = productLabel;
-      element.resourceLabel = resourceLabel;
-      const root = page.root as HTMLElement;
-      root.appendChild(element);
-      await page.waitForChanges();
-
-      const button = root.querySelector('button');
-      if (!button) {
-        throw new Error('button not found in document');
-      }
-
-      const mockClick = jest.fn();
-      await new Promise(resolve => {
         // listen for event and fire
-        mockClick.mockImplementation(() => resolve());
-        page.doc.addEventListener('manifold-provisionButton-error', mockClick);
+        page.doc.addEventListener('manifold-provisionButton-click', mockClick);
         button.click();
+
+        expect(mockClick).toBeCalledWith(
+          expect.objectContaining({
+            detail: {
+              planId: ExpandedPlan.id,
+              productLabel,
+              resourceLabel,
+            },
+          })
+        );
       });
 
-      expect(mockClick).toBeCalledWith(
-        expect.objectContaining({
-          detail: {
-            message: 'provision failed',
-            planId: ExpandedPlan.id,
-            productLabel,
-            resourceLabel,
-          },
-        })
-      );
-    });
+      it('invalid: too short', async () => {
+        const productLabel = 'click-product';
+        const resourceLabel = 'x';
 
-    it('success', async () => {
-      const resourceLabel = 'success-resource';
-      const productLabel = 'success-product';
+        const mockClick = jest.fn();
+        element.ownerId = 'owner-id';
+        element.productLabel = productLabel;
+        element.resourceLabel = resourceLabel;
+        const root = page.root as HTMLElement;
+        root.appendChild(element);
+        await page.waitForChanges();
 
-      element.ownerId = 'owner-id';
-      element.productLabel = productLabel;
-      element.resourceLabel = resourceLabel;
-      const root = page.root as HTMLElement;
-      root.appendChild(element);
-      await page.waitForChanges();
+        const button = root.querySelector('button');
+        if (!button) {
+          throw new Error('button not found in document');
+        }
 
-      const button = root.querySelector('button');
-      if (!button) {
-        throw new Error('button not found in document');
-      }
-
-      const mockClick = jest.fn();
-      await new Promise(resolve => {
         // listen for event and fire
-        mockClick.mockImplementation(() => resolve());
-        page.doc.addEventListener('manifold-provisionButton-success', mockClick);
+        page.doc.addEventListener('manifold-provisionButton-invalid', mockClick);
         button.click();
+
+        expect(mockClick).toBeCalledWith(
+          expect.objectContaining({
+            detail: {
+              message: 'Must be at least 3 characters',
+              planId: ExpandedPlan.id,
+              productLabel,
+              resourceLabel,
+            },
+          })
+        );
       });
 
-      expect(mockClick).toBeCalledWith(
-        expect.objectContaining({
-          detail: {
-            createdAt: '2019-01-01 00:00:00',
-            message: `${resourceLabel} successfully provisioned`,
-            planId: ExpandedPlan.id,
-            productLabel,
-            resourceId,
-            resourceLabel,
-          },
-        })
-      );
+      it('invalid: bad characters', async () => {
+        const resourceLabel = '🦞🦞🦞';
+        const productLabel = 'click-product';
+
+        const mockClick = jest.fn();
+        element.ownerId = 'owner-id';
+        element.productLabel = productLabel;
+        element.resourceLabel = resourceLabel;
+        const root = page.root as HTMLElement;
+        root.appendChild(element);
+        await page.waitForChanges();
+
+        const button = root.querySelector('button');
+        if (!button) {
+          throw new Error('button not found in document');
+        }
+
+        // listen for event and fire
+        page.doc.addEventListener('manifold-provisionButton-invalid', mockClick);
+        button.click();
+
+        expect(mockClick).toBeCalledWith(
+          expect.objectContaining({
+            detail: {
+              message:
+                'Must start with a lowercase letter, and use only lowercase, numbers, and hyphens',
+              planId: ExpandedPlan.id,
+              productLabel,
+              resourceLabel,
+            },
+          })
+        );
+      });
+
+      it('error', async () => {
+        const resourceLabel = 'error-resource';
+        const productLabel = 'error-product';
+        element.ownerId = 'owner-id';
+        element.productLabel = productLabel;
+        element.resourceLabel = resourceLabel;
+        const root = page.root as HTMLElement;
+        root.appendChild(element);
+        await page.waitForChanges();
+
+        const button = root.querySelector('button');
+        if (!button) {
+          throw new Error('button not found in document');
+        }
+
+        const mockClick = jest.fn();
+        await new Promise(resolve => {
+          // listen for event and fire
+          mockClick.mockImplementation(() => resolve());
+          page.doc.addEventListener('manifold-provisionButton-error', mockClick);
+          button.click();
+        });
+
+        expect(mockClick).toBeCalledWith(
+          expect.objectContaining({
+            detail: {
+              message: 'provision failed',
+              planId: ExpandedPlan.id,
+              productLabel,
+              resourceLabel,
+            },
+          })
+        );
+      });
+
+      it('success', async () => {
+        const resourceLabel = 'success-resource';
+        const productLabel = 'success-product';
+
+        element.ownerId = 'owner-id';
+        element.productLabel = productLabel;
+        element.resourceLabel = resourceLabel;
+        const root = page.root as HTMLElement;
+        root.appendChild(element);
+        await page.waitForChanges();
+
+        const button = root.querySelector('button');
+        if (!button) {
+          throw new Error('button not found in document');
+        }
+
+        const mockClick = jest.fn();
+        await new Promise(resolve => {
+          // listen for event and fire
+          mockClick.mockImplementation(() => resolve());
+          page.doc.addEventListener('manifold-provisionButton-success', mockClick);
+          button.click();
+        });
+
+        expect(mockClick).toBeCalledWith(
+          expect.objectContaining({
+            detail: {
+              createdAt: '2019-01-01 00:00:00',
+              message: `${resourceLabel} successfully provisioned`,
+              planId: ExpandedPlan.id,
+              productLabel,
+              resourceId,
+              resourceLabel,
+            },
+          })
+        );
+      });
     });
   });
 });

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.spec.ts
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.spec.ts
@@ -1,8 +1,7 @@
 import { newSpecPage } from '@stencil/core/testing';
 import fetchMock from 'fetch-mock';
 
-import { Product, ExpandedPlan, ZiggeoPlan } from '../../spec/mock/catalog';
-import { GatewayResource } from '../../spec/mock/gateway';
+import { Product, ExpandedPlan } from '../../spec/mock/catalog';
 import { connections } from '../../utils/connections';
 
 import { ManifoldDataProvisionButton } from './manifold-data-provision-button';
@@ -11,128 +10,108 @@ import { createGraphqlFetch } from '../../utils/graphqlFetch';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const graphqlEndpoint = 'http://test.com/graphql';
-const proto = ManifoldDataProvisionButton.prototype as any;
-const oldCallback = proto.componentWillLoad;
 
-proto.componentWillLoad = function() {
-  (this as any).restFetch = createRestFetch({
-    getAuthToken: jest.fn(() => '1234'),
-    wait: 10,
-    setAuthToken: jest.fn(),
-  });
-  (this as any).graphqlFetch = createGraphqlFetch({
+async function setup({
+  graphqlFetch = createGraphqlFetch({
     endpoint: graphqlEndpoint,
     getAuthToken: jest.fn(() => '1234'),
     wait: 10,
     setAuthToken: jest.fn(),
+  }),
+  ownerId,
+  planLabel,
+  productLabel,
+  restFetch = createRestFetch({
+    getAuthToken: jest.fn(() => '1234'),
+    wait: 10,
+    setAuthToken: jest.fn(),
+  }),
+  resourceLabel,
+  useAuth = false,
+}: {
+  ownerId?: string;
+  productLabel?: string;
+  planLabel?: string;
+  graphqlFetch?: any;
+  resourceLabel?: string;
+  restFetch?: any;
+  useAuth?: boolean;
+}) {
+  const page = await newSpecPage({
+    components: [ManifoldDataProvisionButton],
+    html: '<div></div>',
   });
 
-  if (oldCallback) {
-    oldCallback.call(this);
-  }
-};
+  const component = page.doc.createElement('manifold-data-provision-button');
+  if (ownerId) component.ownerId = ownerId;
+  component.graphqlFetch = graphqlFetch;
+  component.planLabel = planLabel;
+  component.productLabel = productLabel;
+  component.resourceLabel = resourceLabel;
+  component.restFetch = restFetch;
+
+  if (!page.root) throw new Error('<manifold-data-provision-button> not found in document');
+  page.root.appendChild(component);
+  await page.waitForChanges();
+  return { page, component };
+}
 
 describe('<manifold-data-provision-button>', () => {
-  it('fetches product, plan and profile id on load', () => {
-    const productLabel = 'test-product';
-    const planLabel = 'test-plan';
+  const profile = { profile: { id: '1234' } };
+  const resourceId = 'abcdefghijklmnopqrstuvwxyz123';
 
-    const provisionButton = new ManifoldDataProvisionButton();
-    provisionButton.fetchProductPlanId = jest.fn();
-    provisionButton.fetchProfileId = jest.fn();
-    provisionButton.productLabel = productLabel;
-    provisionButton.planLabel = planLabel;
-    provisionButton.componentWillLoad();
-    expect(provisionButton.fetchProductPlanId).toHaveBeenCalledWith(productLabel, planLabel);
-    expect(provisionButton.fetchProfileId).toHaveBeenCalled();
+  fetchMock.mock(graphqlEndpoint, { data: { profile } });
+  fetchMock.mock(/\/products\//, [Product]);
+  fetchMock.mock(/\/plans\//, [ExpandedPlan]);
+  fetchMock.mock(/\/resource\//, (_: any, req) => {
+    const { label } = JSON.parse(req.body as string);
+    return label.includes('error')
+      ? { status: 500, body: { message: 'provision failed' } }
+      : {
+          status: 200,
+          body: {
+            created_at: '2019-01-01 00:00:00',
+            id: resourceId,
+            label,
+          },
+        };
   });
 
-  it('does not fetch the profile id if set on load', () => {
-    const provisionButton = new ManifoldDataProvisionButton();
-    provisionButton.fetchProfileId = jest.fn();
-    provisionButton.ownerId = '1234';
-    provisionButton.componentWillLoad();
+  beforeEach(() => fetchMock.resetHistory());
 
-    expect(provisionButton.fetchProfileId).not.toHaveBeenCalled();
-  });
-
-  it('fetches product and plan id on change', () => {
-    const newProduct = 'new-product';
-    const newPlan = 'new-plan';
-
-    const provisionButton = new ManifoldDataProvisionButton();
-    provisionButton.fetchProductPlanId = jest.fn();
-    provisionButton.productLabel = 'old-product';
-    provisionButton.planLabel = 'old-plan';
-
-    provisionButton.productChange(newProduct);
-    expect(provisionButton.fetchProductPlanId).toHaveBeenCalledWith(newProduct, 'old-plan');
-
-    provisionButton.planChange(newPlan);
-    expect(provisionButton.fetchProductPlanId).toHaveBeenCalledWith('old-product', newPlan);
-  });
-
-  describe('when created with product and plans labels', () => {
-    afterEach(() => {
-      fetchMock.restore();
+  describe('v0 API', () => {
+    it('[owner-id]: fetches if missing', async () => {
+      await setup({ productLabel: 'test', planLabel: 'test' });
+      expect(fetchMock.called(graphqlEndpoint)).toBe(true);
     });
 
-    beforeEach(() => {
-      fetchMock.mock(graphqlEndpoint, { data: { profile: { id: '1234' } } });
+    it('[owner-id]: doesn’t fetch if set', async () => {
+      const { page } = await setup({ ownerId: '5678', productLabel: 'test', planLabel: 'test' });
+      const provisionButton =
+        page.root && page.root.querySelector('manifold-data-provision-button');
+      if (!provisionButton) throw new Error('provision button not found');
+
+      expect(fetchMock.called(graphqlEndpoint)).toBe(false);
+      expect(provisionButton.ownerId).toEqual('5678');
     });
 
-    it('will fetch the products and find the plan', async () => {
-      const productLabel = 'test-product';
+    it('[plan-label]: fetches by plan label if specified', async () => {
       const planLabel = 'test-plan';
+      await setup({ ownerId: 'test-owner', productLabel: 'test-product', planLabel });
 
-      fetchMock
-        .mock(`${connections.prod.catalog}/products/?label=${productLabel}`, [Product])
-        .mock(`${connections.prod.catalog}/plans/?product_id=${Product.id}&label=${planLabel}`, [
-          ExpandedPlan,
-        ]);
-
-      const page = await newSpecPage({
-        components: [ManifoldDataProvisionButton],
-        html: `
-          <manifold-data-provision-button
-            product-label="${productLabel}"
-            plan-label="${planLabel}"
-          >Provision</manifold-data-provision-button>
-        `,
-      });
-
-      expect(fetchMock.called(`${connections.prod.catalog}/products/?label=${productLabel}`)).toBe(
-        true
-      );
       expect(
         fetchMock.called(
           `${connections.prod.catalog}/plans/?product_id=${Product.id}&label=${planLabel}`
         )
       ).toBe(true);
-
-      const root = page.rootInstance as ManifoldDataProvisionButton;
-      expect(root.productId).toEqual(Product.id);
-      expect(root.planId).toEqual(ExpandedPlan.id);
     });
 
-    it('will fetch the products and find the plan even without a plan label', async () => {
+    it('[product-label]: fetches product by label', async () => {
       const productLabel = 'test-product';
-
-      fetchMock
-        .mock(`${connections.prod.catalog}/products/?label=${productLabel}`, [Product])
-        .mock(`${connections.prod.catalog}/plans/?product_id=${Product.id}`, [
-          ExpandedPlan,
-          ZiggeoPlan,
-        ]);
-
-      const page = await newSpecPage({
-        components: [ManifoldDataProvisionButton],
-        html: `
-          <manifold-data-provision-button
-            product-label="${productLabel}"
-          >Provision</manifold-data-provision-button>
-        `,
-      });
+      const { page } = await setup({ productLabel });
+      const provisionButton =
+        page.root && page.root.querySelector('manifold-data-provision-button');
+      if (!provisionButton) throw new Error('provision button not found');
 
       expect(fetchMock.called(`${connections.prod.catalog}/products/?label=${productLabel}`)).toBe(
         true
@@ -140,242 +119,151 @@ describe('<manifold-data-provision-button>', () => {
       expect(fetchMock.called(`${connections.prod.catalog}/plans/?product_id=${Product.id}`)).toBe(
         true
       );
-
-      const root = page.rootInstance as ManifoldDataProvisionButton;
-      expect(root.productId).toEqual(Product.id);
-      expect(root.planId).toEqual(ExpandedPlan.id);
     });
 
-    it('will do nothing if no product label is given', async () => {
-      fetchMock.mock(`${connections.prod.catalog}/products/`, [Product]);
-
-      await newSpecPage({
-        components: [ManifoldDataProvisionButton],
-        html: `
-          <manifold-data-provision-button>Provision</manifold-data-provision-button>
-        `,
-      });
-
-      expect(fetchMock.called(`${connections.prod.catalog}/products/`)).toBe(false);
-    });
-
-    it('will do nothing if the products return an invalid value', async () => {
-      const productLabel = 'test-product';
-
-      fetchMock
-        .mock(`${connections.prod.catalog}/products/?label=${productLabel}`, {})
-        .mock(`${connections.prod.catalog}/plans/?product_id=${Product.id}`, {});
-
-      const page = await newSpecPage({
-        components: [ManifoldDataProvisionButton],
-        html: `
-          <manifold-data-provision-button
-            product-label="${productLabel}"
-          >Provision</manifold-data-provision-button>
-        `,
-      });
-
-      expect(fetchMock.called(`${connections.prod.catalog}/products/?label=${productLabel}`)).toBe(
-        true
-      );
-
-      const root = page.rootInstance as ManifoldDataProvisionButton;
-      expect(root.productId).toEqual('');
-    });
-
-    it('will do nothing if the products return an invalid value', async () => {
-      const productLabel = 'test-product';
-
-      fetchMock
-        .mock(`${connections.prod.catalog}/products/?label=${productLabel}`, [Product])
-        .mock(`${connections.prod.catalog}/plans/?product_id=${Product.id}`, {});
-
-      const page = await newSpecPage({
-        components: [ManifoldDataProvisionButton],
-        html: `
-          <manifold-data-provision-button
-            product-label="${productLabel}"
-          >Provision</manifold-data-provision-button>
-        `,
-      });
-
-      expect(fetchMock.called(`${connections.prod.catalog}/products/?label=${productLabel}`)).toBe(
-        true
-      );
-      expect(fetchMock.called(`${connections.prod.catalog}/plans/?product_id=${Product.id}`)).toBe(
-        true
-      );
-
-      const root = page.rootInstance as ManifoldDataProvisionButton;
-      expect(root.productId).toEqual('');
-      expect(root.planId).toEqual('');
+    it('[product-label]: doesn’t fetch if missing', async () => {
+      await setup({});
+      expect(fetchMock.called(/\/products\//)).toBe(false);
     });
   });
 
-  describe('when created with no owner ID', () => {
-    afterEach(() => {
-      fetchMock.restore();
-    });
+  describe('events', () => {
+    it('click', async () => {
+      const productLabel = 'click-product';
+      const resourceLabel = 'click-resource';
 
-    const profile = { profile: { id: '1234' } };
+      const mockClick = jest.fn();
+      const { page } = await setup({ ownerId: 'owner-id', productLabel, resourceLabel });
 
-    beforeEach(() => {
-      fetchMock
-        .mock(`${connections.prod.catalog}/products/?label=test`, [Product])
-        .mock(`${connections.prod.catalog}/plans/?product_id=${Product.id}&label=test`, [
-          ExpandedPlan,
-        ])
-        .mock(graphqlEndpoint, { data: profile });
-    });
+      const button = page.root && page.root.querySelector('button');
+      if (!button) throw new Error('button not found in document');
 
-    it('will fetch the owner id on load', async () => {
-      const page = await newSpecPage({
-        components: [ManifoldDataProvisionButton],
-        html: `
-          <manifold-data-provision-button
-            product-label="test"
-            plan-label="test"
-          >Provision</manifold-data-provision-button>
-        `,
-      });
-
-      const root = page.rootInstance as ManifoldDataProvisionButton;
-
-      expect(fetchMock.called(graphqlEndpoint)).toBe(true);
-      expect(root.ownerId).toBe(profile.profile.id);
-    });
-
-    it('will do nothing if the owner id is set', async () => {
-      const page = await newSpecPage({
-        components: [ManifoldDataProvisionButton],
-        html: `
-          <manifold-data-provision-button
-            product-label="test"
-            plan-label="test"
-            owner-id="5678"
-          >Provision</manifold-data-provision-button>
-        `,
-      });
-
-      const root = page.rootInstance as ManifoldDataProvisionButton;
-
-      expect(fetchMock.called(graphqlEndpoint)).toBe(false);
-      expect(root.ownerId).toEqual('5678');
-    });
-  });
-
-  describe('When sending a request to provision', () => {
-    afterEach(() => {
-      fetchMock.restore();
-    });
-
-    beforeEach(() => {
-      fetchMock
-        .mock(/.*\/products\/.*/, [Product])
-        .mock(/.*\/plans\/.*/, [ExpandedPlan])
-        .mock(graphqlEndpoint, { data: { profile: { id: '1234' } } });
-    });
-
-    it('will trigger a dom event on successful provision', async () => {
-      fetchMock.mock(`${connections.prod.gateway}/resource/`, GatewayResource);
-
-      const page = await newSpecPage({
-        components: [ManifoldDataProvisionButton],
-        html: `
-          <manifold-data-provision-button
-            product-label="test"
-            owner-id="1234"
-            resource-label="test"
-          >Provision</manifold-data-provision-button>
-        `,
-      });
-
-      const success = jest.fn();
-      page.doc.addEventListener('manifold-provisionButton-success', success);
-
-      const button = page.doc.querySelector('button[type=submit]') as HTMLButtonElement;
+      // listen for event and fire
+      page.doc.addEventListener('manifold-provisionButton-click', mockClick);
       button.click();
-      await page.waitForChanges();
 
-      expect(fetchMock.called(`${connections.prod.gateway}/resource/`)).toBe(true);
-      expect(success).toHaveBeenCalledWith(
+      expect(mockClick).toBeCalledWith(
         expect.objectContaining({
           detail: {
-            createdAt: GatewayResource.created_at,
-            message: 'test successfully provisioned',
-            resourceId: GatewayResource.id,
-            resourceLabel: GatewayResource.label,
+            planId: ExpandedPlan.id,
+            productLabel,
+            resourceLabel,
           },
         })
       );
     });
 
-    it('will trigger a dom event on failed provision', async () => {
-      fetchMock.mock(`${connections.prod.gateway}/resource/`, {
-        status: 500,
-        body: {
-          message: 'ohnoes',
-        },
-      });
+    it('invalid: too short', async () => {
+      const productLabel = 'click-product';
+      const resourceLabel = 'x';
 
-      const page = await newSpecPage({
-        components: [ManifoldDataProvisionButton],
-        html: `
-          <manifold-data-provision-button
-            product-label="test"
-            owner-id="1234"
-            resource-label="test"
-          >Provision</manifold-data-provision-button>
-        `,
-      });
+      const mockClick = jest.fn();
+      const { page } = await setup({ ownerId: 'owner-id', productLabel, resourceLabel });
 
-      const instance = page.rootInstance as ManifoldDataProvisionButton;
-      instance.error.emit = jest.fn();
+      const button = page.root && page.root.querySelector('button');
+      if (!button) throw new Error('button not found in document');
 
-      expect.assertions(2);
-      return instance.provision().catch(() => {
-        expect(fetchMock.called(`${connections.prod.gateway}/resource/`)).toBe(true);
-        expect(instance.error.emit).toHaveBeenCalledWith({
-          message: 'ohnoes',
-          resourceLabel: 'test',
-        });
-      });
+      // listen for event and fire
+      page.doc.addEventListener('manifold-provisionButton-invalid', mockClick);
+      button.click();
+
+      expect(mockClick).toBeCalledWith(
+        expect.objectContaining({
+          detail: {
+            message: 'Must be at least 3 characters',
+            planId: ExpandedPlan.id,
+            productLabel,
+            resourceLabel,
+          },
+        })
+      );
     });
 
-    it('will trigger a dom event on an invalid resource name', async () => {
-      fetchMock.mock(`${connections.prod.gateway}/resource/`, 500);
+    it('invalid: bad characters', async () => {
+      const resourceLabel = '🦞🦞🦞';
+      const productLabel = 'click-product';
 
-      const page = await newSpecPage({
-        components: [ManifoldDataProvisionButton],
-        html: `
-          <manifold-data-provision-button
-            product-label="test"
-            owner-id="1234"
-            resource-label="t"
-          >Provision</manifold-data-provision-button>
-        `,
+      const mockClick = jest.fn();
+      const { page } = await setup({ ownerId: 'owner-id', productLabel, resourceLabel });
+
+      const button = page.root && page.root.querySelector('button');
+      if (!button) throw new Error('button not found in document');
+
+      // listen for event and fire
+      page.doc.addEventListener('manifold-provisionButton-invalid', mockClick);
+      button.click();
+
+      expect(mockClick).toBeCalledWith(
+        expect.objectContaining({
+          detail: {
+            message:
+              'Must start with a lowercase letter, and use only lowercase, numbers, and hyphens',
+            planId: ExpandedPlan.id,
+            productLabel,
+            resourceLabel,
+          },
+        })
+      );
+    });
+
+    it('error', async () => {
+      const resourceLabel = 'error-resource';
+      const productLabel = 'error-product';
+
+      const { page } = await setup({ ownerId: 'owner-id', productLabel, resourceLabel });
+
+      const button = page.root && page.root.querySelector('button');
+      if (!button) throw new Error('button not found in document');
+
+      const mockClick = jest.fn();
+      await new Promise(resolve => {
+        // listen for event and fire
+        mockClick.mockImplementation(() => resolve());
+        page.doc.addEventListener('manifold-provisionButton-error', mockClick);
+        button.click();
       });
 
-      const instance = page.rootInstance as ManifoldDataProvisionButton;
-      instance.invalid.emit = jest.fn();
+      expect(mockClick).toBeCalledWith(
+        expect.objectContaining({
+          detail: {
+            message: 'provision failed',
+            planId: ExpandedPlan.id,
+            productLabel,
+            resourceLabel,
+          },
+        })
+      );
+    });
 
-      await instance.provision();
+    it('success', async () => {
+      const resourceLabel = 'success-resource';
+      const productLabel = 'success-product';
 
-      expect(fetchMock.called(`${connections.prod.gateway}/resource/`)).toBe(false);
-      expect(instance.invalid.emit).toHaveBeenCalledWith({
-        message: 'Must be at least 3 characters.',
-        resourceLabel: 't',
+      const { page } = await setup({ ownerId: 'owner-id', productLabel, resourceLabel });
+
+      const button = page.root && page.root.querySelector('button');
+      if (!button) throw new Error('button not found in document');
+
+      const mockClick = jest.fn();
+      await new Promise(resolve => {
+        // listen for event and fire
+        mockClick.mockImplementation(() => resolve());
+        page.doc.addEventListener('manifold-provisionButton-success', mockClick);
+        button.click();
       });
 
-      instance.resourceLabel = 'Test';
-      await instance.provision();
-
-      expect(fetchMock.called(`${connections.prod.gateway}/resource/`)).toBe(false);
-      expect(instance.invalid.emit).toHaveBeenCalledWith({
-        message:
-          'Must start with a lowercase letter, and use only lowercase, numbers, and hyphens.',
-        resourceLabel: 'Test',
-      });
+      expect(mockClick).toBeCalledWith(
+        expect.objectContaining({
+          detail: {
+            createdAt: '2019-01-01 00:00:00',
+            message: `${resourceLabel} successfully provisioned`,
+            planId: ExpandedPlan.id,
+            productLabel,
+            resourceId,
+            resourceLabel,
+          },
+        })
+      );
     });
   });
 });

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.spec.ts
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.spec.ts
@@ -87,7 +87,9 @@ describe('<manifold-data-provision-button>', () => {
       const { page } = await setup({ ownerId: '5678', productLabel: 'test', planLabel: 'test' });
       const provisionButton =
         page.root && page.root.querySelector('manifold-data-provision-button');
-      if (!provisionButton) throw new Error('provision button not found');
+      if (!provisionButton) {
+        throw new Error('provision button not found');
+      }
 
       expect(fetchMock.called(graphqlEndpoint)).toBe(false);
       expect(provisionButton.ownerId).toEqual('5678');
@@ -109,7 +111,9 @@ describe('<manifold-data-provision-button>', () => {
       const { page } = await setup({ productLabel });
       const provisionButton =
         page.root && page.root.querySelector('manifold-data-provision-button');
-      if (!provisionButton) throw new Error('provision button not found');
+      if (!provisionButton) {
+        throw new Error('provision button not found');
+      }
 
       expect(fetchMock.called(`${connections.prod.catalog}/products/?label=${productLabel}`)).toBe(
         true
@@ -159,7 +163,9 @@ describe('<manifold-data-provision-button>', () => {
       const { page } = await setup({ ownerId: 'owner-id', productLabel, resourceLabel });
 
       const button = page.root && page.root.querySelector('button');
-      if (!button) throw new Error('button not found in document');
+      if (!button) {
+        throw new Error('button not found in document');
+      }
 
       // listen for event and fire
       page.doc.addEventListener('manifold-provisionButton-invalid', mockClick);
@@ -185,7 +191,9 @@ describe('<manifold-data-provision-button>', () => {
       const { page } = await setup({ ownerId: 'owner-id', productLabel, resourceLabel });
 
       const button = page.root && page.root.querySelector('button');
-      if (!button) throw new Error('button not found in document');
+      if (!button) {
+        throw new Error('button not found in document');
+      }
 
       // listen for event and fire
       page.doc.addEventListener('manifold-provisionButton-invalid', mockClick);
@@ -211,7 +219,9 @@ describe('<manifold-data-provision-button>', () => {
       const { page } = await setup({ ownerId: 'owner-id', productLabel, resourceLabel });
 
       const button = page.root && page.root.querySelector('button');
-      if (!button) throw new Error('button not found in document');
+      if (!button) {
+        throw new Error('button not found in document');
+      }
 
       const mockClick = jest.fn();
       await new Promise(resolve => {
@@ -240,7 +250,9 @@ describe('<manifold-data-provision-button>', () => {
       const { page } = await setup({ ownerId: 'owner-id', productLabel, resourceLabel });
 
       const button = page.root && page.root.querySelector('button');
-      if (!button) throw new Error('button not found in document');
+      if (!button) {
+        throw new Error('button not found in document');
+      }
 
       const mockClick = jest.fn();
       await new Promise(resolve => {


### PR DESCRIPTION
## Reason for change

In exploring some auth PRs last week, I spent a little time improving the events & tests for `<manifold-data-provision-button>`. We didn’t keep the auth work, but I wanted to keep this improved test.

### Changes:
- the events now test DOM events and event names, rather than only testing the event dispatcher.
- more data is now passed for each event, such as `planId`, because why not?
- missing tests were added, such as some of the invalid event. This just ensures that our hard work doesn’t accidentally disappear.

## Testing

Tests should pass; review the updated docs page to make sure the events emitted are correct.

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [x] **Prop changes**: [docs][docs] were updated
- [x] **Prop changes**: E2E tests were updated, testing from the highest level possible

[docs]: https://ui.sandbox.manifold.co
