### PR TITLE
Changed the docs fetching to add a timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Changed the docs fetch mocking to now wait for the real request duration. This duration is obtained at build time from the manifold APIs.
+
 ## [v0.5.8]
 
 ### Fixed

--- a/docs/plugins/gatsby-source-mayflower/gatsby-node.js
+++ b/docs/plugins/gatsby-source-mayflower/gatsby-node.js
@@ -108,6 +108,7 @@ exports.sourceNodes = async ({ actions, createNodeId, createContentDigest }, con
         });
       }
 
+      const start = new Date().getTime();
       // Fetch all the records in one go
       // eslint-disable-next-line no-await-in-loop
       const entities = await fetch(endpoint.path.toString(), {
@@ -116,17 +117,20 @@ exports.sourceNodes = async ({ actions, createNodeId, createContentDigest }, con
         body: endpoint.body,
       }).then(response => response.json());
 
+      const end = new Date().getTime();
+
       results[api][endpoint.name] = entities.map(entity => ({
         entity,
         endpoint,
-        processed: processNode(
+        processed: processNode({
           entity,
-          endpoint.method,
+          method: endpoint.method,
           api,
-          endpoint.name,
+          endpoint: endpoint.name,
+          duration: end - start,
           createNodeId,
-          createContentDigest
-        ),
+          createContentDigest,
+        }),
       }));
     }
 

--- a/docs/plugins/gatsby-source-mayflower/processNode.js
+++ b/docs/plugins/gatsby-source-mayflower/processNode.js
@@ -1,14 +1,22 @@
-module.exports = (node, method, api, endpoint, createNodeId, createContentDigest) => ({
-  id: createNodeId(node.id),
+module.exports = ({
+  entity,
+  method,
+  api,
+  duration,
+  endpoint,
+  createNodeId,
+  createContentDigest,
+}) => ({
+  id: createNodeId(entity.id),
   parent: null,
   children: [],
   mediaType: 'application/json',
-  data: node,
+  data: entity,
+  requestDuration: duration,
   internal: {
     type: `${method}${api.charAt(0).toUpperCase() + api.slice(1)}${endpoint
       .charAt(0)
       .toUpperCase() + endpoint.slice(1)}`,
-    content: JSON.stringify(node.body || node),
-    contentDigest: createContentDigest(node.body || node),
+    contentDigest: createContentDigest(entity.body || entity),
   },
 });

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -21,10 +21,10 @@ interface HomePageProps {
     home: MarkdownRemark.Data;
     page: MarkdownRemark.Data;
     toc: { edges: { node: MarkdownRemark.Data }[] };
-    providers: { edges: { node: { data: Manifold.ManifoldNode } }[] };
-    products: { edges: { node: { data: Manifold.ManifoldNode } }[] };
-    plans: { edges: { node: { data: Manifold.ManifoldNode } }[] };
-    regions: { edges: { node: { data: Manifold.ManifoldNode } }[] };
+    providers: { edges: { node: { data: Manifold.ManifoldNode; requestDuration: number } }[] };
+    products: { edges: { node: { data: Manifold.ManifoldNode; requestDuration: number } }[] };
+    plans: { edges: { node: { data: Manifold.ManifoldNode; requestDuration: number } }[] };
+    regions: { edges: { node: { data: Manifold.ManifoldNode; requestDuration: number } }[] };
   };
 }
 
@@ -48,14 +48,18 @@ function HomePage({ data }: HomePageProps) {
   ]);
 
   const catalogProviders = providers.edges.map(prod => prod.node.data);
+  const catalogProviderRequestDuration = providers.edges[0].node.requestDuration;
   const catalogProducts = products.edges.map(prod => prod.node.data);
+  const catalogProductsRequestDuration = products.edges[0].node.requestDuration;
   const catalogPlans = plans.edges.map(prod => prod.node.data);
+  const catalogPlansRequestDuration = plans.edges[0].node.requestDuration;
   const catalogRegions = regions.edges.map(prod => prod.node.data);
+  const catalogRegionsRequestDuration = regions.edges[0].node.requestDuration;
   // Mock catalog calls to always return the latest catalog data
-  mockProviders(catalogProviders);
-  mockProducts(catalogProducts);
-  mockPlans(catalogPlans);
-  mockRegions(catalogRegions);
+  mockProviders(catalogProviders, catalogProviderRequestDuration);
+  mockProducts(catalogProducts, catalogProductsRequestDuration);
+  mockPlans(catalogPlans, catalogPlansRequestDuration);
+  mockRegions(catalogRegions, catalogRegionsRequestDuration);
   // Mock marketplace calls to return fake resource data
   mockResources();
 
@@ -95,6 +99,7 @@ export const query = graphql`
     providers: allGetCatalogProviders {
       edges {
         node {
+          requestDuration
           data {
             id
             type
@@ -115,6 +120,7 @@ export const query = graphql`
     products: allGetCatalogProducts {
       edges {
         node {
+          requestDuration
           data {
             id
             body {
@@ -202,6 +208,7 @@ export const query = graphql`
     plans: allGetCatalogPlans {
       edges {
         node {
+          requestDuration
           data {
             id
             type
@@ -280,6 +287,7 @@ export const query = graphql`
     regions: allGetCatalogRegions {
       edges {
         node {
+          requestDuration
           data {
             id
             version

--- a/docs/src/utils/mockCatalog.ts
+++ b/docs/src/utils/mockCatalog.ts
@@ -6,8 +6,12 @@ if (typeof window !== 'undefined') {
   realFetch = fetch;
 }
 
-export const mockProviders = (providers: Manifold.ManifoldNode[]) => {
-  fetchMock.mock('express:/v1/providers/:id', url => {
+const waitForDuration = (time: number) => new Promise(resolve => setTimeout(resolve, time));
+
+export const mockProviders = (providers: Manifold.ManifoldNode[], duration: number) => {
+  fetchMock.mock('express:/v1/providers/:id', async url => {
+    await waitForDuration(duration);
+
     const result = /v1\/providers\/([^/]+?)(?:\/)?$/i.exec(url);
     if (result) {
       const id = result[1];
@@ -22,7 +26,9 @@ export const mockProviders = (providers: Manifold.ManifoldNode[]) => {
     }
     return 404;
   });
-  fetchMock.mock('express:/v1/providers/', url => {
+  fetchMock.mock('express:/v1/providers/', async url => {
+    await waitForDuration(duration);
+
     const realUrl = new URL(url);
     if (realUrl.searchParams.has('label')) {
       const label = realUrl.searchParams.get('label');
@@ -43,8 +49,10 @@ export const mockProviders = (providers: Manifold.ManifoldNode[]) => {
   });
 };
 
-export const mockProducts = (products: Manifold.ManifoldNode[]) => {
-  fetchMock.mock('express:/v1/products/:id', url => {
+export const mockProducts = (products: Manifold.ManifoldNode[], duration: number) => {
+  fetchMock.mock('express:/v1/products/:id', async url => {
+    await waitForDuration(duration);
+
     const result = /v1\/products\/([^/]+?)(?:\/)?$/i.exec(url);
     if (result) {
       const id = result[1];
@@ -59,7 +67,9 @@ export const mockProducts = (products: Manifold.ManifoldNode[]) => {
     }
     return 404;
   });
-  fetchMock.mock('express:/v1/products', url => {
+  fetchMock.mock('express:/v1/products', async url => {
+    await waitForDuration(duration);
+
     const realUrl = new URL(url);
     const validProducts = products.filter((node: Manifold.ManifoldNode) => {
       const body = node.body as Manifold.ProductBody;
@@ -96,8 +106,10 @@ export const mockProducts = (products: Manifold.ManifoldNode[]) => {
   });
 };
 
-export const mockPlans = (plans: Manifold.ManifoldNode[]) => {
-  fetchMock.mock('express:/v1/plans/:id', url => {
+export const mockPlans = (plans: Manifold.ManifoldNode[], duration: number) => {
+  fetchMock.mock('express:/v1/plans/:id', async url => {
+    await waitForDuration(duration);
+
     const result = /v1\/plans\/([^/]+?)(?:\/)?$/i.exec(url);
     if (result) {
       const id = result[1];
@@ -112,7 +124,9 @@ export const mockPlans = (plans: Manifold.ManifoldNode[]) => {
     }
     return 404;
   });
-  fetchMock.mock('express:/v1/plans', url => {
+  fetchMock.mock('express:/v1/plans', async url => {
+    await waitForDuration(duration);
+
     const realUrl = new URL(url);
     const validPlans = plans.filter((node: Manifold.ManifoldNode) => {
       const body = node.body as Manifold.PlanBody;
@@ -158,8 +172,10 @@ export const mockPlans = (plans: Manifold.ManifoldNode[]) => {
   });
 };
 
-export const mockRegions = (regions: Manifold.ManifoldNode[]) => {
-  fetchMock.mock('express:/v1/regions/:id', url => {
+export const mockRegions = (regions: Manifold.ManifoldNode[], duration: number) => {
+  fetchMock.mock('express:/v1/regions/:id', async url => {
+    await waitForDuration(duration);
+
     const result = /v1\/regions\/([^/]+?)(?:\/)?$/i.exec(url);
     if (result) {
       const id = result[1];
@@ -174,7 +190,9 @@ export const mockRegions = (regions: Manifold.ManifoldNode[]) => {
     }
     return 404;
   });
-  fetchMock.mock('express:/v1/regions', url => {
+  fetchMock.mock('express:/v1/regions', async url => {
+    await waitForDuration(duration);
+
     const realUrl = new URL(url);
     return {
       status: 200,

--- a/docs/src/utils/mockMarketplace.ts
+++ b/docs/src/utils/mockMarketplace.ts
@@ -89,6 +89,12 @@ const operations: Provisioning.Operation[] = [
 ];
 
 export const mockResources = () => {
-  fetchMock.mock('express:/v1/resources/', resources);
-  fetchMock.mock('express:/v1/operations/', operations);
+  fetchMock.mock(
+    'express:/v1/resources/',
+    new Promise(res => setTimeout(() => res(resources), 300))
+  );
+  fetchMock.mock(
+    'express:/v1/operations/',
+    new Promise(res => setTimeout(() => res(operations), 300))
+  );
 };

--- a/src/components/manifold-mock-resource/manifold-mock-resource.tsx
+++ b/src/components/manifold-mock-resource/manifold-mock-resource.tsx
@@ -949,7 +949,7 @@ export class ManifoldMockResource {
     window.setTimeout(() => {
       this.loading = false;
       this.resource = this.mock;
-    }, 1000);
+    }, 300);
   }
 
   @logger()


### PR DESCRIPTION
Work is related to manifoldco/engineering#9042

## Reason for change

The mocked fetch function in the docs will now wait for a certain amount of time before resolving, to ensure that the docs are as close as possible to the real life loading times.

## Testing

Test with the docs. The product or plans components should now display the loading states for a few milliseconds rather than be automatically loaded.

## Checklist

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [x] **Prop changes**: [docs][docs] were updated
- [x] **Prop changes**: E2E tests were updated, testing from the highest level possible

[docs]: https://ui.sandbox.manifold.co
