### PR TITLE
Mock resource endpoints in the docs

### DIFF
--- a/docs/docs/components/manifold-resource-list.md
+++ b/docs/docs/components/manifold-resource-list.md
@@ -1,10 +1,7 @@
 ---
 title: 🔒 Resource List
 path: /components/resource-list
-example: |
-  <manifold-connection>
-    <manifold-resource-list paused></manifold-resource-list>
-  </manifold-connection>
+example: <manifold-resource-list></manifold-resource-list>
 ---
 
 <manifold-toast alert-type="warning">

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -7,6 +7,7 @@ import fetchMock from 'fetch-mock';
 import Page from '../components/Page';
 import theme from '../lib/theme';
 import { mockPlans, mockProducts, mockProviders, mockRegions } from '../utils/mockCatalog';
+import { mockResources } from '../utils/mockMarketplace';
 
 fetchMock.config.fallbackToNetwork = true;
 fetchMock.config.overwriteRoutes = true;
@@ -41,10 +42,10 @@ function HomePage({ data }: HomePageProps) {
     regions,
   } = data;
   const currentPage = page || home;
-  const links = edges.map(({ node: { frontmatter: { title, path } } }) => {
-    const link: [string, string] = [path, title];
-    return link;
-  });
+  const links = edges.map(({ node: { frontmatter: { title, path } } }): [string, string] => [
+    path,
+    title,
+  ]);
 
   const catalogProviders = providers.edges.map(prod => prod.node.data);
   const catalogProducts = products.edges.map(prod => prod.node.data);
@@ -55,6 +56,8 @@ function HomePage({ data }: HomePageProps) {
   mockProducts(catalogProducts);
   mockPlans(catalogPlans);
   mockRegions(catalogRegions);
+  // Mock marketplace calls to return fake resource data
+  mockResources();
 
   return (
     <ThemeProvider theme={theme}>

--- a/docs/src/utils/mockMarketplace.ts
+++ b/docs/src/utils/mockMarketplace.ts
@@ -1,0 +1,94 @@
+import fetchMock from 'fetch-mock';
+import { Marketplace } from '@manifoldco/ui/dist/types/types/marketplace';
+import { Provisioning } from '@manifoldco/ui/dist/types/types/provisioning';
+
+const resources: Marketplace.Resource[] = [
+  {
+    id: '1',
+    type: 'resource',
+    version: 1,
+    body: {
+      label: 'logging',
+      name: 'Logging',
+      product_id: '234qkjvrptpy3thna4qttwt7m2nf6',
+      plan_id: '2351u7mty4bkwtwqdvzmbmw1w63w2',
+      region_id: '1234',
+      source: 'catalog',
+      owner_id: '/user/1234',
+      features: {},
+      created_at: '',
+      updated_at: '',
+    },
+  },
+  {
+    id: 'provisioning',
+    type: 'resource',
+    version: 1,
+    body: {
+      label: 'cms',
+      name: 'CMS',
+      product_id: '234qqzb2wm6gavkvaqr9e6b54j9dg',
+      plan_id: '2351kz26adxddkbewu644wx4b186y',
+      region_id: '1234',
+      source: 'catalog',
+      owner_id: '/user/1234',
+      features: {},
+      created_at: '',
+      updated_at: '',
+    },
+  },
+  {
+    id: 'deprovisioning',
+    type: 'resource',
+    version: 1,
+    body: {
+      label: 'test',
+      name: 'Test',
+      product_id: '234qkjvrptpy3thna4qttwt7m2nf6',
+      plan_id: '2351u7mty4bkwtwqdvzmbmw1w63w2',
+      region_id: '1234',
+      source: 'catalog',
+      owner_id: '/user/1234',
+      features: {},
+      created_at: '',
+      updated_at: '',
+    },
+  },
+];
+
+const operations: Provisioning.Operation[] = [
+  {
+    id: '1',
+    version: 1,
+    type: 'operation',
+    body: {
+      resource_id: 'provisioning',
+      name: 'CMS',
+      label: 'cms',
+      state: 'provision',
+      type: 'provision',
+      product_id: '234qqzb2wm6gavkvaqr9e6b54j9dg',
+      plan_id: '2351kz26adxddkbewu644wx4b186y',
+      region_id: '1234',
+      user_id: '/user/1234',
+      message: 'provisioning',
+    } as Provisioning.provision,
+  },
+  {
+    id: '2',
+    version: 1,
+    type: 'operation',
+    body: {
+      resource_id: 'deprovisioning',
+      user_id: '/user/1234',
+      message: 'deprovisioning',
+      type: 'deprovision',
+      state: 'deprovision',
+    } as Provisioning.deprovision,
+  },
+];
+
+export const mockResources = () => {
+  fetchMock.mock('express:/v1/resources/', resources);
+  fetchMock.mock('express:/v1/operations/', operations);
+};

--- a/src/components/manifold-mock-resource/manifold-mock-resource.tsx
+++ b/src/components/manifold-mock-resource/manifold-mock-resource.tsx
@@ -949,7 +949,7 @@ export class ManifoldMockResource {
     window.setTimeout(() => {
       this.loading = false;
       this.resource = this.mock;
-    }, 2000);
+    }, 1000);
   }
 
   @logger()

--- a/src/components/manifold-resource-list/manifold-resource-list.tsx
+++ b/src/components/manifold-resource-list/manifold-resource-list.tsx
@@ -129,7 +129,7 @@ export class ManifoldResourceList {
               | Provisioning.transfer
               | Provisioning.deprovision = operation.body;
 
-            // Don't run this code is the operation is done, fallback to the simpler resource code.
+            // Don't run this code if the operation is done, fallback to the simpler resource code.
             if (opBody.state === 'done') {
               return;
             }


### PR DESCRIPTION
## Reason for change

This PR hardcodes some data into the docs and mock all fetch calls made to the LIST resources endpoint and the LIST operations endpoint. The goal is to make the list resource page work properly without having to implement an auth system in our docs.

<img width="1362" alt="Capture d’écran 2019-08-27 à 11 09 08" src="https://user-images.githubusercontent.com/20424444/63784702-0cc32300-c8bd-11e9-8fdb-2b6c85881545.png">


## Testing

Test with the docs, view the list resources component's page.

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [x] **Prop changes**: [docs][docs] were updated
- [x] **Prop changes**: E2E tests were updated, testing from the highest level possible

[docs]: https://ui.sandbox.manifold.co
