### PR TITLE
Don’t set auth token if undefined or 'undefined'

### DIFF
--- a/src/utils/graphqlFetch.ts
+++ b/src/utils/graphqlFetch.ts
@@ -64,12 +64,14 @@ export function createGraphqlFetch({
     const rttStart = performance.now();
     const { emitter, ...request } = args;
 
+    const token = getAuthToken();
+    // yes sometimes the auth token can be 'undefined'
+    const auth: { [key: string]: string } =
+      token && token !== 'undefined' ? { authorization: `Bearer ${token}` } : {};
+
     const response = await fetch(endpoint, {
       method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        ...(getAuthToken() ? { authorization: `Bearer ${getAuthToken()}` } : {}),
-      },
+      headers: { 'content-type': 'application/json', ...auth },
       body: JSON.stringify(request),
     }).catch((e: Response) => {
       // handle unexpected errors


### PR DESCRIPTION
## Reason for change
**Before**
<img width="1434" alt="before" src="https://user-images.githubusercontent.com/1369770/64281770-b4b59d80-cf08-11e9-8af6-50b98cd8e4d1.png">


## Testing

Test out **Product Name** in Storybook. Make sure the one for “from product label” works

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
