### PR TITLE
Ignore irrelevant fields in test matcher

### DIFF
--- a/src/components/manifold-oauth/manifold-oauth.spec.ts
+++ b/src/components/manifold-oauth/manifold-oauth.spec.ts
@@ -29,7 +29,6 @@ describe('<manifold-oauth>', () => {
     it('receiveManifoldToken', async () => {
       const data = {
         access_token: 'secret-token',
-        duration: 1,
         expiry: 1,
       };
 
@@ -54,12 +53,11 @@ describe('<manifold-oauth>', () => {
       page.rootInstance.tokenListener(goodEvent);
       expect(mock).toHaveBeenCalledWith(
         expect.objectContaining({
-          detail: {
-            duration: data.duration,
+          detail: expect.objectContaining({
             error: undefined,
             expiry: data.expiry,
             token: data.access_token,
-          },
+          }),
         })
       );
     });


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

A test was failing because one of the values we were matching against was unpredictable. But we didn't need to test for that value, so this PR removes that value from the matcher.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->
Tests should consistently pass now.

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
