### PR TITLE
Make a separate query for free plans until backend query can be fixed

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -25,12 +25,14 @@ import {
   Marketplace,
 } from './types/marketplace';
 import {
-  Product,
   ProductEdge,
-} from './types/graphql';
+} from './types/componentData';
 import {
   AuthToken,
 } from './types/auth';
+import {
+  Product,
+} from './types/graphql';
 import {
   Option,
 } from './types/Select';

--- a/src/components/manifold-marketplace-grid/utils.ts
+++ b/src/components/manifold-marketplace-grid/utils.ts
@@ -1,4 +1,4 @@
-import { ProductEdge } from '../../types/graphql';
+import { ProductEdge } from '../../types/componentData';
 
 export function filteredServices(filter: string, services?: ProductEdge[]): ProductEdge[] {
   if (!filter || !services) {

--- a/src/components/manifold-marketplace/manifold-marketplace.tsx
+++ b/src/components/manifold-marketplace/manifold-marketplace.tsx
@@ -126,7 +126,7 @@ export class ManifoldMarketplace {
     this.isLoading = true;
     const services = await fetchAllPages({
       query: productQuery,
-      nextPage: { first: 25, after: '' },
+      nextPage: { first: 50, after: '' },
       getConnection: (q: Query) => q.products,
       graphqlFetch: this.graphqlFetch,
     });
@@ -138,19 +138,7 @@ export class ManifoldMarketplace {
             query: plansQuery,
             nextPage: { first: 25, after: '' },
             variables: { productId: service.node.id },
-            getConnection: (q: Query) => {
-              if (q.product && q.product.plans) {
-                return q.product.plans;
-              }
-
-              return {
-                edges: [],
-                pageInfo: {
-                  hasNextPage: false,
-                  hasPreviousPage: false,
-                },
-              };
-            },
+            getConnection: (q: Query) => q.product && q.product.plans,
             graphqlFetch: this.graphqlFetch,
           });
 

--- a/src/types/componentData.ts
+++ b/src/types/componentData.ts
@@ -1,0 +1,9 @@
+import { Product as GraphQLProduct, ProductEdge as GraphQLProductEdge } from './graphql';
+
+export type Product = GraphQLProduct & {
+  hasFreePlan: boolean;
+};
+
+export type ProductEdge = GraphQLProductEdge & {
+  node: Product;
+};


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

The logic to determine whether a product had free plans was broken, because the backend doesn't know if the plan is free until after it's retrieved it from the database. We therefore need - at least for now - to make separate queries for all the plans in order to determine if any of them are free.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

In the storybook site, the products that show up with a FREE badge should be the ones that actually have free plans.

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
