### PR TITLE
Allow manual authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Added a time to first meaningful render event to be consumed by `<manifold-performance>` component
 
+### Added
+
+- Ability to authenticate and refresh manually, bypassing OAuth. (#495)
+
 ### Changed
 
 - Changed `manifold-marketplace` to use GraphQL. (#489)

--- a/docs/docs/data/manifold-auth-token.md
+++ b/docs/docs/data/manifold-auth-token.md
@@ -5,8 +5,19 @@ path: /data/auth-token
 
 # Auth Token
 
-This component handles [auth][auth] for our components. This is merely a list of options and events;
-to see the full picture please refer to the [guide][auth] on the subject.
+<manifold-toast alert-type="warning">
+  <div>This component may be deprecated in the near-future in favor of
+  setting tokens directly on <code>&lt;manifold-connection/&gt;</code></div>
+</manifold-toast>
+
+For all resource-specific operations (creating resources, viewing resources, etc.) the web
+components will need user-level authentication. This component supports two methods of
+authentication: **OAuth** (default) and **manual**.
+
+## Authenticating with OAuth (default)
+
+OAuth is the default method of authentication handled by this component. This is merely a list of
+options and events; to see the full picture please refer to the [guide][auth] on the subject.
 
 This component must be always be used inside [Connection][connection] like so:
 
@@ -21,7 +32,7 @@ OAuth dance can take a couple seconds, so the sooner this can start the faster i
 users). We also recommend **only placing it on the page once** to avoid multiple token requests
 per-page.
 
-## Caching for performance
+### Caching for performance
 
 Sometimes the OAuth dance can take a couple seconds to complete. In that light, we strongly
 recommend caching the token somewhere so that new tokens are only requested when necessary.
@@ -57,6 +68,29 @@ interruption on the user side. Nothing is required on your part for an expired t
 caching set up via the `manifold-token-receive` event listener, your cache will be updated whenever
 new tokens are received.
 
+## Authenticating Manually
+
+Alternately, if you’d like to skip the OAuth process in favor for your own, you may do so like this:
+
+```html
+<manifold-connoction>
+  <manifold-auth-token auth-type="manual" token="my-token"></manifold-auth-token>
+</manifold-connection>
+```
+
+You’ll also need to specify a mechanism for retrieving a new token. It will fire a method you
+specify every time an authorization request fails. You’ll need to attach this method on the
+component itself like so:
+
+```js
+const component = document.querySelector('manifold-auth-token');
+
+component.addEventListener('manifold-token-clear', async () => {
+  const token = await myGetTokenFunction(); // replace this with your token retrieval call
+  component.token = token;
+});
+```
+
 ## Events
 
 The following custom events are emitted to `document`. You can listen for events like so:
@@ -73,9 +107,10 @@ document.addEventListener('manifold-token-receive', ({ detail }) => {
 });
 ```
 
-| Event Name               | Description                              | Data                                   |
-| :----------------------- | :--------------------------------------- | :------------------------------------- |
-| `manifold-token-receive` | Emitted whenever a new token is received | `token`, `expiry`, `error`, `duration` |
+| Event Name               | Description                                                                  | Data                                   |
+| :----------------------- | :--------------------------------------------------------------------------- | :------------------------------------- |
+| `manifold-token-clear`   | Emitted whenever a token fails an auth request. Use this to set a new token. | `token`, `expiry`, `error`, `duration` |
+| `manifold-token-receive` | Emitted whenever a new token is received                                     | `token`, `expiry`, `error`, `duration` |
 
 [connection]: /connection
 [auth]: /advanced/authentication

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -43,6 +43,7 @@ export namespace Components {
     'selectedResource'?: Gateway.Resource;
   }
   interface ManifoldAuthToken {
+    'authType'?: AuthType;
     /**
     * _(hidden)_
     */
@@ -1108,6 +1109,8 @@ declare namespace LocalJSX {
     'selectedResource'?: Gateway.Resource;
   }
   interface ManifoldAuthToken extends JSXBase.HTMLAttributes<HTMLManifoldAuthTokenElement> {
+    'authType'?: AuthType;
+    'onManifold-token-clear'?: (event: CustomEvent<any>) => void;
     'onManifold-token-receive'?: (event: CustomEvent<{ token: string }>) => void;
     /**
     * _(hidden)_

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -22,6 +22,9 @@ import {
   Subscriber,
 } from './state/connection';
 import {
+  AuthType,
+} from './components/manifold-auth-token/manifold-auth-token';
+import {
   GraphqlFetch,
 } from './utils/graphqlFetch';
 import {

--- a/src/components/manifold-auth-token/manifold-auth-token.spec.ts
+++ b/src/components/manifold-auth-token/manifold-auth-token.spec.ts
@@ -4,7 +4,7 @@ import { ConnectionState, Subscriber } from '../../state/connection';
 
 interface Props {
   token?: string;
-  authType?: string;
+  authType?: 'oauth' | 'manual';
   setAuthToken?: (s: string) => void;
   subscribe?: (s: Subscriber) => () => void;
 }
@@ -81,7 +81,7 @@ describe('<manifold-auth-token>', () => {
     it('does not render an iframe', async () => {
       const connection = new ConnectionState();
       connection.authToken = 'foo';
-      const props = {
+      const props: Props = {
         token: connection.authToken,
         authType: 'manual',
         setAuthToken: connection.setAuthToken,
@@ -97,7 +97,7 @@ describe('<manifold-auth-token>', () => {
       it('allows the consumer to reset the token', async () => {
         const connection = new ConnectionState();
         connection.authToken = 'foo';
-        const props = {
+        const props: Props = {
           token: connection.authToken,
           authType: 'manual',
           setAuthToken: connection.setAuthToken,

--- a/src/components/manifold-auth-token/manifold-auth-token.spec.ts
+++ b/src/components/manifold-auth-token/manifold-auth-token.spec.ts
@@ -1,15 +1,25 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { ManifoldAuthToken } from './manifold-auth-token';
+import { ConnectionState, Subscriber } from '../../state/connection';
 
-async function setup(token?: string) {
+interface Props {
+  token?: string;
+  authType?: string;
+  setAuthToken?: (s: string) => void;
+  subscribe?: (s: Subscriber) => () => void;
+}
+
+async function setup(props: Props) {
   const page = await newSpecPage({
     components: [ManifoldAuthToken],
     html: '<div></div>',
   });
 
   const component = page.doc.createElement('manifold-auth-token');
-  component.token = token;
-  component.setAuthToken = jest.fn();
+  component.token = props.token;
+  component.authType = props.authType;
+  component.setAuthToken = props.setAuthToken;
+  component.subscribe = props.subscribe;
 
   const root = page.root as HTMLDivElement;
   root.appendChild(component);
@@ -21,7 +31,7 @@ async function setup(token?: string) {
 describe('<manifold-auth-token>', () => {
   describe('when the token is received', () => {
     it('emits an event', async () => {
-      const { component, page } = await setup();
+      const { component, page } = await setup({});
 
       const shadowcat = component.querySelector('manifold-oauth');
       expect(shadowcat).toBeDefined();
@@ -51,19 +61,68 @@ describe('<manifold-auth-token>', () => {
 
   it('calls the set auth token on load', async () => {
     const token = `test`;
-    const { component } = await setup(token);
+    const { component } = await setup({ token, setAuthToken: jest.fn() });
 
     expect(component.setAuthToken).toHaveBeenCalledWith(token);
   });
 
   it('calls the set auth token on change', async () => {
     const token = `test`;
-    const { component, page } = await setup(token);
+    const { component, page } = await setup({ token, setAuthToken: jest.fn() });
 
     const newToken = `test-new`;
     component.token = newToken;
     await page.waitForChanges();
 
     expect(component.setAuthToken).toHaveBeenCalledWith(newToken);
+  });
+
+  describe('When using manual auth', () => {
+    it('does not render an iframe', async () => {
+      const connection = new ConnectionState();
+      connection.authToken = 'foo';
+      const props = {
+        token: connection.authToken,
+        authType: 'manual',
+        setAuthToken: connection.setAuthToken,
+        subscribe: connection.subscribe,
+      };
+      const { page } = await setup(props);
+
+      const iframe = page.doc.querySelector('iframe');
+      expect(iframe).toBeNull();
+    });
+
+    describe('when the token is cleared', () => {
+      it('allows the consumer to reset the token', async () => {
+        const connection = new ConnectionState();
+        connection.authToken = 'foo';
+        const props = {
+          token: connection.authToken,
+          authType: 'manual',
+          setAuthToken: connection.setAuthToken,
+          subscribe: connection.subscribe,
+        };
+        const { component, page } = await setup(props);
+
+        const received = jest.fn();
+        component.addEventListener('manifold-token-receive', received);
+
+        const listen = new Promise(resolve => {
+          component.addEventListener('manifold-token-clear', async () => {
+            component.token = 'bar';
+            await page.waitForChanges();
+            resolve();
+          });
+        });
+
+        connection.setAuthToken('');
+
+        await listen;
+        expect(received).toHaveBeenCalledWith(
+          expect.objectContaining({ detail: { token: 'bar' } })
+        );
+      });
+    });
   });
 });

--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -6,7 +6,7 @@ import loadMark from '../../utils/loadMark';
 import { report } from '../../utils/errorReport';
 import connection, { Subscriber } from '../../state/connection';
 
-type AuthType = 'oauth' | 'manual';
+export type AuthType = 'oauth' | 'manual';
 
 @Component({ tag: 'manifold-auth-token' })
 export class ManifoldAuthToken {

--- a/stories/data/connectionDecorator.js
+++ b/stories/data/connectionDecorator.js
@@ -7,6 +7,7 @@ export const manifoldConnectionDecorator = storyFn => {
   const token = text('manifold_api_token', localStorage.getItem('manifold_api_token') || '');
   const options = { Production: 'prod', Staging: 'stage' };
   const env = radios('env', options, 'prod');
+  const authType = radios('authType', { Manual: 'manual', Oauth: 'oauth' }, 'manual');
   localStorage.setItem('manifold_api_token', token); // update localStorage to persist
 
   // grab user ID from Manifold (we need this in other stories)
@@ -23,7 +24,7 @@ export const manifoldConnectionDecorator = storyFn => {
 
   return `
   <manifold-connection env="${env}">
-    <manifold-auth-token token="${token}|${new Date(Date.now() + 6.04e8).getTime()}"/>
+    <manifold-auth-token token="${token}" auth-type="${authType}"></manifold-auth-token>
     ${storyFn()}
   </manifold-connection>
 `;

--- a/stories/scenarios.stories.js
+++ b/stories/scenarios.stories.js
@@ -19,7 +19,7 @@ function withVeryFakeExpiry(token) {
 
 storiesOf('Scenarios', module)
   .addDecorator(withKnobs)
-  .add('Auth', () => {
+  .add('auth', () => {
     const options = { Production: 'prod', Staging: 'stage' };
     const env = radios('env', options, 'stage');
     const authType = radios('authType', { Manual: 'manual', Oauth: 'oauth' }, 'oauth');

--- a/stories/scenarios.stories.js
+++ b/stories/scenarios.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/html';
-import { withKnobs, radios } from '@storybook/addon-knobs';
+import { withKnobs, radios, text } from '@storybook/addon-knobs';
 import { manifoldConnectionDecorator } from './data/connectionDecorator';
 
 function withVeryFakeExpiry(token) {
@@ -19,17 +19,18 @@ function withVeryFakeExpiry(token) {
 
 storiesOf('Scenarios', module)
   .addDecorator(withKnobs)
-  .add('OAuth', () => {
+  .add('Auth', () => {
     const options = { Production: 'prod', Staging: 'stage' };
     const env = radios('env', options, 'stage');
+    const authType = radios('authType', { Manual: 'manual', Oauth: 'oauth' }, 'oauth');
+    const token = text('manifold_api_token', localStorage.getItem('manifold_api_token') || '');
+
     return `
       <manifold-connection env="${env}">
         <manifold-performance>
           <p><em>These resources are loaded from the server rather than mocks</em></p>
-          <manifold-auth-token token="${withVeryFakeExpiry(
-            localStorage.getItem('manifold_api_token') || ''
-          )}"/>
-          <manifold-resource-list />
+          <manifold-auth-token token="${token}" auth-type="${authType}"></manifold-auth-token>
+          <manifold-resource-list></manifold-resource-list>
         </manifold-performance>
       </manifold-connection>`;
   })


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

Some platforms will want to authenticate and refresh manually, completely skipping the OAuth process. Platforms will provide an initial token and then listen for the `manifold-token-clear` event, which will allow them to fetch a new token and reassign it to the web component.

Example platform usage (vanilla):

```html
<manifold-auth-token auth-type="manual" token="my-token"></manifold-auth-token>
```

```js
const component = document.querySelector('manifold-auth-token');
component.addEventListener('manifold-token-clear', async () => {
  const token = await myGetTokenFunction();
  component.token = token;
});
```
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

Automated tests should pass. 

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
