### PR TITLE
Add event type to event attributes when sending to DD

### DIFF
--- a/src/components/manifold-performance/manifold-performance.spec.ts
+++ b/src/components/manifold-performance/manifold-performance.spec.ts
@@ -29,6 +29,7 @@ describe('<manifold-performance>', () => {
     await page.waitForChanges();
     dispatchEvent(new CustomEvent('manifold-error', { detail: { message: 'error test' } }));
     expect(ddLogs.logger.info).toHaveBeenCalledWith('manifold-error', {
+      type: 'manifold-error',
       message: 'error test',
     });
   });
@@ -45,6 +46,7 @@ describe('<manifold-performance>', () => {
     page.rootInstance.ddLogs = ddLogs;
     await page.waitForChanges();
     expect(ddLogs.logger.info).toHaveBeenCalledWith('manifold-error', {
+      type: 'manifold-error',
       message: 'error message before DD_LOGS is available',
     });
   });

--- a/src/components/manifold-performance/manifold-performance.tsx
+++ b/src/components/manifold-performance/manifold-performance.tsx
@@ -36,7 +36,7 @@ export class ManifoldPerformance {
     if (!this.ddLogs) {
       this.logQueue.push(e);
     } else {
-      this.ddLogs.logger.info(e.type, e.detail);
+      this.ddLogs.logger.info(e.type, {type: e.type, ...e.detail});
     }
   };
 

--- a/src/components/manifold-performance/manifold-performance.tsx
+++ b/src/components/manifold-performance/manifold-performance.tsx
@@ -36,7 +36,7 @@ export class ManifoldPerformance {
     if (!this.ddLogs) {
       this.logQueue.push(e);
     } else {
-      this.ddLogs.logger.info(e.type, {type: e.type, ...e.detail});
+      this.ddLogs.logger.info(e.type, { type: e.type, ...e.detail });
     }
   };
 


### PR DESCRIPTION
## Reason for change

In order to create log-based metrics against a specific event type in DD, I need the event type to be an attribute of the event

## Testing

Unit tests should cover it, but there is a Storybook example under performance that will now pass the event type through to DD.

## Checklist

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
