### PR TITLE
Allow configurations through manifold-connection

### DIFF
--- a/docs/docs/connection.md
+++ b/docs/docs/connection.md
@@ -5,8 +5,8 @@ path: /connection
 
 # Connection
 
-The connection is necessary to wrap all child web components, and must live at the top level. This
-sets the base URL (production or staging) for all child API calls.
+The connection is necessary for API calls to be issues by our web components. It can also be used to
+set the base URL (production or staging) for all API calls.
 
 ## Usage
 
@@ -27,8 +27,7 @@ sets the base URL (production or staging) for all child API calls.
 </manifold-connection>
 ```
 
-The `<manifold-connection>` component is only needed once, at the top level (but can be re-used, if
-for some reason multiple envs are needed). Child components will still work even if they’re nested
-far down into the tree (even surrounded by React components!).
+The `<manifold-connection>` component is only needed once, and can be placed anywhere in the DOM.
+API calls will not be made if this component is not present somewhere in the DOM.
 
 If you omit the `env` property, `manifold-connection` will point to production by default.

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -71,7 +71,10 @@ export namespace Components {
     'stencilClickEvent'?: (e: MouseEvent) => void;
     'target'?: string;
   }
-  interface ManifoldConnection {}
+  interface ManifoldConnection {
+    'env'?: 'local' | 'stage' | 'prod';
+    'waitTime'?: number;
+  }
   interface ManifoldCopyCredentials {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`
@@ -1136,7 +1139,10 @@ declare namespace LocalJSX {
     'stencilClickEvent'?: (e: MouseEvent) => void;
     'target'?: string;
   }
-  interface ManifoldConnection extends JSXBase.HTMLAttributes<HTMLManifoldConnectionElement> {}
+  interface ManifoldConnection extends JSXBase.HTMLAttributes<HTMLManifoldConnectionElement> {
+    'env'?: 'local' | 'stage' | 'prod';
+    'waitTime'?: number;
+  }
   interface ManifoldCopyCredentials extends JSXBase.HTMLAttributes<HTMLManifoldCopyCredentialsElement> {
     /**
     * _(hidden)_ Passed by `<manifold-connection>`

--- a/src/components/manifold-connection/manifold-connection.tsx
+++ b/src/components/manifold-connection/manifold-connection.tsx
@@ -1,16 +1,19 @@
-import { h, Component } from '@stencil/core';
+import { h, Component, Prop } from '@stencil/core';
 import '../../utils/fetchAllPages';
 
 import logger from '../../utils/logger';
 import loadMark from '../../utils/loadMark';
+import connection from '../../state/connection';
 
-/* This component currently serves no purpose, but it will be needed again
- * when we circle back to https://github.com/manifoldco/engineering/issues/9106
- */
 @Component({ tag: 'manifold-connection' })
 export class ManifoldConnection {
+  @Prop() env?: 'local' | 'stage' | 'prod';
+  @Prop() waitTime?: number;
+
   @loadMark()
-  componentWillLoad() {}
+  componentWillLoad() {
+    connection.initialize({ env: this.env, waitTime: this.waitTime });
+  }
 
   @logger()
   render() {

--- a/src/components/manifold-copy-credentials/manifold-copy-credentials.spec.ts
+++ b/src/components/manifold-copy-credentials/manifold-copy-credentials.spec.ts
@@ -38,9 +38,9 @@ describe('<manifold-copy-credentials>', () => {
     page = await newSpecPage({ components: [ManifoldCopyCredentials], html: `<div></div>` });
     element = page.doc.createElement('manifold-copy-credentials');
     element.graphqlFetch = createGraphqlFetch({
-      endpoint: graphqlEndpoint,
+      endpoint: () => graphqlEndpoint,
       getAuthToken: jest.fn(() => '1234'),
-      wait: 10,
+      wait: () => 10,
       setAuthToken: jest.fn(),
     });
 

--- a/src/components/manifold-credentials/manifold-credentials.spec.tsx
+++ b/src/components/manifold-credentials/manifold-credentials.spec.tsx
@@ -38,9 +38,9 @@ describe('<manifold-credentials>', () => {
     });
     element = page.doc.createElement('manifold-credentials');
     element.graphqlFetch = createGraphqlFetch({
-      endpoint: graphqlEndpoint,
+      endpoint: () => graphqlEndpoint,
       getAuthToken: jest.fn(() => '1234'),
-      wait: 10,
+      wait: () => 10,
       setAuthToken: jest.fn(),
     });
 

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
@@ -13,7 +13,7 @@ const oldCallback = proto.componentWillLoad;
 proto.componentWillLoad = function() {
   (this as any).restFetch = createRestFetch({
     getAuthToken: jest.fn(() => '1234'),
-    wait: 10,
+    wait: () => 10,
     setAuthToken: jest.fn(),
   });
 
@@ -193,6 +193,8 @@ describe('<manifold-data-deprovision-button>', () => {
         `,
       });
 
+      const component = page.root as HTMLManifoldDataDeprovisionButtonElement;
+      component.restFetch = createRestFetch({});
       const button = page.root && page.root.querySelector('button');
       if (!button) {
         throw new Error('button not found in document');
@@ -202,6 +204,7 @@ describe('<manifold-data-deprovision-button>', () => {
       const mockClick = jest.fn();
       page.doc.addEventListener('manifold-deprovisionButton-click', mockClick);
       button.click();
+      await page.waitForChanges();
 
       expect(fetchMock.called(`${connections.prod.gateway}/id/resource/${Resource.id}`)).toBe(true);
       expect(mockClick).toHaveBeenCalledWith(

--- a/src/components/manifold-data-has-resource/manifold-data-has-resource.spec.ts
+++ b/src/components/manifold-data-has-resource/manifold-data-has-resource.spec.ts
@@ -14,7 +14,7 @@ const oldCallback = proto.componentWillLoad;
 proto.componentWillLoad = function() {
   (this as any).restFetch = createRestFetch({
     getAuthToken: jest.fn(() => '1234'),
-    wait: 10,
+    wait: () => 10,
     setAuthToken: jest.fn(),
   });
 

--- a/src/components/manifold-data-manage-button/manifold-data-manage-button.spec.ts
+++ b/src/components/manifold-data-manage-button/manifold-data-manage-button.spec.ts
@@ -15,7 +15,7 @@ async function setup(resourceLabel: string) {
   component.resourceLabel = resourceLabel;
   component.restFetch = createRestFetch({
     getAuthToken: jest.fn(() => '1234'),
-    wait: 10,
+    wait: () => 10,
     setAuthToken: jest.fn(),
   });
 

--- a/src/components/manifold-data-product-name/manifold-data-product-name.spec.ts
+++ b/src/components/manifold-data-product-name/manifold-data-product-name.spec.ts
@@ -24,9 +24,9 @@ describe('<manifold-data-product-name>', () => {
       });
       element = page.doc.createElement('manifold-data-product-name');
       element.graphqlFetch = createGraphqlFetch({
-        endpoint: graphqlEndpoint,
+        endpoint: () => graphqlEndpoint,
         getAuthToken: jest.fn(() => '1234'),
-        wait: 10,
+        wait: () => 10,
         setAuthToken: jest.fn(),
       });
 

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.spec.ts
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.spec.ts
@@ -24,14 +24,14 @@ describe('<manifold-data-provision-button>', () => {
     });
     element = page.doc.createElement('manifold-data-provision-button');
     element.graphqlFetch = createGraphqlFetch({
-      endpoint: graphqlEndpoint,
+      endpoint: () => graphqlEndpoint,
       getAuthToken: jest.fn(() => '1234'),
-      wait: 10,
+      wait: () => 10,
       setAuthToken: jest.fn(),
     });
     element.restFetch = createRestFetch({
       getAuthToken: jest.fn(() => '1234'),
-      wait: 10,
+      wait: () => 10,
       setAuthToken: jest.fn(),
     });
 

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
@@ -13,7 +13,7 @@ const oldCallback = proto.componentWillLoad;
 proto.componentWillLoad = function() {
   (this as any).restFetch = createRestFetch({
     getAuthToken: jest.fn(() => '1234'),
-    wait: 10,
+    wait: () => 10,
     setAuthToken: jest.fn(),
   });
 

--- a/src/components/manifold-data-resource-logo/manifold-data-resource-logo.spec.ts
+++ b/src/components/manifold-data-resource-logo/manifold-data-resource-logo.spec.ts
@@ -16,7 +16,7 @@ async function setup(resourceLabel: string) {
   component.resourceLabel = resourceLabel;
   component.restFetch = createRestFetch({
     getAuthToken: jest.fn(() => '1234'),
-    wait: 10,
+    wait: () => 10,
     setAuthToken: jest.fn(),
   });
 

--- a/src/components/manifold-data-sso-button/manifold-data-sso-button.spec.ts
+++ b/src/components/manifold-data-sso-button/manifold-data-sso-button.spec.ts
@@ -19,7 +19,7 @@ describe('<manifold-data-sso-button>', () => {
     element = page.doc.createElement('manifold-data-sso-button');
     element.restFetch = createRestFetch({
       getAuthToken: jest.fn(() => '1234'),
-      wait: 10,
+      wait: () => 10,
       setAuthToken: jest.fn(),
     });
 

--- a/src/components/manifold-marketplace/manifold-marketplace-happo.ts
+++ b/src/components/manifold-marketplace/manifold-marketplace-happo.ts
@@ -2,6 +2,9 @@ import connection from '../../state/connection';
 import { GraphqlFetch } from '../../utils/graphqlFetch';
 
 export const skeleton = () => {
+  const conn = document.createElement('manifold-connection');
+  document.body.appendChild(conn);
+
   const grid = document.createElement('manifold-marketplace');
 
   const mockFetch = (async (...args) => {
@@ -18,6 +21,9 @@ export const skeleton = () => {
 };
 
 export const allProducts = () => {
+  const conn = document.createElement('manifold-connection');
+  document.body.appendChild(conn);
+
   const grid = document.createElement('manifold-marketplace');
   grid.hideUntilReady = true;
 
@@ -27,6 +33,9 @@ export const allProducts = () => {
 };
 
 export const delayedProducts = () => {
+  const conn = document.createElement('manifold-connection');
+  document.body.appendChild(conn);
+
   const grid = document.createElement('manifold-marketplace');
   grid.hideUntilReady = true;
 

--- a/src/components/manifold-oauth/manifold-oauth.e2e.ts
+++ b/src/components/manifold-oauth/manifold-oauth.e2e.ts
@@ -7,7 +7,9 @@ describe('<manifold-oauth>', () => {
     it('iframe is URL-locked', async () => {
       const page = await newE2EPage();
 
-      await page.setContent('<manifold-oauth></manifold-oauth>');
+      await page.setContent(
+        '<manifold-connection><manifold-oauth></manifold-oauth></manifold-connection>'
+      );
       await page.waitForChanges();
 
       const iframe = await page.find('iframe');
@@ -21,7 +23,9 @@ describe('<manifold-oauth>', () => {
     it('iframe is sandboxed to only allow scripts', async () => {
       const page = await newE2EPage();
 
-      await page.setContent('<manifold-oauth></manifold-oauth>');
+      await page.setContent(
+        '<manifold-connection><manifold-oauth></manifold-oauth></manifold-connection>'
+      );
       await page.waitForChanges();
 
       const iframe = await page.find('iframe');
@@ -37,7 +41,9 @@ describe('<manifold-oauth>', () => {
     it('Firefox: iframe isn’t display: none, but still appears invisible to user', async () => {
       const page = await newE2EPage();
 
-      await page.setContent('<manifold-oauth></manifold-oauth>');
+      await page.setContent(
+        '<manifold-connection><manifold-oauth></manifold-oauth></manifold-connection>'
+      );
       await page.waitForChanges();
       const iframeStyling = await page.$eval('iframe', (elm: any) => ({
         attrs: {

--- a/src/components/manifold-oauth/manifold-oauth.spec.ts
+++ b/src/components/manifold-oauth/manifold-oauth.spec.ts
@@ -1,15 +1,23 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { ManifoldOauth } from './manifold-oauth';
+import connection from '../../state/connection';
 
 describe('<manifold-oauth>', () => {
   describe('v0 props', () => {
     // Testing implementation details isn’t preferred, but E2E testing with
     // page.on('request') proved to be too difficult with Stencil.
     it('[tick]: when changed it resets iframe', async () => {
+      connection.initialize({});
+
       const page = await newSpecPage({
         components: [ManifoldOauth],
         html: '<manifold-oauth></manifold-oauth>',
       });
+
+      const oauth = page.doc.querySelector('manifold-oauth');
+      if (!oauth) {
+        throw new Error('manifold-oauth not in document');
+      }
       const { root, rootInstance } = page;
       if (!root || !rootInstance) {
         throw new Error('manifold-oauth not in document');
@@ -27,6 +35,8 @@ describe('<manifold-oauth>', () => {
 
   describe('v0 events', () => {
     it('receiveManifoldToken', async () => {
+      connection.initialize({});
+
       const data = {
         access_token: 'secret-token',
         expiry: 1,

--- a/src/components/manifold-performance/manifold-performance.e2e.ts
+++ b/src/components/manifold-performance/manifold-performance.e2e.ts
@@ -4,7 +4,7 @@ describe('<manifold-performance>', () => {
   it('should receive manifold-time-to-render event', async () => {
     const page = await newE2EPage();
     await page.setContent(
-      `<manifold-performance><manifold-plan product-label="elegant-cms" plan-label="manifold-developer"></manifold-plan></manifold-performance>`
+      `<manifold-connection><manifold-performance><manifold-plan product-label="elegant-cms" plan-label="manifold-developer"></manifold-plan></manifold-performance></manifold-connection>`
     );
     const evtSpy = await page.spyOnEvent('manifold-time-to-render');
     await new Promise(resolve => {

--- a/src/components/manifold-plan-selector/manifold-plan-selector-happo.ts
+++ b/src/components/manifold-plan-selector/manifold-plan-selector-happo.ts
@@ -4,6 +4,9 @@ import { RestFetch } from '../../utils/restFetch';
 import { GraphqlFetch } from '../../utils/graphqlFetch';
 
 export const skeleton = async () => {
+  const conn = document.createElement('manifold-connection');
+  document.body.appendChild(conn);
+
   const selector = document.createElement('manifold-plan-selector');
   selector.productLabel = product.body.label;
 
@@ -28,6 +31,9 @@ export const skeleton = async () => {
 };
 
 export const jawsDB = async () => {
+  const conn = document.createElement('manifold-connection');
+  document.body.appendChild(conn);
+
   const selector = document.createElement('manifold-plan-selector');
   selector.productLabel = product.body.label;
   selector.hideUntilReady = true;
@@ -38,6 +44,9 @@ export const jawsDB = async () => {
 };
 
 export const delayedJawsDB = async () => {
+  const conn = document.createElement('manifold-connection');
+  document.body.appendChild(conn);
+
   const selector = document.createElement('manifold-plan-selector');
   selector.productLabel = product.body.label;
   selector.hideUntilReady = true;
@@ -56,6 +65,9 @@ export const delayedJawsDB = async () => {
 };
 
 export const planError = async () => {
+  const conn = document.createElement('manifold-connection');
+  document.body.appendChild(conn);
+
   const selector = document.createElement('manifold-plan-selector');
   selector.productLabel = product.body.label;
 

--- a/src/components/manifold-plan-selector/manifold-plan-selector.spec.ts
+++ b/src/components/manifold-plan-selector/manifold-plan-selector.spec.ts
@@ -31,7 +31,7 @@ async function setup(productLabel?: string, resourceLabel?: string) {
   component.resourceLabel = resourceLabel;
   component.restFetch = createRestFetch({
     getAuthToken: jest.fn(() => '1234'),
-    wait: 10,
+    wait: () => 10,
     setAuthToken: jest.fn(),
   });
 

--- a/src/components/manifold-plan-selector/manifold-plan-selector.spec.ts
+++ b/src/components/manifold-plan-selector/manifold-plan-selector.spec.ts
@@ -6,6 +6,7 @@ import { ExpandedPlan } from '../../spec/mock/catalog';
 import { Resource } from '../../spec/mock/marketplace';
 import { connections } from '../../utils/connections';
 import { Product } from '../../types/graphql';
+import { createGraphqlFetch } from '../../utils/graphqlFetch';
 
 const product: Partial<Product> = {
   id: '234w1jyaum5j0aqe3g3bmbqjgf20p',
@@ -23,17 +24,14 @@ const mockProduct = {
 async function setup(productLabel?: string, resourceLabel?: string) {
   const page = await newSpecPage({
     components: [ManifoldPlanSelector],
-    html: '<div></div>',
+    html: '<manifold-connection></manifold-connection>',
   });
 
   const component = page.doc.createElement('manifold-plan-selector');
   component.productLabel = productLabel;
   component.resourceLabel = resourceLabel;
-  component.restFetch = createRestFetch({
-    getAuthToken: jest.fn(() => '1234'),
-    wait: () => 10,
-    setAuthToken: jest.fn(),
-  });
+  component.restFetch = createRestFetch({});
+  component.graphqlFetch = createGraphqlFetch({});
 
   const root = page.root as HTMLDivElement;
   root.appendChild(component);

--- a/src/components/manifold-product/manifold-product.spec.ts
+++ b/src/components/manifold-product/manifold-product.spec.ts
@@ -18,9 +18,9 @@ describe('<manifold-product>', () => {
     });
     element = page.doc.createElement('manifold-product');
     element.graphqlFetch = createGraphqlFetch({
-      endpoint: graphqlEndpoint,
+      endpoint: () => graphqlEndpoint,
       getAuthToken: jest.fn(() => '1234'),
-      wait: 10,
+      wait: () => 10,
       setAuthToken: jest.fn(),
     });
 

--- a/src/components/manifold-region-selector/manifold-region-selector.spec.ts
+++ b/src/components/manifold-region-selector/manifold-region-selector.spec.ts
@@ -15,7 +15,7 @@ async function setup() {
   const component = page.doc.createElement('manifold-region-selector');
   component.restFetch = createRestFetch({
     getAuthToken: jest.fn(() => '1234'),
-    wait: 10,
+    wait: () => 10,
     setAuthToken: jest.fn(),
   });
 

--- a/src/components/manifold-resource-container/manifold-resource-container.spec.ts
+++ b/src/components/manifold-resource-container/manifold-resource-container.spec.ts
@@ -37,7 +37,7 @@ describe('<manifold-resource-credentials>', () => {
     element = page.doc.createElement('manifold-resource-container');
     element.restFetch = createRestFetch({
       getAuthToken: jest.fn(() => '1234'),
-      wait: 10,
+      wait: () => 10,
       setAuthToken: jest.fn(),
     });
     element.graphqlFetch = createGraphqlFetch({

--- a/src/components/manifold-resource-container/manifold-resource-container.spec.ts
+++ b/src/components/manifold-resource-container/manifold-resource-container.spec.ts
@@ -35,16 +35,9 @@ describe('<manifold-resource-credentials>', () => {
       html: `<div></div>`,
     });
     element = page.doc.createElement('manifold-resource-container');
-    element.restFetch = createRestFetch({
-      getAuthToken: jest.fn(() => '1234'),
-      wait: () => 10,
-      setAuthToken: jest.fn(),
-    });
+    element.restFetch = createRestFetch({});
     element.graphqlFetch = createGraphqlFetch({
-      endpoint: graphqlEndpoint,
-      getAuthToken: jest.fn(() => '1234'),
-      wait: 10,
-      setAuthToken: jest.fn(),
+      endpoint: () => graphqlEndpoint,
     });
   });
   afterEach(() => {

--- a/src/components/manifold-resource-list/manifold-resource-list.spec.ts
+++ b/src/components/manifold-resource-list/manifold-resource-list.spec.ts
@@ -32,12 +32,12 @@ const oldCallback = proto.componentWillLoad;
 proto.componentWillLoad = function() {
   (this as any).restFetch = createRestFetch({
     getAuthToken: jest.fn(() => '1234'),
-    wait: 10,
+    wait: () => 10,
     setAuthToken: jest.fn(),
   });
   (this as any).graphqlFetch = createGraphqlFetch({
     getAuthToken: jest.fn(() => '1234'),
-    wait: 10,
+    wait: () => 10,
     setAuthToken: jest.fn(),
   });
 

--- a/src/components/manifold-service-card/manifold-service-card.spec.ts
+++ b/src/components/manifold-service-card/manifold-service-card.spec.ts
@@ -18,7 +18,7 @@ describe('<manifold-service-card>', () => {
     card = page.doc.createElement('manifold-service-card');
     card.restFetch = createRestFetch({
       getAuthToken: jest.fn(() => '1234'),
-      wait: 10,
+      wait: () => 10,
       setAuthToken: jest.fn(),
     });
   });

--- a/src/utils/connections.ts
+++ b/src/utils/connections.ts
@@ -6,6 +6,7 @@ export interface Connection {
   provisioning: string;
   connector: string;
   graphql: string;
+  oauth: string;
 }
 
 export type Env = 'local' | 'stage' | 'prod';
@@ -20,6 +21,7 @@ export const connections: Connections = {
     provisioning: 'http://api.provisioning.arigato.tools/v1',
     connector: 'http://api.connector.arigato.tools/v1',
     graphql: 'http://graphql.arigato.tools/graphql',
+    oauth: 'https://login.arigato.tools/signin/oauth/web', // does this work?
   },
   stage: {
     billing: 'https://api.billing.stage.manifold.co/v1',
@@ -29,6 +31,7 @@ export const connections: Connections = {
     provisioning: 'https://api.provisioning.stage.manifold.co/v1',
     connector: 'https://api.connector.stage.manifold.co/v1',
     graphql: 'https://api.stage.manifold.co/graphql',
+    oauth: 'https://login.stage.manifold.co/signin/oauth/web',
   },
   prod: {
     billing: 'https://api.billing.manifold.co/v1',
@@ -38,5 +41,6 @@ export const connections: Connections = {
     provisioning: 'https://api.provisioning.manifold.co/v1',
     connector: 'https://api.connector.manifold.co/v1',
     graphql: 'https://api.manifold.co/graphql',
+    oauth: 'https://login.manifold.co/signin/oauth/web',
   },
 };

--- a/src/utils/fetchAllPages.spec.ts
+++ b/src/utils/fetchAllPages.spec.ts
@@ -2,6 +2,7 @@ import { gql } from '@manifoldco/gql-zero';
 import fetchMock from 'fetch-mock';
 import { Query } from '../types/graphql';
 import fetchAllPages from './fetchAllPages';
+import { createGraphqlFetch } from './graphqlFetch';
 
 const query = gql`
   query CATEGORIES($first: Int!, $after: String!) {
@@ -254,6 +255,7 @@ describe('Fetching all pages of a GraphQL connection', () => {
       query,
       nextPage: { first: 3, after: '' },
       getConnection: (q: Query) => q.categories,
+      graphqlFetch: createGraphqlFetch({}),
     });
 
     expect(fetchMock.calls).toHaveLength(2);

--- a/src/utils/fetchAllPages.ts
+++ b/src/utils/fetchAllPages.ts
@@ -41,7 +41,7 @@ export default async function fetchAllPages<Edge>({
 
   if (pageInfo.hasNextPage) {
     const next = { first: nextPage.first, after: pageInfo.endCursor || '' };
-    const remaining = await fetchAllPages({ query, nextPage: next, getConnection });
+    const remaining = await fetchAllPages({ query, nextPage: next, getConnection, graphqlFetch });
     return edges.concat(remaining);
   }
 

--- a/src/utils/graphqlFetch.spec.ts
+++ b/src/utils/graphqlFetch.spec.ts
@@ -18,7 +18,7 @@ describe('graphqlFetch', () => {
   describe('general', () => {
     it('defaults to api.manifold.co/graphql', async () => {
       const fetcher = createGraphqlFetch({
-        wait: 0,
+        wait: () => 0,
         /* no endpoint */
       });
       fetchMock.mock('https://api.manifold.co/graphql', {
@@ -36,8 +36,8 @@ describe('graphqlFetch', () => {
         },
       };
       const fetcher = createGraphqlFetch({
-        wait: 0,
-        endpoint: graphqlEndpoint,
+        wait: () => 0,
+        endpoint: () => graphqlEndpoint,
         getAuthToken: () => '1234',
       });
 
@@ -55,8 +55,8 @@ describe('graphqlFetch', () => {
     it('throws if the fetch errored', () => {
       const err = new Error('ohnoes');
       const fetcher = createGraphqlFetch({
-        wait: 0,
-        endpoint: graphqlEndpoint,
+        wait: () => 0,
+        endpoint: () => graphqlEndpoint,
         getAuthToken: () => '1234',
       });
 
@@ -76,8 +76,8 @@ describe('graphqlFetch', () => {
     it('reports db errors', async () => {
       const errors = [{ message: 'bad query', locations: [] }];
       const fetcher = createGraphqlFetch({
-        wait: 0,
-        endpoint: graphqlEndpoint,
+        wait: () => 0,
+        endpoint: () => graphqlEndpoint,
         getAuthToken: () => '1234',
       });
 
@@ -98,8 +98,8 @@ describe('graphqlFetch', () => {
         ],
       };
       const fetcher = createGraphqlFetch({
-        wait: 0,
-        endpoint: graphqlEndpoint,
+        wait: () => 0,
+        endpoint: () => graphqlEndpoint,
         getAuthToken: () => '1234',
       });
 
@@ -112,8 +112,8 @@ describe('graphqlFetch', () => {
 
     it('reports unknown errors', async () => {
       const fetcher = createGraphqlFetch({
-        wait: 0,
-        endpoint: graphqlEndpoint,
+        wait: () => 0,
+        endpoint: () => graphqlEndpoint,
         getAuthToken: () => '1234',
       });
 
@@ -132,8 +132,8 @@ describe('graphqlFetch', () => {
         ],
       };
       const fetcher = createGraphqlFetch({
-        wait: 0,
-        endpoint: graphqlEndpoint,
+        wait: () => 0,
+        endpoint: () => graphqlEndpoint,
         getAuthToken: () => '1234',
       });
 
@@ -150,8 +150,8 @@ describe('graphqlFetch', () => {
     describe('With no retries', () => {
       it('throws when expired', () => {
         const fetcher = createGraphqlFetch({
-          wait: 0,
-          endpoint: graphqlEndpoint,
+          wait: () => 0,
+          endpoint: () => graphqlEndpoint,
           getAuthToken: () => undefined,
         });
 
@@ -169,8 +169,8 @@ describe('graphqlFetch', () => {
       it('resets token on error', async () => {
         const setAuthToken = jest.fn();
         const fetcher = createGraphqlFetch({
-          wait: 0,
-          endpoint: graphqlEndpoint,
+          wait: () => 0,
+          endpoint: () => graphqlEndpoint,
           getAuthToken: () => '1234',
           setAuthToken,
         });
@@ -186,8 +186,8 @@ describe('graphqlFetch', () => {
       it('Will retry if the token is refreshed', async () => {
         const setAuthToken = jest.fn();
         const fetcher = createGraphqlFetch({
-          wait: 0,
-          endpoint: graphqlEndpoint,
+          wait: () => 0,
+          endpoint: () => graphqlEndpoint,
           getAuthToken: () => undefined,
           setAuthToken,
           retries: 1,
@@ -228,8 +228,8 @@ describe('graphqlFetch', () => {
         errors: [{ message: 'no results', locations: [] }],
       };
       const fetcher = createGraphqlFetch({
-        wait: 0,
-        endpoint: graphqlEndpoint,
+        wait: () => 0,
+        endpoint: () => graphqlEndpoint,
         getAuthToken: () => '1234',
       });
 
@@ -253,8 +253,8 @@ describe('graphqlFetch', () => {
       };
 
       const fetcher = createGraphqlFetch({
-        wait: 0,
-        endpoint: graphqlEndpoint,
+        wait: () => 0,
+        endpoint: () => graphqlEndpoint,
         getAuthToken: () => '1234',
       });
 
@@ -275,8 +275,8 @@ describe('graphqlFetch', () => {
         errors: [{ message: 'illegal base32 data at input byte 4', path: ['product'] }],
       };
       const fetcher = createGraphqlFetch({
-        wait: 0,
-        endpoint: graphqlEndpoint,
+        wait: () => 0,
+        endpoint: () => graphqlEndpoint,
         getAuthToken: () => '1234',
       });
 
@@ -289,8 +289,8 @@ describe('graphqlFetch', () => {
 
     it('500: returns generic message if none given', async () => {
       const fetcher = createGraphqlFetch({
-        wait: 0,
-        endpoint: graphqlEndpoint,
+        wait: () => 0,
+        endpoint: () => graphqlEndpoint,
         getAuthToken: () => '1234',
       });
 
@@ -314,8 +314,8 @@ describe('graphqlFetch', () => {
         errors: [{ message: 'no results', locations: [] }],
       };
       const fetcher = createGraphqlFetch({
-        wait: 0,
-        endpoint: graphqlEndpoint,
+        wait: () => 0,
+        endpoint: () => graphqlEndpoint,
         getAuthToken: () => '1234',
       });
 
@@ -338,8 +338,8 @@ describe('graphqlFetch', () => {
         errors: [{ message: 'no results', locations: [] }],
       };
       const fetcher = createGraphqlFetch({
-        wait: 0,
-        endpoint: graphqlEndpoint,
+        wait: () => 0,
+        endpoint: () => graphqlEndpoint,
         getAuthToken: () => '1234',
       });
 

--- a/src/utils/restFetch.spec.ts
+++ b/src/utils/restFetch.spec.ts
@@ -106,7 +106,7 @@ describe('The fetcher created by createRestFetch', () => {
     describe('With retries remaining', () => {
       it('Will return the an error if the token is not refreshed', () => {
         const fetcher = createRestFetch({
-          wait: 1,
+          wait: () => 1,
           getAuthToken: () => undefined,
           retries: 1,
         });
@@ -127,7 +127,7 @@ describe('The fetcher created by createRestFetch', () => {
 
       it('Will retry if the token is refreshed', async () => {
         const fetcher = createRestFetch({
-          wait: 1,
+          wait: () => 1,
           getAuthToken: () => '12344',
           retries: 1,
         });
@@ -164,7 +164,7 @@ describe('The fetcher created by createRestFetch', () => {
     describe('Without retries remaining', () => {
       it('Will return the an error if auth token request expired', () => {
         const fetcher = createRestFetch({
-          wait: 1,
+          wait: () => 1,
           getAuthToken: () => undefined,
           retries: 0,
         });
@@ -188,7 +188,7 @@ describe('The fetcher created by createRestFetch', () => {
   it('auths for everything but catalog', () =>
     nonCatalogServices.forEach(async service => {
       const fetcher = createRestFetch({
-        wait: 1,
+        wait: () => 1,
         getAuthToken: () => '1234',
       });
       fetchMock.mock('path:/v1/test', 200);
@@ -201,7 +201,7 @@ describe('The fetcher created by createRestFetch', () => {
   // (catalog will auth if token is there like it is in these tests, but won’t wait if it’s not)
   it('auths for catalog if token is present initially', async () => {
     const fetcher = createRestFetch({
-      wait: 1,
+      wait: () => 1,
       getAuthToken: () => '1234',
     });
     fetchMock.mock('path:/v1/test', {});

--- a/stories/data/connectionDecorator.js
+++ b/stories/data/connectionDecorator.js
@@ -1,10 +1,11 @@
-import { text } from '@storybook/addon-knobs';
+import { text, radios } from '@storybook/addon-knobs';
 
 // Creates a fake token provider and manifold connection that adds the api token from localstorage
 // with an expiriy date a week from when it is created. 6.04e8 is a week in milliseconds.
 export const manifoldConnectionDecorator = storyFn => {
   const token = text('manifold_api_token', localStorage.getItem('manifold_api_token') || '');
-  const env = text('env', 'prod');
+  const options = { Production: 'prod', Staging: 'stage' };
+  const env = radios('env', options, 'prod', 'env');
   localStorage.setItem('manifold_api_token', token); // update localStorage to persist
   return `
   <manifold-connection env="${env}">

--- a/stories/data/connectionDecorator.js
+++ b/stories/data/connectionDecorator.js
@@ -6,7 +6,7 @@ export const manifoldConnectionDecorator = storyFn => {
   const token = text('manifold_api_token', localStorage.getItem('manifold_api_token') || '');
   localStorage.setItem('manifold_api_token', token); // update localStorage to persist
   return `
-  <manifold-connection>
+  <manifold-connection env="stage">
     <manifold-auth-token token="${token}|${new Date(Date.now() + 6.04e8).getTime()}"/>
     ${storyFn()}
   </manifold-connection>

--- a/stories/data/connectionDecorator.js
+++ b/stories/data/connectionDecorator.js
@@ -5,7 +5,7 @@ import { text, radios } from '@storybook/addon-knobs';
 export const manifoldConnectionDecorator = storyFn => {
   const token = text('manifold_api_token', localStorage.getItem('manifold_api_token') || '');
   const options = { Production: 'prod', Staging: 'stage' };
-  const env = radios('env', options, 'prod', 'env');
+  const env = radios('env', options, 'prod');
   localStorage.setItem('manifold_api_token', token); // update localStorage to persist
   return `
   <manifold-connection env="${env}">

--- a/stories/data/connectionDecorator.js
+++ b/stories/data/connectionDecorator.js
@@ -4,9 +4,10 @@ import { text } from '@storybook/addon-knobs';
 // with an expiriy date a week from when it is created. 6.04e8 is a week in milliseconds.
 export const manifoldConnectionDecorator = storyFn => {
   const token = text('manifold_api_token', localStorage.getItem('manifold_api_token') || '');
+  const env = text('env', 'prod');
   localStorage.setItem('manifold_api_token', token); // update localStorage to persist
   return `
-  <manifold-connection env="stage">
+  <manifold-connection env="${env}">
     <manifold-auth-token token="${token}|${new Date(Date.now() + 6.04e8).getTime()}"/>
     ${storyFn()}
   </manifold-connection>

--- a/stories/scenarios.stories.js
+++ b/stories/scenarios.stories.js
@@ -21,7 +21,7 @@ storiesOf('Scenarios', module)
   .addDecorator(withKnobs)
   .add('OAuth', () => {
     const options = { Production: 'prod', Staging: 'stage' };
-    const env = radios('env', options, 'stage', 'env');
+    const env = radios('env', options, 'stage');
     return `
       <manifold-connection env="${env}">
         <manifold-performance>

--- a/stories/scenarios.stories.js
+++ b/stories/scenarios.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/html';
-import { withKnobs, text } from '@storybook/addon-knobs';
+import { withKnobs, radios } from '@storybook/addon-knobs';
 import { manifoldConnectionDecorator } from './data/connectionDecorator';
 
 function withVeryFakeExpiry(token) {
@@ -20,7 +20,8 @@ function withVeryFakeExpiry(token) {
 storiesOf('Scenarios', module)
   .addDecorator(withKnobs)
   .add('OAuth', () => {
-    const env = text('env', 'stage');
+    const options = { Production: 'prod', Staging: 'stage' };
+    const env = radios('env', options, 'stage', 'env');
     return `
       <manifold-connection env="${env}">
         <manifold-performance>

--- a/stories/scenarios.stories.js
+++ b/stories/scenarios.stories.js
@@ -19,10 +19,10 @@ function withVeryFakeExpiry(token) {
 
 storiesOf('Scenarios', module)
   .addDecorator(withKnobs)
-  .addDecorator(manifoldConnectionDecorator)
   .add('OAuth', () => {
+    const env = text('env', 'stage');
     return `
-      <manifold-connection env="stage">
+      <manifold-connection env="${env}">
         <manifold-performance>
           <p><em>These resources are loaded from the server rather than mocks</em></p>
           <manifold-auth-token token="${withVeryFakeExpiry(

--- a/stories/scenarios.stories.js
+++ b/stories/scenarios.stories.js
@@ -22,7 +22,7 @@ storiesOf('Scenarios', module)
   .addDecorator(manifoldConnectionDecorator)
   .add('OAuth', () => {
     return `
-      <manifold-connection>
+      <manifold-connection env="stage">
         <manifold-performance>
           <p><em>These resources are loaded from the server rather than mocks</em></p>
           <manifold-auth-token token="${withVeryFakeExpiry(


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

The `manifold-connection` was supposed to allow us to configure certain things, like which environment to point to, or how long to wait before timing out. This became broken along the way as we wrestled with state tunnels and race conditions.

This change restores configurability. To accomplish this, the `manifold-connection` calls an `initialize` function on the connection when it loads. The `restFetch` and `graphqlFetch` functions will wait for the connection state to be initialized before proceeding.

The consequence of this is that no component can make network calls unless the `manifold-connection` is present on the page. This is how we originally intended it to work, so this is fine.

In the future, the `initialize` function will also accept the auth token, which will similarly be passed along by `manifold-connection`, allowing us to eliminate the `manifold-auth-token` component.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->
Tests should still pass, and now you should be able to set `env="stage"` on `manifold-connection` and have network calls go to staging.

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
