### PR TITLE
Replace curly rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,7 +35,6 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-member-accessibility': 'off',
     '@typescript-eslint/no-unused-vars': 'off', // compiler catches these well enough
-    parser: '@typescript-eslint/parser',
     'arrow-parens': 'off', // let Prettier decide
     camelcase: 'off', // underscores are a thing
     'class-methods-use-this': 'off', // component lifecycle methods sometimes don't use `this`
@@ -49,15 +48,16 @@ module.exports = {
         objects: 'always-multiline',
       },
     ],
+    curly: ['error', 'all'],
+    'func-names': 'off',
     'function-paren-newline': 'off', // let Prettier decide
     'implicit-arrow-linebreak': 'off', // let Prettier decide
     'import/no-extraneous-dependencies': 'off', // We need zero deps for npm
     'import/prefer-default-export': 'off', // named exports are perfectly fine
     'lines-between-class-members': 'off', // class members don’t need that space!
     'max-len': 'off', // let Prettier decide
+    'no-console': ['error', { allow: ['warn', 'error'] }],
     'object-curly-newline': 'off', // let Prettier decide,
     'prettier/prettier': 'error',
-    'no-console': ['error', { allow: ['warn', 'error'] }],
-    'func-names': 'off',
   },
 };

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
@@ -194,7 +194,9 @@ describe('<manifold-data-deprovision-button>', () => {
       });
 
       const button = page.root && page.root.querySelector('button');
-      if (!button) throw new Error('button not found in document');
+      if (!button) {
+        throw new Error('button not found in document');
+      }
 
       // listen for event and fire
       const mockClick = jest.fn();
@@ -228,7 +230,9 @@ describe('<manifold-data-deprovision-button>', () => {
       });
 
       const button = page.root && page.root.querySelector('button');
-      if (!button) throw new Error('button not found in document');
+      if (!button) {
+        throw new Error('button not found in document');
+      }
 
       const mockClick = jest.fn();
       await new Promise(resolve => {
@@ -264,7 +268,9 @@ describe('<manifold-data-deprovision-button>', () => {
       });
 
       const button = page.root && page.root.querySelector('button');
-      if (!button) throw new Error('button not found in document');
+      if (!button) {
+        throw new Error('button not found in document');
+      }
 
       const mockClick = jest.fn();
       await new Promise(resolve => {

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
@@ -177,7 +177,9 @@ describe('<manifold-data-rename-button>', () => {
       });
 
       const button = page.root && page.root.querySelector('button');
-      if (!button) throw new Error('button not found in document');
+      if (!button) {
+        throw new Error('button not found in document');
+      }
 
       // listen for event and fire
       page.doc.addEventListener('manifold-renameButton-click', mockClick);
@@ -204,7 +206,9 @@ describe('<manifold-data-rename-button>', () => {
       });
 
       const button = page.root && page.root.querySelector('button');
-      if (!button) throw new Error('button not found in document');
+      if (!button) {
+        throw new Error('button not found in document');
+      }
 
       // listen for event and fire
       const mockClick = jest.fn();
@@ -239,7 +243,9 @@ describe('<manifold-data-rename-button>', () => {
       });
 
       const button = page.root && page.root.querySelector('button');
-      if (!button) throw new Error('button not found in document');
+      if (!button) {
+        throw new Error('button not found in document');
+      }
 
       // listen for event and fire
       const mockClick = jest.fn();
@@ -276,7 +282,9 @@ describe('<manifold-data-rename-button>', () => {
       });
 
       const button = page.root && page.root.querySelector('button');
-      if (!button) throw new Error('button not found in document');
+      if (!button) {
+        throw new Error('button not found in document');
+      }
 
       const mockClick = jest.fn();
       await new Promise(resolve => {
@@ -313,7 +321,9 @@ describe('<manifold-data-rename-button>', () => {
       });
 
       const button = page.root && page.root.querySelector('button');
-      if (!button) throw new Error('button not found in document');
+      if (!button) {
+        throw new Error('button not found in document');
+      }
 
       const mockClick = jest.fn();
       await new Promise(resolve => {

--- a/src/components/manifold-data-sso-button/manifold-data-sso-button.spec.ts
+++ b/src/components/manifold-data-sso-button/manifold-data-sso-button.spec.ts
@@ -152,7 +152,9 @@ describe('<manifold-data-sso-button>', () => {
     it('click', async () => {
       fetchMock.mock(`${connections.prod.connector}/sso`, authCode);
 
-      if (!page.root) throw new Error('<manifold-sso-button> not found in document');
+      if (!page.root) {
+        throw new Error('<manifold-sso-button> not found in document');
+      }
 
       const resourceLabel = 'click-label';
       element.resourceLabel = resourceLabel;
@@ -160,7 +162,9 @@ describe('<manifold-data-sso-button>', () => {
       await page.waitForChanges();
 
       const button = element.querySelector('button');
-      if (!button) throw new Error('button not found in document');
+      if (!button) {
+        throw new Error('button not found in document');
+      }
 
       const onClick = jest.fn();
       await new Promise(resolve => {
@@ -188,7 +192,9 @@ describe('<manifold-data-sso-button>', () => {
         body: { message },
       });
 
-      if (!page.root) throw new Error('<manifold-sso-button> not found in document');
+      if (!page.root) {
+        throw new Error('<manifold-sso-button> not found in document');
+      }
 
       const resourceLabel = 'error-label';
       element.resourceLabel = resourceLabel;
@@ -196,7 +202,9 @@ describe('<manifold-data-sso-button>', () => {
       await page.waitForChanges();
 
       const button = element.querySelector('button');
-      if (!button) throw new Error('button not found in document');
+      if (!button) {
+        throw new Error('button not found in document');
+      }
 
       const onError = jest.fn();
       await new Promise(resolve => {
@@ -221,7 +229,9 @@ describe('<manifold-data-sso-button>', () => {
     it('success', async () => {
       fetchMock.mock(`${connections.prod.connector}/sso`, authCode);
 
-      if (!page.root) throw new Error('<manifold-sso-button> not found in document');
+      if (!page.root) {
+        throw new Error('<manifold-sso-button> not found in document');
+      }
 
       const resourceLabel = 'success-label';
       element.resourceLabel = resourceLabel;
@@ -229,7 +239,9 @@ describe('<manifold-data-sso-button>', () => {
       await page.waitForChanges();
 
       const button = element.querySelector('button');
-      if (!button) throw new Error('button not found in document');
+      if (!button) {
+        throw new Error('button not found in document');
+      }
 
       const onSuccess = jest.fn();
       await new Promise(resolve => {


### PR DESCRIPTION
## Reason for change

This replaces the `curly` ESLint rule that was accidentally removed. Separated from #452 for readability.

## Testing

No code was change; just lint changes.

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
