### PR TITLE
Remove READMEs from Storybook

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,2 +1,1 @@
-import 'storybook-readme/register';
 import '@storybook/addon-knobs/register';

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -2,13 +2,9 @@ import { addDecorator, configure } from '@storybook/html';
 import { defineCustomElements } from '../dist/loader';
 import '../dist/manifold/manifold.css';
 import './theme-manifold.css';
-import { addReadme } from 'storybook-readme/html';
 
 // Init web components
 defineCustomElements();
-
-// storybook-readme
-addDecorator(addReadme);
 
 // Load stories (import all files ending in *.stories.js)
 const req = require.context('../stories', true, /\.stories\.js$/);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2595,41 +2595,6 @@
         }
       }
     },
-    "@storybook/client-logger": {
-      "version": "5.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.1.10.tgz",
-      "integrity": "sha512-vB1NoFWRTgcERwodhbgoDwI00eqU8++nXI7GhMS1CY8haZaSp3gyKfHRWyfH+M+YjQuGBRUcvIk4gK6OtSrDOw==",
-      "dev": true,
-      "requires": {
-        "core-js": "^3.0.1"
-      }
-    },
-    "@storybook/components": {
-      "version": "5.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-5.1.10.tgz",
-      "integrity": "sha512-QUQeeQp1xNWiL4VlxFAea0kqn2zvBfmfPlUddOFO9lBhT6pVy0xYPjXjbTVWjVcYzZpyUNWw5GplqrR5jhlaCA==",
-      "dev": true,
-      "requires": {
-        "@storybook/client-logger": "5.1.10",
-        "@storybook/theming": "5.1.10",
-        "core-js": "^3.0.1",
-        "global": "^4.3.2",
-        "markdown-to-jsx": "^6.9.1",
-        "memoizerific": "^1.11.3",
-        "polished": "^3.3.1",
-        "popper.js": "^1.14.7",
-        "prop-types": "^15.7.2",
-        "react": "^16.8.3",
-        "react-dom": "^16.8.3",
-        "react-focus-lock": "^1.18.3",
-        "react-helmet-async": "^1.0.2",
-        "react-popper-tooltip": "^2.8.3",
-        "react-syntax-highlighter": "^8.0.1",
-        "react-textarea-autosize": "^7.1.0",
-        "recompose": "^0.30.0",
-        "simplebar-react": "^1.0.0-alpha.6"
-      }
-    },
     "@storybook/core": {
       "version": "5.1.11",
       "resolved": "https://registry.npmjs.org/@storybook/core/-/core-5.1.11.tgz",
@@ -2849,15 +2814,6 @@
         }
       }
     },
-    "@storybook/core-events": {
-      "version": "5.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.1.10.tgz",
-      "integrity": "sha512-Lvu/rNcgS+XCkQKSGdNpUSWjpFF9AOSHPXsvkwHbRwJYdMDn3FznlXfDUiubOWtsziXHB6vl3wkKDlH+ckb32Q==",
-      "dev": true,
-      "requires": {
-        "core-js": "^3.0.1"
-      }
-    },
     "@storybook/html": {
       "version": "5.1.11",
       "resolved": "https://registry.npmjs.org/@storybook/html/-/html-5.1.11.tgz",
@@ -2902,34 +2858,6 @@
           "version": "6.7.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
           "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-          "dev": true
-        }
-      }
-    },
-    "@storybook/theming": {
-      "version": "5.1.10",
-      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.1.10.tgz",
-      "integrity": "sha512-5cN1lmdVUwAR8U3T49Lfb8JW5RBvxBSPGZpUmbLGz1zi0tWBJgYXoGtw4RbTBjV9kCQOXkHGH12AsdDxHh931w==",
-      "dev": true,
-      "requires": {
-        "@emotion/core": "^10.0.9",
-        "@emotion/styled": "^10.0.7",
-        "@storybook/client-logger": "5.1.10",
-        "common-tags": "^1.8.0",
-        "core-js": "^3.0.1",
-        "deep-object-diff": "^1.1.0",
-        "emotion-theming": "^10.0.9",
-        "global": "^4.3.2",
-        "memoizerific": "^1.11.3",
-        "polished": "^3.3.1",
-        "prop-types": "^15.7.2",
-        "resolve-from": "^5.0.0"
-      },
-      "dependencies": {
-        "resolve-from": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
           "dev": true
         }
       }
@@ -8936,12 +8864,6 @@
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
     },
-    "get-own-enumerable-property-symbols": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
-      "integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg==",
-      "dev": true
-    },
     "get-stdin": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
@@ -11915,12 +11837,6 @@
       "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
       "dev": true
     },
-    "lodash.toarray": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
-      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
-      "dev": true
-    },
     "lodash.unescape": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
@@ -12134,16 +12050,6 @@
       "integrity": "sha512-XUi5HJhhV5R74k8/0H2oCbCiYf/u4cO/rX8tnGkRvrqhsr5BRNU6Mg0yt/8UIx1iIS8220BNJsDb7XnILhLepw==",
       "dev": true
     },
-    "markdown-loader": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-loader/-/markdown-loader-5.1.0.tgz",
-      "integrity": "sha512-xtQNozLEL+55ZSPTNwro8epZqf1h7HjAZd/69zNe8lbckDiGVHeLQm849bXzocln2pwRK2A/GrW/7MAmwjcFog==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^1.2.3",
-        "marked": "^0.7.0"
-      }
-    },
     "markdown-table": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
@@ -12159,12 +12065,6 @@
         "prop-types": "^15.6.2",
         "unquote": "^1.1.0"
       }
-    },
-    "marked": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
-      "dev": true
     },
     "material-colors": {
       "version": "1.2.6",
@@ -12530,15 +12430,6 @@
       "dev": true,
       "requires": {
         "lower-case": "^1.1.1"
-      }
-    },
-    "node-emoji": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
-      "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
-      "dev": true,
-      "requires": {
-        "lodash.toarray": "^4.4.0"
       }
     },
     "node-fetch": {
@@ -14152,12 +14043,6 @@
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
     },
-    "prism-themes": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/prism-themes/-/prism-themes-1.1.0.tgz",
-      "integrity": "sha512-xBkflbKbstGGasW3P68KQzAuObLQeH//I5mn37jKVHVDrRLp4Xct/n8F/tV5h+CKIMa3nDAZ2q0bt8ItSiS72A==",
-      "dev": true
-    },
     "prismjs": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.16.0.tgz",
@@ -14708,33 +14593,6 @@
       "requires": {
         "classnames": "^2.2.5",
         "prop-types": "^15.6.0"
-      }
-    },
-    "react-element-to-jsx-string": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/react-element-to-jsx-string/-/react-element-to-jsx-string-14.0.3.tgz",
-      "integrity": "sha512-ziZAm7OwEfFtyhCmQiFNI87KFu+G9EP8qVW4XtDHdKNqqprYifLzqXkzHqC1vnVsPhyp2znoPm0bJHAf1mUBZA==",
-      "dev": true,
-      "requires": {
-        "is-plain-object": "3.0.0",
-        "stringify-object": "3.3.0"
-      },
-      "dependencies": {
-        "is-plain-object": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-          "dev": true,
-          "requires": {
-            "isobject": "^4.0.0"
-          }
-        },
-        "isobject": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
-          "dev": true
-        }
       }
     },
     "react-error-overlay": {
@@ -16306,26 +16164,6 @@
       "integrity": "sha512-zzzP5ZY6QWumnAFV6kBRbS44pUMcpZBNER5DWUe1HETlaKXqLcCQxbNu6IHaKr1pUsjuhUGBdOy8sWKmMkL6pQ==",
       "dev": true
     },
-    "storybook-readme": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/storybook-readme/-/storybook-readme-5.0.8.tgz",
-      "integrity": "sha512-Ej3RotbnfFtk4yAFqJ/39RpaDO/1Yw81TzSHJIQDL7O4E/tKn51247zq3KvAC8b7JM5IY5GlNNjS4q8cBEeBAA==",
-      "dev": true,
-      "requires": {
-        "@storybook/components": "^5.0.6",
-        "@storybook/core-events": "^5.0.6",
-        "html-loader": "^0.5.5",
-        "lodash": "^4.17.11",
-        "markdown-loader": "^5.0.0",
-        "marked": "^0.7.0",
-        "node-emoji": "1.10.0",
-        "prism-themes": "^1.1.0",
-        "prismjs": "^1.16.0",
-        "react-element-to-jsx-string": "^14.0.2",
-        "string-raw": "^1.0.1",
-        "vuex": "^3.1.0"
-      }
-    },
     "stream-browserify": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
@@ -16392,12 +16230,6 @@
         }
       }
     },
-    "string-raw": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string-raw/-/string-raw-1.0.1.tgz",
-      "integrity": "sha1-Ab4mZaHPosV1IMkQaY9sonakxyY=",
-      "dev": true
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -16463,25 +16295,6 @@
         "character-entities-legacy": "^1.0.0",
         "is-alphanumerical": "^1.0.0",
         "is-hexadecimal": "^1.0.0"
-      }
-    },
-    "stringify-object": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
-      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
-      "dev": true,
-      "requires": {
-        "get-own-enumerable-property-symbols": "^3.0.0",
-        "is-obj": "^1.0.1",
-        "is-regexp": "^1.0.0"
-      },
-      "dependencies": {
-        "is-regexp": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-          "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
-          "dev": true
-        }
       }
     },
     "strip-ansi": {
@@ -18131,12 +17944,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
       "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==",
-      "dev": true
-    },
-    "vuex": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.1.1.tgz",
-      "integrity": "sha512-ER5moSbLZuNSMBFnEBVGhQ1uCBNJslH9W/Dw2W7GZN23UQA69uapP5GTT9Vm8Trc0PzBSVt6LzF3hGjmv41xcg==",
       "dev": true
     },
     "w3c-hr-time": {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "prettier": "^1.18.2",
     "puppeteer": "1.19.0",
     "rollup-plugin-replace": "^2.2.0",
-    "storybook-readme": "^5.0.8",
     "stylelint": "^10.1.0",
     "stylelint-config-prettier": "^5.2.0",
     "stylelint-config-rational-order": "^0.1.2",

--- a/stories/manifold-auth-token.stories.js
+++ b/stories/manifold-auth-token.stories.js
@@ -1,5 +1,4 @@
 import { storiesOf } from '@storybook/html';
-import markdown from '../docs/docs/advanced/authentication.md';
 
 function withVeryFakeExpiry(token) {
   /* During the ui transition from REST calls to GraphQL and PUMA,
@@ -17,7 +16,6 @@ function withVeryFakeExpiry(token) {
 }
 
 storiesOf('Auth Token Provider [Data]', module)
-  .addParameters({ readme: { sidebar: markdown } })
   .addDecorator(storyFn =>
     localStorage.manifold_api_token
       ? storyFn()

--- a/stories/manifold-button-link.stories.js
+++ b/stories/manifold-button-link.stories.js
@@ -1,6 +1,5 @@
 import { storiesOf } from '@storybook/html';
 import { eye } from '@manifoldco/icons';
-import markdown from '../docs/docs/components/manifold-button-link.md';
 
 const renderButton = color =>
   `
@@ -21,7 +20,6 @@ const renderButton = color =>
   `;
 
 storiesOf('Button Link', module)
-  .addParameters({ readme: { sidebar: markdown } })
   .add('default', () => renderButton())
   .add('black', () => renderButton('black'))
   .add('gray', () => renderButton('gray'))

--- a/stories/manifold-button.stories.js
+++ b/stories/manifold-button.stories.js
@@ -1,6 +1,5 @@
 import { storiesOf } from '@storybook/html';
 import { eye } from '@manifoldco/icons';
-import markdown from '../docs/docs/components/manifold-button.md';
 
 const renderButton = color =>
   `
@@ -24,7 +23,6 @@ const renderButton = color =>
   `;
 
 storiesOf('Button', module)
-  .addParameters({ readme: { sidebar: markdown } })
   .add('default', () => renderButton())
   .add('black', () => renderButton('black'))
   .add('gray', () => renderButton('gray'))

--- a/stories/manifold-data-deprovision-button.stories.js
+++ b/stories/manifold-data-deprovision-button.stories.js
@@ -1,10 +1,8 @@
 import { storiesOf } from '@storybook/html';
 
-import markdown from '../docs/docs/data/manifold-data-deprovision-button.md';
 import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Provision Button [Data]', module)
-  .addParameters({ readme: { sidebar: markdown } })
   .addDecorator(manifoldConnectionDecorator)
   .add(
     'default',

--- a/stories/manifold-data-has-resource.stories.js
+++ b/stories/manifold-data-has-resource.stories.js
@@ -1,10 +1,8 @@
 import { storiesOf } from '@storybook/html';
 
-import markdown from '../docs/docs/components/manifold-resource-list.md';
 import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Has Resources 🔒 [Data]', module)
-  .addParameters({ readme: { sidebar: markdown } })
   .addDecorator(manifoldConnectionDecorator)
   .add(
     'The user has resources',

--- a/stories/manifold-data-manage-button.stories.js
+++ b/stories/manifold-data-manage-button.stories.js
@@ -1,10 +1,8 @@
 import { storiesOf } from '@storybook/html';
 
-import markdown from '../docs/docs/data/manifold-data-manage-button.md';
 import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Manage Button 🔒 [Data]', module)
-  .addParameters({ readme: { sidebar: markdown } })
   .addDecorator(manifoldConnectionDecorator)
   .add(
     'default',

--- a/stories/manifold-data-product-logo.stories.js
+++ b/stories/manifold-data-product-logo.stories.js
@@ -1,13 +1,9 @@
 import { storiesOf } from '@storybook/html';
 
-import markdown from '../docs/docs/data/manifold-data-product-logo.md';
-
-storiesOf('Product Logo [Data]', module)
-  .addParameters({ readme: { sidebar: markdown } })
-  .add(
-    'default',
-    () =>
-      `
+storiesOf('Product Logo [Data]', module).add(
+  'default',
+  () =>
+    `
         <manifold-data-product-logo product-label="aiven-redis"></manifold-data-product-logo>
       `
-  );
+);

--- a/stories/manifold-data-product-name.stories.js
+++ b/stories/manifold-data-product-name.stories.js
@@ -1,12 +1,10 @@
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text } from '@storybook/addon-knobs';
 
-import markdown from '../docs/docs/data/manifold-data-product-name.md';
 import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Product Name', module)
   .addDecorator(withKnobs)
-  .addParameters({ readme: { sidebar: markdown } })
   .addDecorator(manifoldConnectionDecorator)
   .add('from product label', () => {
     const productLabel = text('product-label', 'jawsdb-postgres');

--- a/stories/manifold-data-provision-button.stories.js
+++ b/stories/manifold-data-provision-button.stories.js
@@ -1,10 +1,8 @@
 import { storiesOf } from '@storybook/html';
 
-import markdown from '../docs/docs/data/manifold-data-provision-button.md';
 import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Provision Button [Data]', module)
-  .addParameters({ readme: { sidebar: markdown } })
   .addDecorator(manifoldConnectionDecorator)
   .add(
     'default',

--- a/stories/manifold-data-rename-button.stories.js
+++ b/stories/manifold-data-rename-button.stories.js
@@ -1,10 +1,8 @@
 import { storiesOf } from '@storybook/html';
 
-import markdown from '../docs/docs/data/manifold-data-rename-button.md';
 import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Rename Button 🔒 [Data]', module)
-  .addParameters({ readme: { sidebar: markdown } })
   .addDecorator(manifoldConnectionDecorator)
   .add(
     'default',

--- a/stories/manifold-data-resource-list.stories.js
+++ b/stories/manifold-data-resource-list.stories.js
@@ -1,10 +1,8 @@
 import { storiesOf } from '@storybook/html';
 
-import markdown from '../docs/docs/data/manifold-data-resource-list.md';
 import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Resource List 🔒 [Data]', module)
-  .addParameters({ readme: { sidebar: markdown } })
   .addDecorator(manifoldConnectionDecorator)
   .add(
     'default',
@@ -17,4 +15,5 @@ storiesOf('Resource List 🔒 [Data]', module)
           <li><a href="/resources/logging-test">logging-test</a></li>
         </ul>
       </manifold-data-resource-list>
-    `);
+    `
+  );

--- a/stories/manifold-data-sso-button.stories.js
+++ b/stories/manifold-data-sso-button.stories.js
@@ -1,10 +1,8 @@
 import { storiesOf } from '@storybook/html';
 
-import markdown from '../docs/docs/data/manifold-data-sso-button.md';
 import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('SSO Button 🔒 [Data]', module)
-  .addParameters({ readme: { sidebar: markdown } })
   .addDecorator(manifoldConnectionDecorator)
   .add(
     'default',

--- a/stories/manifold-marketplace.stories.js
+++ b/stories/manifold-marketplace.stories.js
@@ -1,9 +1,6 @@
 import { storiesOf } from '@storybook/html';
 
-import markdown from '../docs/docs/components/manifold-marketplace.md';
-
 storiesOf('Marketplace', module)
-  .addParameters({ readme: { sidebar: markdown } })
   .add(
     'default',
     () =>

--- a/stories/manifold-performance.stories.js
+++ b/stories/manifold-performance.stories.js
@@ -1,10 +1,8 @@
 import { storiesOf } from '@storybook/html';
 
-import markdown from '../docs/docs/components/manifold-performance.md';
 import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Performance', module)
-  .addParameters({ readme: { sidebar: markdown } })
   .addDecorator(manifoldConnectionDecorator)
   .add(
     '<manifold-plan> metrics',

--- a/stories/manifold-plan-selector.stories.js
+++ b/stories/manifold-plan-selector.stories.js
@@ -1,9 +1,6 @@
 import { storiesOf } from '@storybook/html';
 
-import markdown from '../docs/docs/components/manifold-plan-selector.md';
-
 storiesOf('Plan Selector', module)
-  .addParameters({ readme: { sidebar: markdown } })
   .add(
     'Blitline',
     () => '<manifold-plan-selector product-label="blitline"></manifold-plan-selector>'

--- a/stories/manifold-plan.stories.js
+++ b/stories/manifold-plan.stories.js
@@ -1,10 +1,8 @@
 import { storiesOf } from '@storybook/html';
 
-import markdown from '../docs/docs/components/manifold-plan.md';
 import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Plan', module)
-  .addParameters({ readme: { sidebar: markdown } })
   .addDecorator(manifoldConnectionDecorator)
   .add(
     'ElegantCMS Free',

--- a/stories/manifold-product.stories.js
+++ b/stories/manifold-product.stories.js
@@ -1,9 +1,6 @@
 import { storiesOf } from '@storybook/html';
 
-import markdown from '../docs/docs/components/manifold-product.md';
-
 storiesOf('Product', module)
-  .addParameters({ readme: { sidebar: markdown } })
   .add(
     'JawsDB',
     () => `

--- a/stories/manifold-resource-card.stories.js
+++ b/stories/manifold-resource-card.stories.js
@@ -1,17 +1,18 @@
 import { storiesOf } from '@storybook/html';
-import markdown from '../docs/docs/components/manifold-resource-card.md';
 
 storiesOf('Resource card 🔒 ', module)
-  .addParameters({ readme: { sidebar: markdown } })
   .add(
     'View resource',
-    () => '<manifold-resource-card-view name="My resource" label="my-resource" logo="https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png" resource-id="1234" resource-status="available"/>'
+    () =>
+      '<manifold-resource-card-view name="My resource" label="my-resource" logo="https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png" resource-id="1234" resource-status="available"/>'
   )
   .add(
     'Loading resource',
-    () => '<manifold-resource-card-view name="My resource" label="my-resource" logo="https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png" loading="" resource-status="unknown"/>'
+    () =>
+      '<manifold-resource-card-view name="My resource" label="my-resource" logo="https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png" loading="" resource-status="unknown"/>'
   )
   .add(
     'Resource with link',
-    () => '<manifold-resource-card-view name="My resource" label="my-resource" logo="https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png" resource-id="1234" resource-status="unknown" resource-link-format="/resources/:resource" />'
+    () =>
+      '<manifold-resource-card-view name="My resource" label="my-resource" logo="https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png" resource-id="1234" resource-status="unknown" resource-link-format="/resources/:resource" />'
   );

--- a/stories/manifold-resource-credentials.stories.js
+++ b/stories/manifold-resource-credentials.stories.js
@@ -1,10 +1,8 @@
 import { storiesOf } from '@storybook/html';
 
-import markdown from '../docs/docs/components/manifold-credentials.md';
 import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Resource Credentials 🔒', module)
-  .addParameters({ readme: { sidebar: markdown } })
   .addDecorator(manifoldConnectionDecorator)
   .add(
     'default',

--- a/stories/manifold-resource-list.stories.js
+++ b/stories/manifold-resource-list.stories.js
@@ -1,10 +1,8 @@
 import { storiesOf } from '@storybook/html';
 
-import markdown from '../docs/docs/components/manifold-resource-list.md';
 import { manifoldConnectionDecorator } from './connectionDecorator';
 
 storiesOf('Resource List 🔒', module)
-  .addParameters({ readme: { sidebar: markdown } })
   .addDecorator(manifoldConnectionDecorator)
   .add(
     'default',

--- a/stories/manifold-resource-plan.stories.js
+++ b/stories/manifold-resource-plan.stories.js
@@ -1,14 +1,10 @@
 import { storiesOf } from '@storybook/html';
 
-import markdown from '../docs/docs/components/manifold-resource-plan.md';
-
-storiesOf('Resource Plan Details 🔒', module)
-  .addParameters({ readme: { sidebar: markdown } })
-  .add(
-    'default',
-    () => `
+storiesOf('Resource Plan Details 🔒', module).add(
+  'default',
+  () => `
       <manifold-mock-resource>
         <manifold-resource-plan></manifold-resource-plan>
       </manifold-mock-resource>
     `
-  );
+);

--- a/stories/manifold-resource-product.stories.js
+++ b/stories/manifold-resource-product.stories.js
@@ -1,13 +1,10 @@
 import { storiesOf } from '@storybook/html';
-import markdown from '../docs/docs/components/manifold-resource-product.md';
 
-storiesOf('Resource Product Details 🔒', module)
-  .addParameters({ readme: { sidebar: markdown } })
-  .add(
-    'default',
-    () => `
+storiesOf('Resource Product Details 🔒', module).add(
+  'default',
+  () => `
       <manifold-mock-resource>
         <manifold-resource-product></manifold-resource-product>
       </manifold-mock-resource>
     `
-  );
+);

--- a/stories/manifold-resource-status.stories.js
+++ b/stories/manifold-resource-status.stories.js
@@ -1,8 +1,6 @@
 import { storiesOf } from '@storybook/html';
-import markdown from '../docs/docs/components/manifold-resource-status.md';
 
 storiesOf('Resource Status 🔒', module)
-  .addParameters({ readme: { sidebar: markdown } })
   .add(
     'default',
     () => `

--- a/stories/manifold-service-card.stories.js
+++ b/stories/manifold-service-card.stories.js
@@ -1,9 +1,6 @@
 import { storiesOf } from '@storybook/html';
 
-import markdown from '../docs/docs/components/manifold-service-card.md';
-
 storiesOf('Service card', module)
-  .addParameters({ readme: { sidebar: markdown } })
   .add(
     'JawsDB',
     () => `<manifold-service-card product-label="jawsdb-mysql"></manifold-service-card>`

--- a/stories/manifold-toast.stories.js
+++ b/stories/manifold-toast.stories.js
@@ -1,8 +1,6 @@
 import { storiesOf } from '@storybook/html';
-import markdown from '../docs/docs/components/manifold-toast.md';
 
 storiesOf('Toast', module)
-  .addParameters({ readme: { sidebar: markdown } })
   .add('basic', () => '<manifold-toast>Basic info</manifold-toast>')
   .add(
     'error',


### PR DESCRIPTION
## Reason for change

From a poll in Slack, we found that the READMEs are not helpful in Storybook. So now, they’re gone! [Knobs](https://storybook.js.org/addons/) are now front-and-center.

## Testing

- [ ] Verify Storybook still loads.

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
