### PR TITLE
Convert <manifold-credentials> to GraphQL

### DIFF
--- a/.manifold-ci.yml
+++ b/.manifold-ci.yml
@@ -1,2 +1,0 @@
-team: manifold
-project: manifold-ui-ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fixed `<manifold-button>` borders (#500)
+- `<manifold-credentials>` now uses GraphQL (#490)
 
 ## [v0.5.10]
 

--- a/docs/docs/advanced/resource-details.md
+++ b/docs/docs/advanced/resource-details.md
@@ -1,232 +1,106 @@
 ---
-title: Resource Details View
+title: Resource Helpers
 path: /advanced/resource-details
+example: |
+  <style>
+    manifold-data-rename-button button,
+    manifold-data-deprovision-button button,
+    manifold-data-sso-button button {
+      border: none;
+      padding: 0;
+    }
+  </style>
+  <manifold-mock-resource>
+    <div style="display: flex; justify-content: space-between; margin-bottom: 1em;">
+      <div style="display: flex; align-items: center;">
+        <manifold-input default-value="my-resource" disabled></manifold-input>
+        <manifold-resource-status size="small" style="margin-left: 1em;"></manifold-resource-status>
+      </div>
+      <div>
+        <manifold-resource-rename>
+          <manifold-button>Rename</manifold-button>
+        </manifold-resource-rename>
+        <manifold-resource-sso>
+          <manifold-button>SSO</manifold-button>
+        </manifold-resource-sso>
+        <manifold-resource-deprovision>
+          <manifold-button>Deprovision</manifold-button>
+        </manifold-resource-deprovision>
+      </div>
+    </div>
+    <manifold-resource-product style="margin-bottom: 1em"></manifold-resource-product>
+    <manifold-resource-plan style="margin-bottom: 1em"></manifold-resource-plan>
+    <manifold-resource-credentials></manifold-resource-credentials>
+  </manifold-mock-resource>
 ---
 
-# Creating a resource details view
+# Resource Helpers
 
-A specific set of component are available to use for creating a resource details view without having
-to keep giving the resource label as attributes to all the components in the library.
+A special wrapper component, `<manifold-resource-container>`, can be used to create a special shared
+context for related resource components. Using this has the following advantages:
 
-To setup a resource details view, wrap all the structure you want to be part of the resource details
-view in a `manifold-resource-container` component with access to the resource label.
+- Requests will be consolidated so users experience shorter loading times
+- You don’t have to specify `resource-label="my-resource"` on all its children
+
+To use this special context, you also have to use aliased components, as specified below:
 
 ```html
 <manifold-resource-container resource-label="my-resource">
-  <!--- Your structure goes here --->
-</manifold-resource-container>
-```
+  <!-- use any, or all, of the following components: -->
 
-<style>
-  manifold-data-rename-button button, manifold-data-deprovision-button button, manifold-data-sso-button button {
-    border: none;
-    padding: 0;
-  }
-</style>
-<manifold-mock-resource>
-  <div style="display: flex; justify-content: space-between; margin-bottom: 1em;">
-    <div style="display: flex; align-items: center;">
-      <manifold-input default-value="my-resource" disabled></manifold-input>
-      <manifold-resource-status size="small" style="margin-left: 1em;"></manifold-resource-status>
-    </div>
-    <div>
-      <manifold-resource-rename>
-        <manifold-button>Rename</manifold-button>
-      </manifold-resource-rename>
-      <manifold-resource-sso>
-        <manifold-button>SSO</manifold-button>
-      </manifold-resource-sso>
-      <manifold-resource-deprovision>
-        <manifold-button>Deprovision</manifold-button>
-      </manifold-resource-deprovision>
-    </div>
-  </div>
-  <manifold-resource-product style="margin-bottom: 1em"></manifold-resource-product>
-  <manifold-resource-plan style="margin-bottom: 1em"></manifold-resource-plan>
   <manifold-resource-credentials></manifold-resource-credentials>
-</resource-mock-resource>
 
-## Refetching until the resource is valid
-
-The `refetch-until-valid` property on the `resource-container` can be used to force the container to
-refetch the resource until it has found one and the status of that resource is available. This is
-useful for reloading the page until the resource has finished resizing or provisioning for example.
-
-## The resource credentials
-
-The [`manifold-credentials`](/components/credentials) component can be used inside the container
-without any attribute by using the `manifold-resource-credentials` component.
-
-```html
-<manifold-resource-container resource-label="my-resource">
-  <!--- Your structure goes here --->
-  <manifold-resource-credentials></manifold-resource-credentials>
-</manifold-resource-container>
-```
-
-## The resource deprovision Button
-
-The [`manifold-data-deprovision-button`](/data/deprovision-button) component can be used inside the
-container without any attribute by using the `manifold-resource-deprovision` component. This
-component is still acting as a data component and can be stylized or be given children.
-
-```html
-<manifold-resource-container resource-label="my-resource">
-  <!--- Your structure goes here --->
   <manifold-resource-deprovision>Deprovision</manifold-resource-deprovision>
-</manifold-resource-container>
-```
 
-### Events
-
-For validation, error, and success messages, it will emit custom events.
-
-```js
-document.addEventListener('manifold-deprovisionButton-click', ({ detail: { resourceLabel } }) =>
-  console.info(`⌛ Deprovisioning ${resourceLabel} …`)
-);
-document.addEventListener('manifold-deprovisionButton-success', ({ detail: { resourceLabel } }) =>
-  alert(`${resourceLabel} deprovisioned successfully!`)
-);
-document.addEventListener('manifold-deprovisionButton-error', ({ detail }) => console.log(detail));
-// {message: "bad_request: bad_request: No plan_id provided", resourceid: "1234", resourceLabel: "my-resource"}
-```
-
-| Name                                 | Returns                                  | Description                                                                                                                 |
-| ------------------------------------ | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `manifold-deprovisionButton-click`   | `resourceLabel`                          | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
-| `manifold-deprovisionButton-success` | `message`, `resourceId`, `resourceLabel` | Successful deprovision. Returns a resource ID and resource Label.                                                           |
-| `manifold-deprovisionButton-error`   | `message`, `resourceId`, `resourceLabel` | Erred provision, along with information on what went wrong.                                                                 |
-
-## The resource rename Button
-
-The [`manifold-data-rename-button`](/data/rename-button) component can be used inside the container
-without any attribute by using the `manifold-resource-rename` component. This component is still
-acting as a data component and can be stylized or be given children.
-
-```html
-<manifold-resource-container resource-label="my-resource">
-  <!--- Your structure goes here --->
-  <manifold-resource-rename>Rename</manifold-resource-rename>
-</manifold-resource-container>
-```
-
-### Events
-
-For validation, error, and success messages, it will emit custom events.
-
-```js
-document.addEventListener(
-  'manifold-renameButton-click',
-  ({ detail: { resourceLabel, newLabel } }) =>
-    console.info(`⌛ Renaming ${resourceLabel} to ${newLabel} …`)
-);
-document.addEventListener(
-  'manifold-renameButton-success',
-  ({ detail: { resourceLabel, newLabel } }) =>
-    alert(`${resourceLabel} renamed to ${newLabel} successfully!`)
-);
-document.addEventListener('manifold-renameButton-error', ({ detail }) => console.log(detail));
-// {
-//   message: 'bad_request: bad_request: No plan_id provided',
-//   resourceid: '1234',
-//   resourceLabel: 'my-resource',
-//   newLabel: 'new-name',
-// }
-document.addEventListener('manifold-renameButton-invalid', ({ detail }) => console.log(detail));
-// {
-//   message: 'bad_request: bad_request: No plan_id provided',
-//   resourceid: '1234',
-//   resourceLabel: 'my-resource',
-//   newLabel: 'new-name',
-// }
-```
-
-| Name                            | Returns                                              | Description                                                                                                                 |
-| ------------------------------- | ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `manifold-renameButton-click`   | `resourceId`, `resourceLabel`, `newLabel`            | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
-| `manifold-renameButton-success` | `message`, `resourceId`, `resourceLabel`, `newLabel` | Successful renaming. Returns a resource ID and resource Label as well as a message and the new name for the resource.       |
-| `manifold-renameButton-error`   | `message`, `resourceId`, `resourceLabel`, `newLabel` | Erred rename, along with information on what went wrong.                                                                    |
-| `manifold-renameButton-error`   | `message`, `resourceId`, `resourceLabel`, `newLabel` | Invalid renaming, along with information on what went wrong.                                                                |
-
-## The resource sso Button
-
-The [`manifold-data-sso-button`](/data/sso-button) component can be used inside the container
-without any attribute by using the `manifold-resource-sso` component. This component is still acting
-as a data component and can be stylized or be given children.
-
-```html
-<manifold-resource-container resource-label="my-resource">
-  <!--- Your structure goes here --->
-  <manifold-resource-sso>SSO into resource</manifold-resource-sso>
-</manifold-resource-container>
-```
-
-### Events
-
-For validation, error, and success messages, it will emit custom events.
-
-```js
-document.addEventListener('manifold-ssoButton-click', ({ detail: { resourceLabel } }) =>
-  console.info(`User is logging into ${resourceLabel}…`)
-);
-document.addEventListener(
-  'manifold-ssoButton-success',
-  ({ detail: { resourceLabel, redirectUrl } }) => (window.location = redirectUrl)
-);
-document.addEventListener('manifold-ssoButton-error', ({ detail }) => console.log(detail));
-// {
-//   type: 'not_found',
-//   message: 'no_found: Resource not found',
-//   resourceid: '1234',
-//   resourceLabel: 'my-resource',
-// }
-```
-
-| Name                         | Returns                                                 | Description                                                                                                                 |
-| ---------------------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `manifold-ssoButton-click`   | `resourceId`, `resourceLabel`                           | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
-| `manifold-ssoButton-success` | `message`, `resourceId`, `resourceLabel`, `redirectUrl` | Successful sso. Returns a resource ID, resource Label and the redirect_url for the product's dashboard.                     |
-| `manifold-ssoButton-error`   | `message`, `resourceId`, `resourceLabel`                | Erred sso, along with information on what went wrong.                                                                       |
-
-## The resource product details
-
-The [`manifold-resource-card`][service-card] component can be used inside the container without any
-attribute by using the [`manifold-resource-product`][resource-product] component.
-
-```html
-<manifold-resource-container resource-label="my-resource">
-  <!--- Your structure goes here --->
-  <manifold-resource-product></manifold-resource-product>
-</manifold-resource-container>
-```
-
-## The resource plan details
-
-The [`manifold-plan`][plan] component can be used inside the container without any attribute by
-using the [`manifold-resource-plan`][resource-plan] component.
-
-```html
-<manifold-resource-container resource-label="my-resource">
-  <!--- Your structure goes here --->
   <manifold-resource-plan></manifold-resource-plan>
-</manifold-resource-container>
-```
 
-## The resource status
+  <manifold-resource-product></manifold-resource-product>
 
-You can display the resource's status like on the `resource-card` component or the standalone
-[`manifold-resource-status-view`][status] component inside the container by using the
-`manifold-resource-status` component.
+  <manifold-resource-rename>Rename</manifold-resource-rename>
 
-```html
-<manifold-resource-container resource-label="my-resource">
+  <manifold-resource-sso>Launch Dashboard</manifold-resource-sso>
+
   <manifold-resource-status></manifold-resource-status>
 </manifold-resource-container>
 ```
 
+All of the children of `<manifold-resource-container>` are special versions of existing components.
+**These versions of components don’t require any attributes.** They do emit all events, and accept
+all children of their aliases:
+
+| Original component                                  | Resource context version          |       Events?       |
+| :-------------------------------------------------- | :-------------------------------- | :-----------------: |
+| [`<manifold-credentials>`][credentials]             | `<manifold-resource-credentials>` |                     |
+| [`<manifold-data-deprovision-button>`][deprovision] | `<manifold-resource-deprovision>` | [Yes][deprovision]  |
+| [`<manifold-data-rename-button>`][rename]           | `<manifold-resource-rename>`      |    [Yes][rename]    |
+| [`<manifold-data-sso-button>`][sso]                 | `<manifold-resource-sso>`         |     [Yes][sso]      |
+| [`<manifold-service-card>`][service-card]           | `<manifold-resource-product>`     | [Yes][service-card] |
+| [`<manifold-plan>`][plan]                           | `<manifold-resource-plan>`        |                     |
+| [`<manifold-resource-status>`][status]              | `<manifold-resource-status>`      |                     |
+
+_For example: the `<manifold-resource-sso>` component will emit the same `manifold-ssoButton-click`,
+`manifold-ssoButton-success`, and `manifold-ssoButton-error` events as
+`<manifold-data-sso-button>`._
+
+## Refetch until valid
+
+The `refetch-until-valid` property on the `resource-container` can be used to force the container to
+continually attempt to fetch the resource until it has found one and the status of that resource is
+available. This is useful for reloading the page until the resource has finished resizing or
+provisioning for example.
+
+```html
+<manifold-resource-container resource-label="my-resource" refetch-until-valid>
+  <manifold-resource-credentials></manifold-resource-credentials>
+</manifold-resource-container>
+```
+
+[credentials]: /components/credentials
+[deprovision]: /data/deprovision-button
 [plan]: /components/plan
+[rename]: /data/rename-button
 [resource-plan]: /components/manifold-resource-plan
 [resource-product]: /components/manifold-resource-product
 [service-card]: /components/manifold-service-card
-[status]: o/components/resource-status/
+[sso]: /data/sso-button
+[status]: /components/resource-status/

--- a/docs/docs/advanced/resource-details.md
+++ b/docs/docs/advanced/resource-details.md
@@ -5,17 +5,18 @@ path: /advanced/resource-details
 
 # Creating a resource details view
 
-A specific set of component are available to use for creating a resource details view without having to keep
-giving the resource label as attributes to all the components in the library.
+A specific set of component are available to use for creating a resource details view without having
+to keep giving the resource label as attributes to all the components in the library.
 
-To setup a resource details view, wrap all the structure you want to be part of the resource details view in
-a `manifold-resource-container` component with access to the resource label.
+To setup a resource details view, wrap all the structure you want to be part of the resource details
+view in a `manifold-resource-container` component with access to the resource label.
 
 ```html
 <manifold-resource-container resource-label="my-resource">
   <!--- Your structure goes here --->
 </manifold-resource-container>
 ```
+
 <style>
   manifold-data-rename-button button, manifold-data-deprovision-button button, manifold-data-sso-button button {
     border: none;
@@ -46,12 +47,15 @@ a `manifold-resource-container` component with access to the resource label.
 </resource-mock-resource>
 
 ## Refetching until the resource is valid
-The `refetch-until-valid` property on the `resource-container` can be used to force the container to refetch the resource until it has found one and the status of that resource is available. This is useful for reloading the page until the resource has finished resizing or provisioning for example.
+
+The `refetch-until-valid` property on the `resource-container` can be used to force the container to
+refetch the resource until it has found one and the status of that resource is available. This is
+useful for reloading the page until the resource has finished resizing or provisioning for example.
 
 ## The resource credentials
 
-The [`manifold-credentials`](/components/credentials) component can be used inside the container without any attribute by
-using the `manifold-resource-credentials` component.
+The [`manifold-credentials`](/components/credentials) component can be used inside the container
+without any attribute by using the `manifold-resource-credentials` component.
 
 ```html
 <manifold-resource-container resource-label="my-resource">
@@ -62,9 +66,9 @@ using the `manifold-resource-credentials` component.
 
 ## The resource deprovision Button
 
-The [`manifold-data-deprovision-button`](/data/deprovision-button) component can be used inside the container without any attribute by
-using the `manifold-resource-deprovision` component. This component is still acting as a data component and can
-be stylized or be given children.
+The [`manifold-data-deprovision-button`](/data/deprovision-button) component can be used inside the
+container without any attribute by using the `manifold-resource-deprovision` component. This
+component is still acting as a data component and can be stylized or be given children.
 
 ```html
 <manifold-resource-container resource-label="my-resource">
@@ -81,25 +85,24 @@ For validation, error, and success messages, it will emit custom events.
 document.addEventListener('manifold-deprovisionButton-click', ({ detail: { resourceLabel } }) =>
   console.info(`⌛ Deprovisioning ${resourceLabel} …`)
 );
-document.addEventListener(
-  'manifold-deprovisionButton-success',
-  ({ detail: { resourceLabel } }) =>alert(`${resourceLabel} deprovisioned successfully!`)
+document.addEventListener('manifold-deprovisionButton-success', ({ detail: { resourceLabel } }) =>
+  alert(`${resourceLabel} deprovisioned successfully!`)
 );
 document.addEventListener('manifold-deprovisionButton-error', ({ detail }) => console.log(detail));
 // {message: "bad_request: bad_request: No plan_id provided", resourceid: "1234", resourceLabel: "my-resource"}
 ```
 
 | Name                                 | Returns                                  | Description                                                                                                                 |
-|--------------------------------------|------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| ------------------------------------ | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `manifold-deprovisionButton-click`   | `resourceLabel`                          | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
 | `manifold-deprovisionButton-success` | `message`, `resourceId`, `resourceLabel` | Successful deprovision. Returns a resource ID and resource Label.                                                           |
-| `manifold-deprovisionButton-error`   |     `message`, `resourceId`, `resourceLabel`       | Erred provision, along with information on what went wrong.     
+| `manifold-deprovisionButton-error`   | `message`, `resourceId`, `resourceLabel` | Erred provision, along with information on what went wrong.                                                                 |
 
 ## The resource rename Button
 
-The [`manifold-data-rename-button`](/data/rename-button) component can be used inside the container without any attribute by
-using the `manifold-resource-rename` component. This component is still acting as a data component and can
-be stylized or be given children.
+The [`manifold-data-rename-button`](/data/rename-button) component can be used inside the container
+without any attribute by using the `manifold-resource-rename` component. This component is still
+acting as a data component and can be stylized or be given children.
 
 ```html
 <manifold-resource-container resource-label="my-resource">
@@ -113,31 +116,44 @@ be stylized or be given children.
 For validation, error, and success messages, it will emit custom events.
 
 ```js
-document.addEventListener('manifold-renameButton-click', ({ detail: { resourceLabel, newLabel } }) =>
-  console.info(`⌛ Renaming ${resourceLabel} to ${newLabel} …`)
+document.addEventListener(
+  'manifold-renameButton-click',
+  ({ detail: { resourceLabel, newLabel } }) =>
+    console.info(`⌛ Renaming ${resourceLabel} to ${newLabel} …`)
 );
 document.addEventListener(
   'manifold-renameButton-success',
-  ({ detail: { resourceLabel, newLabel } }) => alert(`${resourceLabel} renamed to ${newLabel} successfully!`)
+  ({ detail: { resourceLabel, newLabel } }) =>
+    alert(`${resourceLabel} renamed to ${newLabel} successfully!`)
 );
 document.addEventListener('manifold-renameButton-error', ({ detail }) => console.log(detail));
-// {message: "bad_request: bad_request: No plan_id provided", resourceid: "1234", resourceLabel: "my-resource", newLabel: "new-name"}
+// {
+//   message: 'bad_request: bad_request: No plan_id provided',
+//   resourceid: '1234',
+//   resourceLabel: 'my-resource',
+//   newLabel: 'new-name',
+// }
 document.addEventListener('manifold-renameButton-invalid', ({ detail }) => console.log(detail));
-// {message: "bad_request: bad_request: No plan_id provided", resourceid: "1234", resourceLabel: "my-resource", newLabel: "new-name"}
+// {
+//   message: 'bad_request: bad_request: No plan_id provided',
+//   resourceid: '1234',
+//   resourceLabel: 'my-resource',
+//   newLabel: 'new-name',
+// }
 ```
 
 | Name                            | Returns                                              | Description                                                                                                                 |
-|---------------------------------|------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| ------------------------------- | ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `manifold-renameButton-click`   | `resourceId`, `resourceLabel`, `newLabel`            | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
 | `manifold-renameButton-success` | `message`, `resourceId`, `resourceLabel`, `newLabel` | Successful renaming. Returns a resource ID and resource Label as well as a message and the new name for the resource.       |
 | `manifold-renameButton-error`   | `message`, `resourceId`, `resourceLabel`, `newLabel` | Erred rename, along with information on what went wrong.                                                                    |
-| `manifold-renameButton-error`   |   `message`, `resourceId`, `resourceLabel`, `newLabel`   | Invalid renaming, along with information on what went wrong. 
+| `manifold-renameButton-error`   | `message`, `resourceId`, `resourceLabel`, `newLabel` | Invalid renaming, along with information on what went wrong.                                                                |
 
 ## The resource sso Button
 
-The [`manifold-data-sso-button`](/data/sso-button) component can be used inside the container without any attribute by
-using the `manifold-resource-sso` component. This component is still acting as a data component and can
-be stylized or be given children.
+The [`manifold-data-sso-button`](/data/sso-button) component can be used inside the container
+without any attribute by using the `manifold-resource-sso` component. This component is still acting
+as a data component and can be stylized or be given children.
 
 ```html
 <manifold-resource-container resource-label="my-resource">
@@ -152,26 +168,31 @@ For validation, error, and success messages, it will emit custom events.
 
 ```js
 document.addEventListener('manifold-ssoButton-click', ({ detail: { resourceLabel } }) =>
-  console.info(`⌛ Sooing into ${resourceLabel} …`)
+  console.info(`User is logging into ${resourceLabel}…`)
 );
 document.addEventListener(
   'manifold-ssoButton-success',
-  ({ detail: { resourceLabel, redirectUrl } }) => window.location = redirectUrl
+  ({ detail: { resourceLabel, redirectUrl } }) => (window.location = redirectUrl)
 );
 document.addEventListener('manifold-ssoButton-error', ({ detail }) => console.log(detail));
-// {type: "not_found", message: "no_found: Resource not found", resourceid: "1234", resourceLabel: "my-resource"}
+// {
+//   type: 'not_found',
+//   message: 'no_found: Resource not found',
+//   resourceid: '1234',
+//   resourceLabel: 'my-resource',
+// }
 ```
 
 | Name                         | Returns                                                 | Description                                                                                                                 |
-|------------------------------|---------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| ---------------------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `manifold-ssoButton-click`   | `resourceId`, `resourceLabel`                           | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
 | `manifold-ssoButton-success` | `message`, `resourceId`, `resourceLabel`, `redirectUrl` | Successful sso. Returns a resource ID, resource Label and the redirect_url for the product's dashboard.                     |
 | `manifold-ssoButton-error`   | `message`, `resourceId`, `resourceLabel`                | Erred sso, along with information on what went wrong.                                                                       |
 
 ## The resource product details
 
-The [`manifold-resource-card`](/components/manifold-service-card) component can be used inside the container without any attribute by
-using the [`manifold-resource-product`](/components/manifold-resource-product) component.
+The [`manifold-resource-card`][service-card] component can be used inside the container without any
+attribute by using the [`manifold-resource-product`][resource-product] component.
 
 ```html
 <manifold-resource-container resource-label="my-resource">
@@ -182,8 +203,8 @@ using the [`manifold-resource-product`](/components/manifold-resource-product) c
 
 ## The resource plan details
 
-The [`manifold-plan`](/components/plan) component can be used inside the container without any attribute by
-using the [`manifold-resource-plan`](/components/manifold-resource-plan) component.
+The [`manifold-plan`][plan] component can be used inside the container without any attribute by
+using the [`manifold-resource-plan`][resource-plan] component.
 
 ```html
 <manifold-resource-container resource-label="my-resource">
@@ -195,12 +216,17 @@ using the [`manifold-resource-plan`](/components/manifold-resource-plan) compone
 ## The resource status
 
 You can display the resource's status like on the `resource-card` component or the standalone
-[`manifold-resource-status-view`](/components/manifold-resource-card) component inside the container by
-using the `manifold-resource-status` component.
+[`manifold-resource-status-view`][status] component inside the container by using the
+`manifold-resource-status` component.
 
 ```html
 <manifold-resource-container resource-label="my-resource">
-  <!--- Your structure goes here --->
   <manifold-resource-status></manifold-resource-status>
 </manifold-resource-container>
 ```
+
+[plan]: /components/plan
+[resource-plan]: /components/manifold-resource-plan
+[resource-product]: /components/manifold-resource-product
+[service-card]: /components/manifold-service-card
+[status]: o/components/resource-status/

--- a/docs/docs/components/manifold-credentials.md
+++ b/docs/docs/components/manifold-credentials.md
@@ -2,7 +2,7 @@
 title: '🔒 Resource Credentials'
 path: '/components/credentials'
 example: |
-  <manifold-credentials-view></manifold-credentials-view>
+  <manifold-credentials resource-label="config"></manifold-credentials>
 ---
 
 # 🔒 Credentials
@@ -28,3 +28,5 @@ more about slots][slot].
   <MyButton slot="hide-button">Hide credentials</MyButton>
 </manifold-credentials>
 ```
+
+[slot]: https://stenciljs.com/docs/templating-jsx/

--- a/docs/docs/components/manifold-credentials.md
+++ b/docs/docs/components/manifold-credentials.md
@@ -8,7 +8,8 @@ example: '<manifold-credentials resource-name="cms-stage"></manifold-credentials
 
 Display credentials for a resource. 🔒 Requires authentication.
 
-The resource label needs to be provided for the component to be able to fetch the resource's credentials on demand.
+The resource label needs to be provided for the component to be able to fetch the resource's
+credentials on demand.
 
 ```html
 <manifold-credentials resource-label="my-resource"></manifold-credentials>
@@ -16,16 +17,13 @@ The resource label needs to be provided for the component to be able to fetch th
 
 ## Customizing the buttons
 
-You can pass in your own button or link for the show and hide buttons of the component by passing in any element with `slot="show-button"` and `slot="hide-button"` as an attribute respectively. [Read more about slots][slot].
+You can pass in your own button or link for the show and hide buttons of the component by passing in
+any element with `slot="show-button"` and `slot="hide-button"` as an attribute respectively. [Read
+more about slots][slot].
 
 ```jsx
 <manifold-credentials resource-label="my-resource">
-  <MyButton slot="show-button">
-    Show credentials
-  </MyButton>
-  <MyButton slot="hide-button">
-    Hide credentials
-  </MyButton>
+  <MyButton slot="show-button">Show credentials</MyButton>
+  <MyButton slot="hide-button">Hide credentials</MyButton>
 </manifold-credentials>
 ```
-

--- a/docs/docs/components/manifold-credentials.md
+++ b/docs/docs/components/manifold-credentials.md
@@ -1,7 +1,8 @@
 ---
 title: '🔒 Resource Credentials'
 path: '/components/credentials'
-example: '<manifold-credentials resource-name="cms-stage"></manifold-credentials>'
+example: |
+  <manifold-credentials-view></manifold-credentials-view>
 ---
 
 # 🔒 Credentials

--- a/docs/docs/components/manifold-resource-status.md
+++ b/docs/docs/components/manifold-resource-status.md
@@ -9,24 +9,24 @@ example: '<manifold-mock-resource><manifold-resource-status></manifold-resource-
 Displays an availability tag for a resource. Can be used standalone without any data fetching.
 
 ```html
-  <manifold-resource-status-view state="available"></manifold-resource-product>
+<manifold-resource-status state="available"></manifold-resource-status>
 ```
 
 ## Resource states
 
 ```html
-  <manifold-resource-status-view state="available"></manifold-resource-product>
-  <manifold-resource-status-view state="provision"></manifold-resource-product>
-  <manifold-resource-status-view state="degraded"></manifold-resource-product>
-  <manifold-resource-status-view state="offline"></manifold-resource-product>
+<manifold-resource-status state="available"></manifold-resource-status>
+<manifold-resource-status state="provision"></manifold-resource-status>
+<manifold-resource-status state="degraded"></manifold-resource-status>
+<manifold-resource-status state="offline"></manifold-resource-status>
 ```
 
 ## Sizes
 
 ```html
-  <manifold-resource-status-view size="xsmall" state="available"></manifold-resource-product>
-  <manifold-resource-status-view size="small" state="available"></manifold-resource-product>
-  <manifold-resource-status-view size="medium" state="available"></manifold-resource-product>
+<manifold-resource-status size="xsmall" state="available"></manifold-resource-status>
+<manifold-resource-status size="small" state="available"></manifold-resource-status>
+<manifold-resource-status size="medium" state="available"></manifold-resource-status>
 ```
 
 ## Loading state

--- a/docs/docs/data/manifold-data-deprovision-button.md
+++ b/docs/docs/data/manifold-data-deprovision-button.md
@@ -21,7 +21,8 @@ Set the CTA text by adding anything between the opening and closing tags:
 </manifold-data-deprovision-button>
 ```
 
-`slot` can be attached to any HTML or JSX element. To read more about slots, see [Stencil’s Documentation][stencil-slot]
+`slot` can be attached to any HTML or JSX element. To read more about slots, see [Stencil’s
+Documentation][stencil-slot]
 
 ## Events
 
@@ -31,27 +32,29 @@ For validation, error, and success messages, it will emit custom events.
 document.addEventListener('manifold-deprovisionButton-click', ({ detail: { resourceLabel } }) =>
   console.info(`⌛ Deprovisioning ${resourceLabel} …`)
 );
-document.addEventListener(
-  'manifold-deprovisionButton-success',
-  ({ detail: { resourceLabel } }) =>alert(`${resourceLabel} deprovisioned successfully!`)
+document.addEventListener('manifold-deprovisionButton-success', ({ detail: { resourceLabel } }) =>
+  alert(`${resourceLabel} deprovisioned successfully!`)
 );
 document.addEventListener('manifold-deprovisionButton-error', ({ detail }) => console.log(detail));
-// {message: "bad_request: bad_request: No plan_id provided", resourceid: "1234", resourceLabel: "my-resource"}
+// {
+//   message: 'bad_request: bad_request: No plan_id provided',
+//   resourceid: '1234',
+//   resourceLabel: 'my-resource',
+// }
 ```
 
 | Name                                 | Returns                                  | Description                                                                                                                 |
-|--------------------------------------|------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| ------------------------------------ | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `manifold-deprovisionButton-click`   | `resourceLabel`                          | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
 | `manifold-deprovisionButton-success` | `message`, `resourceId`, `resourceLabel` | Successful deprovision. Returns a resource ID and resource Label.                                                           |
-| `manifold-deprovisionButton-error`   | `message`, `resourceId`, `resourceLabel` | Erred deprovision, along with information on what went wrong.                                                                 |
+| `manifold-deprovisionButton-error`   | `message`, `resourceId`, `resourceLabel` | Erred deprovision, along with information on what went wrong.                                                               |
 
 ## Styling
 
-Whereas other components in this system take advantage of [Shadow
-DOM][shadow-dom] encapsulation for ease of use, we figured this component
-should be customizable. As such, style it however you’d like! We recommend
-attaching styles to a parent element using any CSS-in-JS framework of your
-choice, or plain ol’ CSS.
+Whereas other components in this system take advantage of [Shadow DOM][shadow-dom] encapsulation for
+ease of use, we figured this component should be customizable. As such, style it however you’d like!
+We recommend attaching styles to a parent element using any CSS-in-JS framework of your choice, or
+plain ol’ CSS.
 
 [shadow-dom]: https://developers.google.com/web/fundamentals/web-components/shadowdom
 [stencil-slot]: https://stenciljs.com/docs/templating-jsx/

--- a/docs/docs/data/manifold-data-rename-button.md
+++ b/docs/docs/data/manifold-data-rename-button.md
@@ -1,12 +1,12 @@
 ---
 title: "\U0001F512 Rename Button"
-path: "/data/rename-button"
+path: '/data/rename-button'
 example: |
   <manifold-data-rename-button resource-label="my-resource">
     Rename resource
   </manifold-data-rename-button>
-
 ---
+
 # 🔒 Rename Button
 
 An unstyled button for renaming resources. 🔒 Requires authentication.
@@ -40,9 +40,19 @@ document.addEventListener(
     alert(`${resourceLabel} renamed to ${newLabel} successfully!`)
 );
 document.addEventListener('manifold-renameButton-error', ({ detail }) => console.log(detail));
-// {message: "bad_request: bad_request: No plan_id provided", resourceid: "1234", resourceLabel: "my-resource", newLabel: "new-name"}
+// {
+//   message: 'bad_request: bad_request: No plan_id provided',
+//   resourceid: '1234',
+//   resourceLabel: 'my-resource',
+//   newLabel: 'new-name',
+// }
 document.addEventListener('manifold-renameButton-invalid', ({ detail }) => console.log(detail));
-// {message: "bad_request: bad_request: No plan_id provided", resourceid: "1234", resourceLabel: "my-resource", newLabel: "new-name"}
+// {
+//   message: 'bad_request: bad_request: No plan_id provided',
+//   resourceid: '1234',
+//   resourceLabel: 'my-resource',
+//   newLabel: 'new-name',
+// }
 ```
 
 | Name                            |                       Returns                        | Description                                                                                                                 |

--- a/docs/docs/data/manifold-data-sso-button.md
+++ b/docs/docs/data/manifold-data-sso-button.md
@@ -21,7 +21,8 @@ Set the CTA text by adding anything between the opening and closing tags:
 </manifold-data-sso-button>
 ```
 
-`slot` can be attached to any HTML or JSX element. To read more about slots, see [Stencil’s Documentation][stencil-slot]
+`slot` can be attached to any HTML or JSX element. To read more about slots, see [Stencil’s
+Documentation][stencil-slot]
 
 ## Events
 
@@ -33,25 +34,29 @@ document.addEventListener('manifold-ssoButton-click', ({ detail: { resourceLabel
 );
 document.addEventListener(
   'manifold-ssoButton-success',
-  ({ detail: { resourceLabel, redirectUrl } }) => window.location = redirectUrl
+  ({ detail: { resourceLabel, redirectUrl } }) => (window.location = redirectUrl)
 );
 document.addEventListener('manifold-ssoButton-error', ({ detail }) => console.log(detail));
-// {type: "not_found", message: "not_found: Resource not found", resourceid: "1234", resourceLabel: "my-resource"}
+// {
+//   type: 'not_found',
+//   message: 'not_found: Resource not found',
+//   resourceid: '1234',
+//   resourceLabel: 'my-resource',
+// }
 ```
 
-| Name                         |                       Returns                               | Description                                                                                                                 |
-| :----------------------------| :---------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------- |
-| `manifold-ssoButton-click`   |              `resourceId`, `resourceLabel`                  | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
-| `manifold-ssoButton-success` |   `message`, `resourceId`, `resourceLabel`, `redirectUrl`   | Successful sso. Returns a resource ID, resource Label and the redirect_url for the product's dashboard.                     |
-| `manifold-ssoButton-error`   |           `message`, `resourceId`, `resourceLabel`          | Erred sso, along with information on what went wrong.                                                                       |
+| Name                         |                         Returns                         | Description                                                                                                                 |
+| :--------------------------- | :-----------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------- |
+| `manifold-ssoButton-click`   |              `resourceId`, `resourceLabel`              | Fires immediately when button is clicked. May be used to trigger a loading state, until `-success` or `-error` is received. |
+| `manifold-ssoButton-success` | `message`, `resourceId`, `resourceLabel`, `redirectUrl` | Successful sso. Returns a resource ID, resource Label and the redirect_url for the product's dashboard.                     |
+| `manifold-ssoButton-error`   |        `message`, `resourceId`, `resourceLabel`         | Erred sso, along with information on what went wrong.                                                                       |
 
 ## Styling
 
-Whereas other components in this system take advantage of [Shadow
-DOM][shadow-dom] encapsulation for ease of use, we figured this component
-should be customizable. As such, style it however you’d like! We recommend
-attaching styles to a parent element using any CSS-in-JS framework of your
-choice, or plain ol’ CSS.
+Whereas other components in this system take advantage of [Shadow DOM][shadow-dom] encapsulation for
+ease of use, we figured this component should be customizable. As such, style it however you’d like!
+We recommend attaching styles to a parent element using any CSS-in-JS framework of your choice, or
+plain ol’ CSS.
 
 [shadow-dom]: https://developers.google.com/web/fundamentals/web-components/shadowdom
 [stencil-slot]: https://stenciljs.com/docs/templating-jsx/

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "generate:specs:marketplace": "npx @manifoldco/swagger-to-ts src/spec/marketplace/v1.yaml -w 'export namespace Marketplace' -o src/types/marketplace.ts",
     "generate:specs:provisioning": "npx @manifoldco/swagger-to-ts src/spec/provisioning/v1.yaml -w 'export namespace Provisioning' -o src/types/provisioning.ts",
     "generate:specs:connector": "npx @manifoldco/swagger-to-ts src/spec/connector/v1.yaml -w 'export namespace Connector' -o src/types/connector.ts",
-    "happo": "npm run build && cp .manifold-ci.yml .manifold.yml && manifold run -- happo run",
+    "happo": "npm run build && manifold run -t manifold -p manifold-ui-ci -- happo run",
     "happo-ci-circleci": "npm run build && happo-ci-circleci",
     "heroku-postbuild": "npm run build:docs",
     "lint": "npm run lint:js && npm run lint:css && npm run prepare:docs && cd docs && npm i && npm run lint",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -10,6 +10,7 @@ import {
   Catalog,
 } from './types/catalog';
 import {
+  CredentialEdge,
   PlanConnection,
   Product,
   ProductEdge,
@@ -26,9 +27,6 @@ import {
 import {
   RestFetch,
 } from './utils/restFetch';
-import {
-  Marketplace,
-} from './types/marketplace';
 import {
   AuthToken,
 } from './types/auth';
@@ -92,15 +90,14 @@ export namespace Components {
     'startingAt'?: boolean;
   }
   interface ManifoldCredentials {
-    'resourceId'?: string;
-    'resourceLabel': string;
     /**
     * _(hidden)_
     */
-    'restFetch'?: RestFetch;
+    'graphqlFetch'?: GraphqlFetch;
+    'resourceLabel'?: string;
   }
   interface ManifoldCredentialsView {
-    'credentials'?: Marketplace.Credential[];
+    'credentials'?: CredentialEdge[];
     'loading': boolean;
     'resourceLabel': string;
   }
@@ -1159,15 +1156,14 @@ declare namespace LocalJSX {
     'startingAt'?: boolean;
   }
   interface ManifoldCredentials extends JSXBase.HTMLAttributes<HTMLManifoldCredentialsElement> {
-    'resourceId'?: string;
-    'resourceLabel'?: string;
     /**
     * _(hidden)_
     */
-    'restFetch'?: RestFetch;
+    'graphqlFetch'?: GraphqlFetch;
+    'resourceLabel'?: string;
   }
   interface ManifoldCredentialsView extends JSXBase.HTMLAttributes<HTMLManifoldCredentialsViewElement> {
-    'credentials'?: Marketplace.Credential[];
+    'credentials'?: CredentialEdge[];
     'loading'?: boolean;
     'onCredentialsRequested'?: (event: CustomEvent<any>) => void;
     'resourceLabel'?: string;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -95,11 +95,11 @@ export namespace Components {
     */
     'graphqlFetch'?: GraphqlFetch;
     'resourceLabel'?: string;
+    'showCredentials': () => Promise<void>;
   }
   interface ManifoldCredentialsView {
     'credentials'?: CredentialEdge[];
     'loading': boolean;
-    'resourceLabel': string;
   }
   interface ManifoldDataDeprovisionButton {
     'loading'?: boolean;
@@ -1166,7 +1166,6 @@ declare namespace LocalJSX {
     'credentials'?: CredentialEdge[];
     'loading'?: boolean;
     'onCredentialsRequested'?: (event: CustomEvent<any>) => void;
-    'resourceLabel'?: string;
   }
   interface ManifoldDataDeprovisionButton extends JSXBase.HTMLAttributes<HTMLManifoldDataDeprovisionButtonElement> {
     'loading'?: boolean;

--- a/src/components/manifold-credentials-view/manifold-credentials-view-happo.ts
+++ b/src/components/manifold-credentials-view/manifold-credentials-view-happo.ts
@@ -3,7 +3,6 @@ import fromJSON from '../../spec/mock/fromJSON';
 
 export const credsHidden = () => {
   const creds = document.createElement('manifold-credentials-view');
-  creds.resourceLabel = 'test';
 
   document.body.appendChild(creds);
 
@@ -12,7 +11,6 @@ export const credsHidden = () => {
 
 export const credsShown = () => {
   const creds = document.createElement('manifold-credentials-view');
-  creds.resourceLabel = 'test';
   creds.credentials = fromJSON(credentials);
 
   document.body.appendChild(creds);
@@ -31,7 +29,6 @@ export const resourceLoading = () => {
 
 export const credsHiddenWithCustomButton = () => {
   const creds = document.createElement('manifold-credentials-view');
-  creds.resourceLabel = 'test';
 
   const button = document.createElement('manifold-button');
   button.color = 'orange';
@@ -50,7 +47,6 @@ export const credsHiddenWithCustomButton = () => {
 
 export const credsShownWithCustomButton = () => {
   const creds = document.createElement('manifold-credentials-view');
-  creds.resourceLabel = 'test';
   creds.credentials = fromJSON(credentials);
 
   const button = document.createElement('manifold-button');

--- a/src/components/manifold-credentials-view/manifold-credentials-view.css
+++ b/src/components/manifold-credentials-view/manifold-credentials-view.css
@@ -90,6 +90,8 @@
 
 .secrets {
   min-height: var(--height);
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .secrets-menu {

--- a/src/components/manifold-credentials-view/manifold-credentials-view.tsx
+++ b/src/components/manifold-credentials-view/manifold-credentials-view.tsx
@@ -105,7 +105,7 @@ export class ManifoldCredentialsView {
       <div
         class="credential"
         data-showing={!!this.credentials}
-        style={{ height: `${(this.credentials && this.credentials.length) || 0 * 1.75}em` }}
+        style={{ height: this.credentials ? `${this.credentials.length * 1.75}em` : undefined }}
       >
         <div class="screen-left" />
         <div class="screen-right" />

--- a/src/components/manifold-credentials-view/manifold-credentials-view.tsx
+++ b/src/components/manifold-credentials-view/manifold-credentials-view.tsx
@@ -9,10 +9,9 @@ import logger from '../../utils/logger';
   styleUrl: 'manifold-credentials-view.css',
   shadow: true,
 })
-export class ManifoldResourceCredentials {
+export class ManifoldCredentialsView {
   @Element() private el: HTMLElement;
   @Prop() credentials?: CredentialEdge[];
-  @Prop() resourceLabel: string = '';
   @Prop() loading: boolean = false;
   @State() shouldTransition: boolean = false;
   @Event() credentialsRequested: EventEmitter;
@@ -21,12 +20,13 @@ export class ManifoldResourceCredentials {
   hideButtonEl?: Element;
 
   componentDidLoad() {
-    // hack to prevent “Hide credentials” from being visible on load in Firefox
+    this.findNodes();
+    this.addListeners();
+
+    // hide the first transition for 250ms (long enough to transition in)
     setTimeout(() => {
       this.shouldTransition = true;
     }, 250);
-    this.findNodes();
-    this.addListeners();
   }
 
   componentDidUpdate() {
@@ -35,18 +35,16 @@ export class ManifoldResourceCredentials {
     this.addListeners();
   }
 
-  componentDidUnload() {
+  componentWillUnload() {
     this.removeListeners();
   }
 
   findNodes() {
-    this.el.childNodes.forEach(child => {
-      if ((child as HTMLElement).getAttribute('slot') === 'show-button') {
-        this.showButtonEl =
-          (child as HTMLElement).querySelector('*:not(manifold-forward-slot)') || undefined;
-      } else if ((child as HTMLElement).getAttribute('slot') === 'hide-button') {
-        this.hideButtonEl =
-          (child as HTMLElement).querySelector('*:not(manifold-forward-slot)') || undefined;
+    this.el.childNodes.forEach((child: HTMLElement) => {
+      if (child.getAttribute('slot') === 'show-button') {
+        this.showButtonEl = child.querySelector('*:not(manifold-forward-slot)') || undefined;
+      } else if (child.getAttribute('slot') === 'hide-button') {
+        this.hideButtonEl = child.querySelector('*:not(manifold-forward-slot)') || undefined;
       }
     });
   }

--- a/src/components/manifold-credentials-view/manifold-credentials-view.tsx
+++ b/src/components/manifold-credentials-view/manifold-credentials-view.tsx
@@ -19,10 +19,12 @@ export class ManifoldCredentialsView {
   showButtonEl?: Element;
   hideButtonEl?: Element;
 
-  componentDidLoad() {
+  componentWillLoad() {
     this.findNodes();
     this.addListeners();
+  }
 
+  componentDidLoad() {
     // hide the first transition for 250ms (long enough to transition in)
     setTimeout(() => {
       this.shouldTransition = true;

--- a/src/components/manifold-credentials/manifold-credentials.tsx
+++ b/src/components/manifold-credentials/manifold-credentials.tsx
@@ -1,4 +1,4 @@
-import { h, Element, Component, Prop, State } from '@stencil/core';
+import { h, Element, Component, Method, Prop, State } from '@stencil/core';
 import { gql } from '@manifoldco/gql-zero';
 
 import { CredentialEdge } from '../../types/graphql';
@@ -21,7 +21,8 @@ export class ManifoldCredentials {
     this.credentials = undefined;
   };
 
-  fetchCredentials = async () => {
+  @Method()
+  async showCredentials() {
     if (!this.graphqlFetch) {
       return;
     }
@@ -56,10 +57,10 @@ export class ManifoldCredentials {
       undefined;
 
     this.loading = false;
-  };
+  }
 
   credentialsRequested = () => {
-    this.fetchCredentials();
+    this.showCredentials();
     this.loading = false;
   };
 
@@ -70,7 +71,6 @@ export class ManifoldCredentials {
         credentials={this.credentials}
         loading={this.loading}
         onCredentialsRequested={this.credentialsRequested}
-        resourceLabel={this.resourceLabel}
       >
         <manifold-forward-slot slot="show-button">
           <slot name="show-button" />
@@ -79,7 +79,7 @@ export class ManifoldCredentials {
           <slot name="hide-button" />
         </manifold-forward-slot>
       </manifold-credentials-view>,
-      this.errors
+      Array.isArray(this.errors)
         ? this.errors.map(({ message }) => (
             <manifold-toast alert-type="error">{message}</manifold-toast>
           ))

--- a/src/components/manifold-resource-credentials/manifold-resource-credentials.tsx
+++ b/src/components/manifold-resource-credentials/manifold-resource-credentials.tsx
@@ -12,10 +12,7 @@ export class ManifoldResourceCredentials {
   @logger()
   render() {
     return (
-      <manifold-credentials
-        resourceLabel={this.data && this.data.label}
-        resourceId={this.data && this.data.id}
-      >
+      <manifold-credentials resourceLabel={this.data && this.data.label}>
         <manifold-forward-slot slot="show-button">
           <slot name="show-button" />
         </manifold-forward-slot>

--- a/src/spec/mock/cms-stage/credentials.json
+++ b/src/spec/mock/cms-stage/credentials.json
@@ -1,16 +1,8 @@
 [
   {
-    "body": {
-      "created_at": "2019-05-09T16:31:39.977Z",
-      "resource_id": "2688md3pntgz1njdzm5kz124m7nta",
-      "source": "catalog",
-      "updated_at": "2019-05-09T16:31:39.977Z",
-      "values": {
-        "JWT_API_KEY": "HEAVILY-REDACTED"
-      }
-    },
-    "id": "268p7hxf849r6r77a6augfh4uqm8p",
-    "type": "credential",
-    "version": 1
+    "node": {
+      "key": "JWT_API_KEY",
+      "value": "HEAVILY-REDACTED"
+    }
   }
 ]


### PR DESCRIPTION
## Reason for change

Updates `<manifold-credentials>` to use GraphQL

Performance Δ in `ms` (15 trials)

|                     | REST       | GraphQL       | Reduction |
|:------------|:----------|:------------|:----------:|
| **Mean**    |  `174.3 ms` | `173.7 ms`   |    0%       |
| **Median** |  `166 ms`  | `150 ms`      |     10%        |
| **Payload** |  `0.4 KB`  |  `0.3 KB` |       25%       |

Result: **improvement** (barely) 🎉 

## Testing

- [ ] Verify `<manifold-credentials>` works in Storybook when setting `manifold_api_token` (click on **Knobs** to change it to a resource name you have access to)
- [ ] Read the **Resource Helpers** section of the docs to see if it makes more sense (compare to the [version in master](http://ui.sandbox.manifold.co/advanced/resource-details/?theme=default))

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [x] **Prop changes**: [docs][docs] were updated
- [x] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [x] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
