### PR TITLE
Increase page size to fetch all products in one go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Changed `manifold-marketplace` to use GraphQL. (#489)
 - Improved Storybook stories (#500)
 - `@manifoldco/shadowcat` is now part of UI. (#498)
-- `<manifold-data-provision-button>` will now work even if given an undefined resource label. The API will auto-generate the label if omitted. (#503)
+- `<manifold-data-provision-button>` will now work even if given an undefined resource label. The
+  API will auto-generate the label if omitted. (#503)
 
 ### Fixed
 
 - Fixed `<manifold-button>` borders (#500)
 - `<manifold-credentials>` now uses GraphQL (#490)
+- `<manifold-marketplace>` fetches products in one request (#522)
 
 ## [v0.5.10]
 

--- a/src/components/manifold-marketplace-grid/manifold-marketplace-grid.tsx
+++ b/src/components/manifold-marketplace-grid/manifold-marketplace-grid.tsx
@@ -227,7 +227,7 @@ export class ManifoldMarketplaceGrid {
       <manifold-service-card-view
         description={productNode.tagline}
         isFeatured={this.featured && this.featured.includes(productNode.label)}
-        isFree={productNode.freePlans ? productNode.freePlans.edges.length > 0 : false}
+        isFree={Array.isArray(this.freeProducts) && this.freeProducts.includes(productNode.label)}
         logo={productNode.logoUrl}
         name={productNode.displayName}
         preserveEvent={this.preserveEvent}

--- a/src/components/manifold-marketplace/manifold-marketplace.tsx
+++ b/src/components/manifold-marketplace/manifold-marketplace.tsx
@@ -65,28 +65,33 @@ const productQuery = gql`
   }
 `;
 
-const freePlans = gql`
-  query FREE_PLANS($first: Int!, $after: String!) {
-    products(first: $first, after: $after) {
-      edges {
-        node {
-          label
-          plans(first: $first) {
-            edges {
-              node {
-                free
-              }
-            }
-          }
-        }
-      }
-      pageInfo {
-        hasNextPage
-        endCursor
-      }
-    }
-  }
-`;
+// TODO: fix the freePlans query in GraphQL
+const TEMPORARY_FREE_PRODUCTS = [
+  'blitline',
+  'bonsai-elasticsearch',
+  'cloudamqp',
+  'cloudcube',
+  'custom-recognition',
+  'degraffdb-generators-stage',
+  'elegant-cms',
+  'generic-tagging',
+  'hypdf',
+  'informant',
+  'logdna',
+  'mailgun',
+  'memcachier-cache',
+  'pdfshift',
+  'piio',
+  'posthook',
+  'prefab',
+  'scaledrone',
+  'scoutapp',
+  'till',
+  'timber-logging',
+  'timber-logging-staging',
+  'valence',
+  'websolr',
+];
 
 @Component({ tag: 'manifold-marketplace' })
 export class ManifoldMarketplace {
@@ -110,7 +115,6 @@ export class ManifoldMarketplace {
   /** Template format structure, with `:product` placeholder */
   @Prop() templateLinkFormat?: string;
   @Prop() hideUntilReady?: boolean = false;
-  @State() freeProducts: string[] = [];
   @State() parsedFeatured: string[] = [];
   @State() parsedProducts: string[] = [];
   @State() services: ProductEdge[];
@@ -119,7 +123,6 @@ export class ManifoldMarketplace {
   @loadMark()
   componentWillLoad() {
     this.parseProps();
-    this.fetchFreeProducts();
     const call = this.fetchProducts();
 
     if (this.hideUntilReady) {
@@ -140,21 +143,6 @@ export class ManifoldMarketplace {
     this.isLoading = false;
   }
 
-  async fetchFreeProducts() {
-    const products = await fetchAllPages({
-      query: freePlans,
-      nextPage: { first: 50, after: '' },
-      getConnection: (q: Query) => q.products,
-      graphqlFetch: this.graphqlFetch,
-    });
-    this.freeProducts = products
-      .filter(
-        ({ node: { plans } }) =>
-          plans && plans.edges.findIndex(({ node: { free } }) => free === true) !== -1
-      )
-      .map(({ node }) => node.label);
-  }
-
   private parse(list: string): string[] {
     return list.split(',').map(item => item.trim());
   }
@@ -173,7 +161,7 @@ export class ManifoldMarketplace {
     return (
       <manifold-marketplace-grid
         featured={this.parsedFeatured}
-        freeProducts={this.freeProducts}
+        freeProducts={TEMPORARY_FREE_PRODUCTS}
         hideCategories={this.hideCategories}
         hideSearch={this.hideSearch}
         hideTemplates={this.hideTemplates}

--- a/src/components/manifold-marketplace/manifold-marketplace.tsx
+++ b/src/components/manifold-marketplace/manifold-marketplace.tsx
@@ -115,7 +115,7 @@ export class ManifoldMarketplace {
     this.isLoading = true;
     this.services = await fetchAllPages({
       query: productQuery,
-      nextPage: { first: 25, after: '' },
+      nextPage: { first: 50, after: '' },
       getConnection: (q: Query) => q.products,
       graphqlFetch: this.graphqlFetch,
     });

--- a/src/utils/graphqlFetch.spec.ts
+++ b/src/utils/graphqlFetch.spec.ts
@@ -307,6 +307,7 @@ describe('graphqlFetch', () => {
       });
     });
   });
+
   describe('metrics', () => {
     it('emits a metrics event from document when no EventEmitter supplied', async () => {
       const body = {
@@ -332,6 +333,7 @@ describe('graphqlFetch', () => {
       await fetcher({ query: '' });
       expect(event && event.detail && event.detail.duration).toBeDefined();
     });
+
     it('emits a metrics event from an EventEmitter when supplied', async () => {
       const body = {
         data: null,
@@ -356,6 +358,23 @@ describe('graphqlFetch', () => {
       expect((emitter.emit as jest.Mock).mock.calls[0][0]).toMatchObject({
         type: 'manifold-graphql-fetch-duration',
       });
+    });
+  });
+
+  describe('performance', () => {
+    it('keeps connection alive (speeds up Chrome)', async () => {
+      const fetcher = createGraphqlFetch({
+        wait: () => 0,
+        endpoint: () => graphqlEndpoint,
+        getAuthToken: () => '1234',
+      });
+      fetchMock.mock(graphqlEndpoint, {
+        status: 200,
+        body: { data: null, errors: null },
+      });
+      await fetcher({ query: '' });
+      const body = fetchMock.calls()[0][1] as RequestInit;
+      expect(body.headers).toEqual(expect.objectContaining({ Connection: 'keep-alive' }));
     });
   });
 });

--- a/src/utils/graphqlFetch.ts
+++ b/src/utils/graphqlFetch.ts
@@ -50,7 +50,11 @@ export function createGraphqlFetch({
 
     const response = await fetch(endpoint(), {
       method: 'POST',
-      headers: { 'content-type': 'application/json', ...auth },
+      headers: {
+        Connection: 'keep-alive',
+        'Content-type': 'application/json',
+        ...auth,
+      },
       body: JSON.stringify(request),
     }).catch((e: Response) => {
       // handle unexpected errors


### PR DESCRIPTION
## Reason for change
Marketplace is fetching in 2 calls rather than one, which is causing it to be slower than the original REST query and double the calls it needs to. Let’s grab all the products in one request.

This PR also adds a patch for the `freePlans` query until that is fixed (https://github.com/manifoldco/engineering/issues/9381).

Lastly, this PR also adds a header to the GraphQL request which dramatically speeds up performance in Chrome.

## Testing
1. Test the `<manifold-marketplace>` component in Storybook. Confirm that:
    - [ ] It only fires one GraphQL request now
    - [ ] the request it does fire is performant in Chrome AND Firefox (`100ms` or less)

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [x] **Prop changes**: [docs][docs] were updated
- [x] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
