### PR TITLE
Add receiveManifoldToken to list of loggable events

### DIFF
--- a/src/components/manifold-performance/manifold-performance.tsx
+++ b/src/components/manifold-performance/manifold-performance.tsx
@@ -40,12 +40,13 @@ export class ManifoldPerformance {
     }
     if (!this.ddLogs) {
       this.logQueue.push(e);
+      return;
+    }
+
+    if (e.type === 'manifold-error' || (e.type === 'receiveManifoldToken' && e.detail.error)) {
+      this.ddLogs.logger.error(e.type, { type: e.type, ...e.detail });
     } else {
-      if (e.type === 'manifold-error' || (e.type === 'receiveManifoldToken' && e.detail.error)) {
-        this.ddLogs.logger.error(e.type, { type: e.type, ...e.detail });
-      } else {
-        this.ddLogs.logger.info(e.type, { type: e.type, ...e.detail });
-      }
+      this.ddLogs.logger.info(e.type, { type: e.type, ...e.detail });
     }
   };
 

--- a/src/components/manifold-performance/manifold-performance.tsx
+++ b/src/components/manifold-performance/manifold-performance.tsx
@@ -34,6 +34,10 @@ export class ManifoldPerformance {
   };
 
   logMetric = (e: CustomEvent) => {
+    if (e.type === 'receiveManifoldToken' && !e.detail.token) {
+      // Only log duration if token is defined
+      return;
+    }
     if (e.type === 'receiveManifoldToken') {
       delete e.detail.token;
       delete e.detail.expiry;

--- a/src/components/manifold-performance/manifold-performance.tsx
+++ b/src/components/manifold-performance/manifold-performance.tsx
@@ -11,6 +11,7 @@ const loggableEvents = [
   'manifold-rest-fetch-duration',
   'manifold-graphql-fetch-duration',
   'manifold-error',
+  'receiveManifoldToken',
 ];
 
 @Component({ tag: 'manifold-performance' })
@@ -33,10 +34,18 @@ export class ManifoldPerformance {
   };
 
   logMetric = (e: CustomEvent) => {
+    if (e.type === 'receiveManifoldToken') {
+      delete e.detail.token;
+      delete e.detail.expiry;
+    }
     if (!this.ddLogs) {
       this.logQueue.push(e);
     } else {
-      this.ddLogs.logger.info(e.type, { type: e.type, ...e.detail });
+      if (e.type === 'manifold-error' || (e.type === 'receiveManifoldToken' && e.detail.error)) {
+        this.ddLogs.logger.error(e.type, { type: e.type, ...e.detail });
+      } else {
+        this.ddLogs.logger.info(e.type, { type: e.type, ...e.detail });
+      }
     }
   };
 

--- a/stories/manifold-auth-token.stories.js
+++ b/stories/manifold-auth-token.stories.js
@@ -27,9 +27,11 @@ storiesOf('Auth Token Provider [Data]', module)
     'See your resources',
     () => `
       <manifold-connection>
-        These resources are loaded from the server rather than mocks
-        <manifold-auth-token token="${withVeryFakeExpiry(localStorage.manifold_api_token)}"/>
-        <manifold-resource-list />
+        <manifold-performance>
+          These resources are loaded from the server rather than mocks
+          <manifold-auth-token token="${withVeryFakeExpiry(localStorage.manifold_api_token)}"/>
+          <manifold-resource-list />
+        </manifold-performance>
       </manifold-connection>
     `
   );


### PR DESCRIPTION
## Reason for change

- Adds shadowcat's `receiveManifoldToken` event to list of performance metrics we're logging to DataDog.
- Strips token and expiry fields from event attributes being logged
- Logs `receiveManifoldToken` events with error attributes and all `manifold-error` events as errors, all other events as info

## Testing

I added `<manifold-performance>` to the auth token story in Storybook

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
