### PR TITLE
Return records from fetchAllPages

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1031,61 +1031,6 @@
         "@manifoldco/shadowcat": "^0.1.7",
         "@stencil/state-tunnel": "^1.0.1",
         "clipboard-polyfill": "^2.8.6"
-      },
-      "dependencies": {
-        "@manifoldco/gql-zero": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/@manifoldco/gql-zero/-/gql-zero-0.2.0.tgz",
-          "integrity": "sha512-s0nPkp5PUzvqK8SaIQEMw5AYArC4slq+YQ9xL9lG8QImMO1NIWfnrvwJRVAO+Ns5dmeZeAdXACX+1g2k27I0Yg=="
-        },
-        "@manifoldco/shadowcat": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/@manifoldco/shadowcat/-/shadowcat-0.1.7.tgz",
-          "integrity": "sha512-wqywMKogg2n2jOurfKlx90115Xfu0Kk5ai+YcPi7FuEaU18tUZY8cKrb/Xm4TX3TnfTSClQuWlS2I4qasG81Dw=="
-        },
-        "@stencil/state-tunnel": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@stencil/state-tunnel/-/state-tunnel-1.0.1.tgz",
-          "integrity": "sha512-DYG8uROgL9hkjVTCtCfRBb0d3FwpiFB0muRrNZQ2X1Qo5hxMuNNji76/ILddqeq0AfgkKCW82xrMPDpy+rNIhQ=="
-        },
-        "clipboard": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz",
-          "integrity": "sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==",
-          "requires": {
-            "good-listener": "^1.2.2",
-            "select": "^1.1.2",
-            "tiny-emitter": "^2.0.0"
-          }
-        },
-        "clipboard-polyfill": {
-          "version": "2.8.6",
-          "resolved": "https://registry.npmjs.org/clipboard-polyfill/-/clipboard-polyfill-2.8.6.tgz",
-          "integrity": "sha512-kz/1ov+PXsBpGnW9XJH3dLWdYj12FpXqO89Dngm/GRPoI36E/tnYs6N0YPTEhxM9WHAlFiN5eoyIVuv5nzKXvg=="
-        },
-        "delegate": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-          "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
-        },
-        "good-listener": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-          "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-          "requires": {
-            "delegate": "^3.1.2"
-          }
-        },
-        "select": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-          "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
-        },
-        "tiny-emitter": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-          "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
-        }
       }
     },
     "@mikaelkristiansson/domready": {

--- a/src/utils/fetchAllPages.spec.ts
+++ b/src/utils/fetchAllPages.spec.ts
@@ -233,6 +233,8 @@ const secondPage = {
 };
 
 describe('Fetching all pages of a GraphQL connection', () => {
+  afterEach(fetchMock.reset);
+
   it('fetches all the pages', async () => {
     fetchMock
       .once('https://api.manifold.co/graphql', {

--- a/src/utils/fetchAllPages.spec.ts
+++ b/src/utils/fetchAllPages.spec.ts
@@ -1,7 +1,7 @@
 import { gql } from '@manifoldco/gql-zero';
 import fetchMock from 'fetch-mock';
 import { Query, CategoryEdge } from '../types/graphql';
-import fetchAllPages, { createAggregator as agg } from './fetchAllPages';
+import fetchAllPages from './fetchAllPages';
 
 const query = gql`
   query CATEGORIES($first: Int!, $after: String!) {
@@ -248,19 +248,13 @@ describe('Fetching all pages of a GraphQL connection', () => {
         { overwriteRoutes: false }
       );
 
-    const aggregator = agg<CategoryEdge>();
-    const aggSpy = jest.spyOn(aggregator, 'write');
-
-    await fetchAllPages({
+    const entries = await fetchAllPages({
       query,
       nextPage: { first: 3, after: '' },
-      agg: aggregator,
       getConnection: (q: Query) => q.categories,
     });
 
-    expect(fetchMock.calls).toHaveLength(aggSpy.mock.calls.length);
-    expect(aggregator.entries()).toEqual(
-      firstPage.categories.edges.concat(secondPage.categories.edges)
-    );
+    expect(fetchMock.calls).toHaveLength(2);
+    expect(entries).toEqual(firstPage.categories.edges.concat(secondPage.categories.edges));
   });
 });

--- a/src/utils/fetchAllPages.spec.ts
+++ b/src/utils/fetchAllPages.spec.ts
@@ -1,6 +1,6 @@
 import { gql } from '@manifoldco/gql-zero';
 import fetchMock from 'fetch-mock';
-import { Query, CategoryEdge } from '../types/graphql';
+import { Query } from '../types/graphql';
 import fetchAllPages from './fetchAllPages';
 
 const query = gql`

--- a/src/utils/fetchAllPages.ts
+++ b/src/utils/fetchAllPages.ts
@@ -1,10 +1,6 @@
 import connection from '../state/connection';
 import { PageInfo, Query } from '../types/graphql';
 
-interface PageAggregator<Edge> {
-  write: (edges: Edge[]) => void;
-}
-
 interface Connection<Edge> {
   pageInfo: PageInfo;
   edges: Edge[];
@@ -18,16 +14,14 @@ interface NextPage {
 interface Args<Edge> {
   query: string;
   nextPage: NextPage;
-  agg: PageAggregator<Edge>;
   getConnection: (q: Query) => Connection<Edge>;
 }
 
 export default async function fetchAllPages<Edge>({
   query,
   nextPage = { first: 25, after: '' },
-  agg,
   getConnection,
-}: Args<Edge>) {
+}: Args<Edge>): Promise<Edge[]> {
   const page = await connection.graphqlFetch({ query, variables: nextPage });
 
   if (page.errors) {
@@ -36,22 +30,15 @@ export default async function fetchAllPages<Edge>({
 
   if (page.data) {
     const { edges, pageInfo } = getConnection(page.data);
-    agg.write(edges);
 
     if (pageInfo.hasNextPage) {
       const next = { first: nextPage.first, after: pageInfo.endCursor || '' };
-      await fetchAllPages({ query, nextPage: next, agg, getConnection });
+      const remaining = await fetchAllPages({ query, nextPage: next, getConnection });
+      return edges.concat(remaining);
     }
+
+    return edges;
   }
-}
 
-export function createAggregator<T>() {
-  const entries: T[] = [];
-
-  return {
-    write: (edges: T[]) => {
-      entries.push(...edges);
-    },
-    entries: () => entries,
-  };
+  return [];
 }


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

This is an improvement on the `fetchAllPages` implementation. This function originally wrote each page to an aggregator, rather than returning all the pages itself. This change allows the function to return the data so that the aggregator isn't needed.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->
Tests should pass.

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
