### PR TITLE
MVP: Manual Authentication

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -41,6 +41,7 @@ export namespace Components {
     'selectedResource'?: Gateway.Resource;
   }
   interface ManifoldAuthToken {
+    'authType'?: AuthType;
     /**
     * _(hidden)_
     */
@@ -1081,6 +1082,8 @@ declare namespace LocalJSX {
     'selectedResource'?: Gateway.Resource;
   }
   interface ManifoldAuthToken extends JSXBase.HTMLAttributes<HTMLManifoldAuthTokenElement> {
+    'authType'?: AuthType;
+    'onManifold-token-clear'?: (event: CustomEvent<any>) => void;
     'onManifold-token-receive'?: (event: CustomEvent<{ token: string }>) => void;
     /**
     * _(hidden)_


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->
## MVP

This is an alternative MVP for manual authentication requirements, the first one being #491. In this version, we emit an event and expect the platform to update the `token` prop on our web component. There's a test here that proves this works.

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
