### PR TITLE
Simplify GraphQL query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Multiple queries in GraphQL now supported in TypeScript
+
 ## [v0.5.9]
 
 ### Added

--- a/src/components/manifold-data-product-logo/manifold-data-product-logo.tsx
+++ b/src/components/manifold-data-product-logo/manifold-data-product-logo.tsx
@@ -46,7 +46,7 @@ export class ManifoldDataProductLogo {
     const variables = { productLabel };
     const { data } = await this.graphqlFetch({ query, variables });
 
-    this.product = data && data.product ? data.product : undefined;
+    this.product = (data && data.product) || undefined;
   };
 
   @logger()

--- a/src/components/manifold-data-product-logo/manifold-data-product-logo.tsx
+++ b/src/components/manifold-data-product-logo/manifold-data-product-logo.tsx
@@ -44,12 +44,9 @@ export class ManifoldDataProductLogo {
 
     this.product = undefined;
     const variables = { productLabel };
-    const { data } = await this.graphqlFetch<'product'>({
-      query,
-      variables,
-    });
+    const { data } = await this.graphqlFetch({ query, variables });
 
-    this.product = data ? data.product : undefined;
+    this.product = data && data.product ? data.product : undefined;
   };
 
   @logger()

--- a/src/components/manifold-data-product-name/manifold-data-product-name.tsx
+++ b/src/components/manifold-data-product-name/manifold-data-product-name.tsx
@@ -39,7 +39,7 @@ export class ManifoldDataProductName {
 
     this.productName = undefined;
 
-    const { data, errors } = await this.graphqlFetch<'product'>({
+    const { data, errors } = await this.graphqlFetch({
       query: gql`
         query PRODUCT_NAME($productLabel: String!) {
           product(label: $productLabel) {
@@ -64,7 +64,7 @@ export class ManifoldDataProductName {
 
     this.productName = undefined;
 
-    const { data, errors } = await this.graphqlFetch<'resource'>({
+    const { data, errors } = await this.graphqlFetch({
       query: gql`
         query RESOURCE($resourceLabel: String!) {
           resource(label: $resourceLabel) {

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
@@ -207,7 +207,7 @@ export class ManifoldDataProvisionButton {
       return;
     }
 
-    const { data } = await this.graphqlFetch<'profile'>({ query });
+    const { data } = await this.graphqlFetch({ query });
 
     if (data) {
       this.ownerId = data.profile.id;

--- a/src/components/manifold-data-resource-list/manifold-data-resource-list.tsx
+++ b/src/components/manifold-data-resource-list/manifold-data-resource-list.tsx
@@ -64,12 +64,12 @@ export class ManifoldDataResourceList {
       return;
     }
 
-    const { data, errors } = await this.graphqlFetch<'resources'>({
+    const { data, errors } = await this.graphqlFetch({
       query,
     });
 
     if (data) {
-      this.resources = data.resources.edges;
+      this.resources = (data.resources && data.resources.edges) || [];
     } else if (errors) {
       this.errors = errors;
     }

--- a/src/components/manifold-product/manifold-product.tsx
+++ b/src/components/manifold-product/manifold-product.tsx
@@ -58,12 +58,9 @@ export class ManifoldProduct {
     }
 
     const variables = { productLabel };
-    const { data } = await this.graphqlFetch<'product'>({
-      query,
-      variables,
-    });
+    const { data } = await this.graphqlFetch({ query, variables });
 
-    this.product = data ? data.product : undefined;
+    this.product = data && data.product ? data.product : undefined;
   };
 
   @logger()

--- a/src/components/manifold-product/manifold-product.tsx
+++ b/src/components/manifold-product/manifold-product.tsx
@@ -60,7 +60,7 @@ export class ManifoldProduct {
     const variables = { productLabel };
     const { data } = await this.graphqlFetch({ query, variables });
 
-    this.product = data && data.product ? data.product : undefined;
+    this.product = (data && data.product) || undefined;
   };
 
   @logger()

--- a/src/components/manifold-resource-list/manifold-resource-list.tsx
+++ b/src/components/manifold-resource-list/manifold-resource-list.tsx
@@ -111,7 +111,7 @@ export class ManifoldResourceList {
       endpoint: `/resources/?me`,
     });
 
-    const fetchProducts = this.graphqlFetch<'products'>({
+    const fetchProducts = this.graphqlFetch({
       query: gql`
         query PRODUCT_LOGOS {
           products(first: 500) {
@@ -147,7 +147,11 @@ export class ManifoldResourceList {
     // Can continue without product logos if necessary.
     if (operationsResp && resourcesResp) {
       const products =
-        (productsResp && productsResp.data && productsResp.data.products.edges) || [];
+        (productsResp &&
+          productsResp.data &&
+          productsResp.data.products &&
+          productsResp.data.products.edges) ||
+        [];
 
       const userResource = ManifoldResourceList.userResources(resourcesResp);
 

--- a/src/utils/graphqlFetch.ts
+++ b/src/utils/graphqlFetch.ts
@@ -1,29 +1,7 @@
 import { EventEmitter } from '@stencil/core';
-import {
-  Category,
-  CategoryConnection,
-  Product,
-  ProductConnection,
-  Profile,
-  Provider,
-  Resource,
-  ResourceConnection,
-  RegionConnection,
-} from '../types/graphql';
+import { Query } from '../types/graphql';
 import { report } from './errorReport';
 import { waitForAuthToken } from './auth';
-
-interface QueryData {
-  category: { category: Category };
-  categories: { categories: CategoryConnection };
-  product: { product: Product };
-  products: { products: ProductConnection };
-  profile: { profile: Profile };
-  provider: { provider: Provider };
-  regions: { regions: RegionConnection };
-  resource: { resource: Resource };
-  resources: { resources: ResourceConnection };
-}
 
 interface CreateGraphqlFetch {
   endpoint?: string;
@@ -43,14 +21,12 @@ export interface GraphqlError {
   path?: string;
 }
 
-export interface GraphqlResponseBody<T extends keyof QueryData> {
-  data: QueryData[T] | null;
+export interface GraphqlResponseBody {
+  data: Query | null;
   errors?: GraphqlError[];
 }
 
-export type GraphqlFetch = <T extends keyof QueryData>(
-  args: GraphqlArgs
-) => Promise<GraphqlResponseBody<T>>;
+export type GraphqlFetch = (args: GraphqlArgs) => Promise<GraphqlResponseBody>;
 
 export function createGraphqlFetch({
   endpoint = 'https://api.manifold.co/graphql',
@@ -59,10 +35,7 @@ export function createGraphqlFetch({
   getAuthToken = () => undefined,
   setAuthToken = () => {},
 }: CreateGraphqlFetch): GraphqlFetch {
-  async function graphqlFetch<T extends keyof QueryData>(
-    args: GraphqlArgs,
-    attempts: number
-  ): Promise<GraphqlResponseBody<T>> {
+  async function graphqlFetch(args: GraphqlArgs, attempts: number): Promise<GraphqlResponseBody> {
     const rttStart = performance.now();
     const { emitter, ...request } = args;
 
@@ -81,7 +54,7 @@ export function createGraphqlFetch({
       return Promise.reject(e);
     });
 
-    const body: GraphqlResponseBody<T> = await response.json();
+    const body: GraphqlResponseBody = await response.json();
 
     // handle unauthenticated error
     if (response.status === 401) {


### PR DESCRIPTION
## Reason for change

I realized there’s a problem with the GraphQL types we’re using (which is kinda my fault). Consider the following example:

```ts
const { data } = await graphqlFetch<'products'>({ query });
if (data) {
  this.products = data.products
}
```

The `<'product'>` generic declares what we’re expecting from the GraphQL query. But it brings with it the following problems:

**Problem 1: no combined queries** If we queried for `products` and `resources` in the same query, this would throw a type error. So this type system restricts us unnecessarily in the biggest benefit of GraphQL: combined queries.

**Problem 2: bad queries** Further, say our `products` query succeeded but `resources` failed. How would we know? We need to handle the case of either—or both—being undefined.

**Problem 3: manually-managing types** But lastly, this is a manual list that we have to maintain outside of our GraphQL endpoint. If our GraphQL endpoint changes, then our tests won’t catch it because we’re using manually-managed types. This isn’t smart.


### What this PR does
This uses the auto-generated `Query` to fix all of the above problems. Sure, it results in an extra null check on our side, but gives us much more in return.


Props to @davidleger95 who did it this way originally and I suggested he change it to this. I’m a dummy.

## Testing

Tests should pass. Also inspect the following components in Storybook to make sure they still work:

- `manifold-data-product-logo`
- `manifold-data-product-name`
- `manifold-data-provision-button`
- `manifold-product`
- `manifold-resource-list`


## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
