### PR TITLE
Fix Git tags

### DIFF
--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -23,7 +23,7 @@ FILES_TO_COPY.forEach(file => copySync(resolve(__dirname, '..', file), resolve(W
 // 2. Read Git tag
 let version;
 try {
-  version = execSync('git describe --abbrev=0 --tags --exact-match')
+  version = execSync('git describe --abbrev=0 --tags')
     .toString()
     .replace('v', '')
     .replace('\n', '');

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -14,7 +14,7 @@ const SELECT_FLAG = /-.*/; // Selects anything after a hyphen, or nothing
 // 1. Read Git tag
 let version;
 try {
-  version = execSync('git describe --abbrev=0 --tags --exact-match')
+  version = execSync('git describe --abbrev=0 --tags')
     .toString()
     .replace('v', '')
     .replace('\n', '');


### PR DESCRIPTION
## Reason for change

This removes the `exact-match` requirement for getting the `package.json` version from Git. In hindsight, that’s not needed. Originally it was added to prevent accidentally publishing a version twice to npm, but npm itself restricts you from doing that.

This may result in some weirdness if we’re using non-semver Git tags, but we’ll cross that bridge later when we come to it.

## Testing

Try `npm run docs` and witness no console errors!

## Checklist

<!-- are all the steps completed? -->

N/A

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
