### PR TITLE
Use GET for GraphQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- GraphQL now uses GET instead of POST requests (#524)
+
 ## [v0.5.11]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -4936,9 +4936,9 @@
       }
     },
     "@types/babel__core": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",
-      "integrity": "sha512-cfCCrFmiGY/yq0NuKNxIQvZFy9kY/1immpSpTngOnyIbD4+eJOG5mxphhHDv3CHL9GltO4GcKr54kGBg3RNdbg==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
+      "integrity": "sha512-8fBo0UR2CcwWxeX7WIIgJ7lXjasFxoYgRnFHUj+hRvKkpiBJbxhdAPTCY6/ZKM0uxANFVzt4yObSLuTiTnazDA==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -5189,9 +5189,9 @@
       }
     },
     "@types/yargs-parser": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.0.0.tgz",
-      "integrity": "sha512-wBlsw+8n21e6eTd4yVv8YD/E3xq0O6nNnJIquutAsFGE7EyMKz7W6RNT6BRu1SmdgmlCZ9tb0X+j+D6HGr8pZw==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
+      "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -11304,9 +11304,9 @@
       }
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
+      "integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",

--- a/src/components/manifold-copy-credentials/manifold-copy-credentials.spec.ts
+++ b/src/components/manifold-copy-credentials/manifold-copy-credentials.spec.ts
@@ -49,9 +49,10 @@ describe('<manifold-copy-credentials>', () => {
 
     // mock graphql (a resource with “error” in the name will throw)
     fetchMock.reset();
-    fetchMock.mock(graphqlEndpoint, (_, req) => {
-      const body = (req.body && req.body.toString()) || '';
-      return body.includes('error')
+    fetchMock.mock(`begin:${graphqlEndpoint}`, url => {
+      const search = new URLSearchParams(url.split('?')[1]);
+      const variables = JSON.parse(search.get('variables') || '');
+      return variables.resourceLabel.includes('error')
         ? { data: null, errors: [{ message: 'resource not found' }] }
         : { data: { resource: { credentials: { edges: credentials } } } };
     });

--- a/src/components/manifold-credentials/manifold-credentials.spec.tsx
+++ b/src/components/manifold-credentials/manifold-credentials.spec.tsx
@@ -46,9 +46,10 @@ describe('<manifold-credentials>', () => {
 
     // mock graphql (a resource with “error” in the name will throw)
     fetchMock.reset();
-    fetchMock.mock(graphqlEndpoint, (_, req) => {
-      const body = (req.body && req.body.toString()) || '';
-      return body.includes('error')
+    fetchMock.mock(`begin:${graphqlEndpoint}`, url => {
+      const search = new URLSearchParams(url.split('?')[1]);
+      const variables = JSON.parse(search.get('variables') || '');
+      return variables.resourceLabel.includes('error')
         ? { data: null, errors: [{ message: 'resource not found' }] }
         : {
             data: {

--- a/src/components/manifold-data-product-name/manifold-data-product-name.spec.ts
+++ b/src/components/manifold-data-product-name/manifold-data-product-name.spec.ts
@@ -32,24 +32,27 @@ describe('<manifold-data-product-name>', () => {
 
       fetchMock.reset();
 
-      fetchMock.mock(graphqlEndpoint, (_, req) => {
-        const body = (req.body && req.body.toString()) || '';
+      fetchMock.mock(`begin:${graphqlEndpoint}`, url => {
+        const search = new URLSearchParams(url.split('?')[1]);
+        const variables = JSON.parse(search.get('variables') || '');
+        const label = variables.resourceLabel || variables.productLabel;
         let product;
         // fake the product query here
-        if (body.includes('jawsdb')) {
+        if (label.includes('jawsdb')) {
           product = { displayName: products.jawsdb };
-        } else if (body.includes('logdna')) {
+        } else if (label.includes('logdna')) {
           product = { displayName: products.logdna };
-        } else if (body.includes('mailgun')) {
+        } else if (label.includes('mailgun')) {
           product = { displayName: products.mailgun };
         }
 
-        // if querying resource, return resource
-        if (body.includes('resource')) {
+        // if querying resource, return product in resource wrapper
+        if (variables.resourceLabel) {
           return product
             ? { data: { resource: { plan: { product } } } }
             : { data: null, errors: [{ message: 'resource not found' }] };
         }
+
         // otherwise return product
         return product
           ? { data: { product } }

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.spec.ts
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.spec.ts
@@ -37,7 +37,7 @@ describe('<manifold-data-provision-button>', () => {
 
     fetchMock.reset();
 
-    fetchMock.mock(graphqlEndpoint, profile);
+    fetchMock.mock(`begin:${graphqlEndpoint}`, profile);
     fetchMock.mock(/\/products\//, [Product]);
     fetchMock.mock(/\/plans\//, [ExpandedPlan]);
     fetchMock.mock(/\/resource\//, (_: any, req) => {
@@ -64,7 +64,7 @@ describe('<manifold-data-provision-button>', () => {
       const root = page.root as HTMLElement;
       root.appendChild(element);
       await page.waitForChanges();
-      expect(fetchMock.called(graphqlEndpoint)).toBe(true);
+      expect(fetchMock.called(`begin:${graphqlEndpoint}`)).toBe(true);
     });
 
     it('[owner-id]: doesn’t fetch if set', async () => {

--- a/src/components/manifold-plan-selector/manifold-plan-selector.spec.ts
+++ b/src/components/manifold-plan-selector/manifold-plan-selector.spec.ts
@@ -47,14 +47,14 @@ describe('<manifold-plan-selector>', () => {
 
   it('fetches product and plans by label on load, if given', async () => {
     const productLabel = 'test-label';
-    fetchMock.mock(connections.prod.graphql, mockProduct);
+    fetchMock.mock(`begin:${connections.prod.graphql}`, mockProduct);
     fetchMock.mock(`${connections.prod.catalog}/plans/?product_id=${mockProduct.data.product.id}`, [
       ExpandedPlan,
     ]);
 
     await setup(productLabel);
 
-    expect(fetchMock.called(connections.prod.graphql)).toBe(true);
+    expect(fetchMock.called(`begin:${connections.prod.graphql}`)).toBe(true);
     expect(
       fetchMock.called(
         `${connections.prod.catalog}/plans/?product_id=${mockProduct.data.product.id}`
@@ -68,14 +68,14 @@ describe('<manifold-plan-selector>', () => {
 
     const { component, page } = await setup('old-product');
 
-    fetchMock.mock(connections.prod.graphql, mockProduct);
+    fetchMock.mock(`begin:${connections.prod.graphql}`, mockProduct);
     fetchMock.mock(`${connections.prod.catalog}/plans/?product_id=${mockProduct.data.product.id}`, [
       ExpandedPlan,
     ]);
     component.productLabel = newProduct;
     await page.waitForChanges();
 
-    expect(fetchMock.called(connections.prod.graphql)).toBe(true);
+    expect(fetchMock.called(`begin:${connections.prod.graphql}`)).toBe(true);
     expect(
       fetchMock.called(
         `${connections.prod.catalog}/plans/?product_id=${mockProduct.data.product.id}`

--- a/src/components/manifold-product/manifold-product.spec.ts
+++ b/src/components/manifold-product/manifold-product.spec.ts
@@ -33,14 +33,14 @@ describe('<manifold-product>', () => {
 
   it('fetches the product by label on load', async () => {
     const productLabel = 'product-label';
-    fetchMock.mock(graphqlEndpoint, product);
+    fetchMock.mock(`begin:${graphqlEndpoint}`, product);
 
     const root = page.root as HTMLElement;
     element.productLabel = productLabel;
     root.appendChild(element);
     await page.waitForChanges();
 
-    expect(fetchMock.called(graphqlEndpoint)).toBe(true);
+    expect(fetchMock.called(`begin:${graphqlEndpoint}`)).toBe(true);
   });
 
   it('fetches the product by label on change', async () => {
@@ -53,11 +53,11 @@ describe('<manifold-product>', () => {
     await page.waitForChanges();
 
     const newLabel = 'new-product-label';
-    fetchMock.mock(graphqlEndpoint, product);
+    fetchMock.mock(`begin:${graphqlEndpoint}`, product);
 
     element.productLabel = newLabel;
     await page.waitForChanges();
 
-    expect(fetchMock.called(graphqlEndpoint)).toBe(true);
+    expect(fetchMock.called(`begin:${graphqlEndpoint}`)).toBe(true);
   });
 });

--- a/src/components/manifold-resource-container/manifold-resource-container.spec.ts
+++ b/src/components/manifold-resource-container/manifold-resource-container.spec.ts
@@ -61,7 +61,7 @@ describe('<manifold-resource-credentials>', () => {
   it('will fetch the resource on load', async () => {
     const resourceLabel = 'test-resource';
     fetchMock.mock(`${connections.prod.gateway}/resources/me/${resourceLabel}`, GatewayResource);
-    fetchMock.mock(graphqlEndpoint, GraphqlResource);
+    fetchMock.mock(`begin:${graphqlEndpoint}`, GraphqlResource);
     const root = page.root as HTMLElement;
     element.resourceLabel = resourceLabel;
     root.appendChild(element);
@@ -69,19 +69,19 @@ describe('<manifold-resource-credentials>', () => {
     expect(fetchMock.called(`${connections.prod.gateway}/resources/me/${resourceLabel}`)).toBe(
       true
     );
-    expect(fetchMock.called(graphqlEndpoint)).toBe(true);
+    expect(fetchMock.called(`begin:${graphqlEndpoint}`)).toBe(true);
   });
   it('will not fetch the resource if the component has no resource label', async () => {
     const resourceLabel = 'test-resource';
     fetchMock.mock(`${connections.prod.gateway}/resources/me/${resourceLabel}`, GatewayResource);
-    fetchMock.mock(graphqlEndpoint, GraphqlResource);
+    fetchMock.mock(`begin:${graphqlEndpoint}`, GraphqlResource);
     const root = page.root as HTMLElement;
     root.appendChild(element);
     await page.waitForChanges();
     expect(fetchMock.called(`${connections.prod.gateway}/resources/me/${resourceLabel}`)).toBe(
       false
     );
-    expect(fetchMock.called(graphqlEndpoint)).toBe(false);
+    expect(fetchMock.called(`begin:${graphqlEndpoint}`)).toBe(false);
   });
   it('will refetch the resource after load if given an invalid resource', async () => {
     const resourceLabel = 'test-resource';
@@ -91,7 +91,7 @@ describe('<manifold-resource-credentials>', () => {
       .once(`${connections.prod.gateway}/resources/me/${resourceLabel}`, {})
       .once(`${connections.prod.gateway}/resources/me/${resourceLabel}`, GatewayResource);
 
-    fetchMock.mock(graphqlEndpoint, GraphqlResource);
+    fetchMock.mock(`begin:${graphqlEndpoint}`, GraphqlResource);
 
     const root = page.root as HTMLElement;
     element.resourceLabel = resourceLabel;
@@ -101,7 +101,7 @@ describe('<manifold-resource-credentials>', () => {
     expect(fetchMock.called(`${connections.prod.gateway}/resources/me/${resourceLabel}`)).toBe(
       true
     );
-    expect(fetchMock.called(graphqlEndpoint)).toBe(true);
+    expect(fetchMock.called(`begin:${graphqlEndpoint}`)).toBe(true);
     expect(window.setTimeout).toHaveBeenCalledTimes(1);
   });
   it('will refetch the resource after load if it received an error', async () => {
@@ -112,14 +112,14 @@ describe('<manifold-resource-credentials>', () => {
       .once(`${connections.prod.gateway}/resources/me/${resourceLabel}`, 404)
       .once(`${connections.prod.gateway}/resources/me/${resourceLabel}`, GatewayResource);
 
-    fetchMock.mock(graphqlEndpoint, GraphqlResource);
+    fetchMock.mock(`begin:${graphqlEndpoint}`, GraphqlResource);
 
     const root = page.root as HTMLElement;
     element.resourceLabel = resourceLabel;
     element.refetchUntilValid = true;
     root.appendChild(element);
     await page.waitForChanges();
-    expect(fetchMock.called(graphqlEndpoint)).toBe(true);
+    expect(fetchMock.called(`begin:${graphqlEndpoint}`)).toBe(true);
     expect(fetchMock.called(`${connections.prod.gateway}/resources/me/${resourceLabel}`)).toBe(
       true
     );

--- a/src/components/manifold-resource-list/manifold-resource-list.spec.ts
+++ b/src/components/manifold-resource-list/manifold-resource-list.spec.ts
@@ -78,7 +78,7 @@ describe('<manifold-resource-list>', () => {
   it('The resources list are rendered if given.', async () => {
     fetchMock
       .mock(`${connections.prod.marketplace}/resources/?me`, resources)
-      .mock(connections.prod.graphql, { data: mockGraphqlProducts })
+      .mock(`begin:${connections.prod.graphql}`, { data: mockGraphqlProducts })
       .mock(`${connections.prod.provisioning}/operations/?is_deleted=false`, [provisionOperation]);
 
     const page = await newSpecPage({
@@ -101,7 +101,7 @@ describe('<manifold-resource-list>', () => {
   it('processes resources properly', async () => {
     fetchMock
       .mock(`${connections.prod.marketplace}/resources/?me`, resources)
-      .mock(connections.prod.graphql, { data: mockGraphqlProducts })
+      .mock(`begin:${connections.prod.graphql}`, { data: mockGraphqlProducts })
       .mock(`${connections.prod.provisioning}/operations/?is_deleted=false`, [provisionOperation]);
 
     const page = await newSpecPage({
@@ -112,7 +112,7 @@ describe('<manifold-resource-list>', () => {
     const instance = page.rootInstance as ManifoldResourceList;
 
     expect(fetchMock.called(`${connections.prod.marketplace}/resources/?me`)).toBe(true);
-    expect(fetchMock.called(connections.prod.graphql)).toBe(true);
+    expect(fetchMock.called(`begin:${connections.prod.graphql}`)).toBe(true);
     expect(fetchMock.called(`${connections.prod.provisioning}/operations/?is_deleted=false`)).toBe(
       true
     );
@@ -152,7 +152,7 @@ describe('<manifold-resource-list>', () => {
     it('slot="loading" is rendered if still loading.', async () => {
       fetchMock
         .mock(`${connections.prod.marketplace}/resources/?me`, {})
-        .mock(connections.prod.graphql, { data: [] })
+        .mock(`begin:${connections.prod.graphql}`, { data: [] })
         .mock(`${connections.prod.provisioning}/operations/?is_deleted=false`, []);
 
       const page = await newSpecPage({
@@ -170,7 +170,7 @@ describe('<manifold-resource-list>', () => {
     it('slot="no-resources" is rendered if no resources are found.', async () => {
       fetchMock
         .mock(`${connections.prod.marketplace}/resources/?me`, [])
-        .mock(connections.prod.graphql, { data: [] })
+        .mock(`begin:${connections.prod.graphql}`, { data: [] })
         .mock(`${connections.prod.provisioning}/operations/?is_deleted=false`, []);
 
       const page = await newSpecPage({

--- a/src/utils/fetchAllPages.spec.ts
+++ b/src/utils/fetchAllPages.spec.ts
@@ -238,12 +238,12 @@ describe('Fetching all pages of a GraphQL connection', () => {
 
   it('fetches all the pages', async () => {
     fetchMock
-      .once('https://api.manifold.co/graphql', {
+      .once('begin:https://api.manifold.co/graphql', {
         status: 200,
         body: { data: firstPage },
       })
       .once(
-        'https://api.manifold.co/graphql',
+        'begin:https://api.manifold.co/graphql',
         {
           status: 200,
           body: { data: secondPage },

--- a/src/utils/gql-min.spec.ts
+++ b/src/utils/gql-min.spec.ts
@@ -1,21 +1,35 @@
-import gqlMin from './gql-min';
+import gqlMin, { gqlSearch } from './gql-min';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const query = `
+query PRODUCTS {
+  products(first: $first, after: $after) {
+    label
+    displayName
+    logo
+    plans(first: $firstPlans) {
+      free
+    }
+  }
+}
+`;
+const minified = `query PRODUCTS{products(first:$first,after:$after){label displayName logo plans(first:$firstPlans){free}}}`;
 
 describe('gqlMin function', () => {
-  // this is a bit snapshot-y, but it’ll do for now
   it('minifies queries', () => {
-    const query = `
-      query PRODUCTS {
-        products(first: $first, after: $after) {
-          label
-          displayName
-          logo
-          plans(first: $firstPlans) {
-            free
-          }
-        }
-      }
-    `;
-    const minified = `query PRODUCTS{products(first:$first,after:$after){label displayName logo plans(first:$firstPlans){free}}}`;
     expect(gqlMin(query)).toBe(minified);
+  });
+});
+
+describe('gqlSearch function', () => {
+  it('escapes full request', () => {
+    const req: any = {
+      query,
+      variables: { first: 50, firstPlans: 20, after: '' },
+      meta: true,
+    };
+    const res = { query: minified, variables: JSON.stringify(req.variables), meta: req.meta };
+    expect(gqlSearch(req)).toBe(new URLSearchParams(res).toString());
   });
 });

--- a/src/utils/gql-min.spec.ts
+++ b/src/utils/gql-min.spec.ts
@@ -1,0 +1,21 @@
+import gqlMin from './gql-min';
+
+describe('gqlMin function', () => {
+  // this is a bit snapshot-y, but it’ll do for now
+  it('minifies queries', () => {
+    const query = `
+      query PRODUCTS {
+        products(first: $first, after: $after) {
+          label
+          displayName
+          logo
+          plans(first: $firstPlans) {
+            free
+          }
+        }
+      }
+    `;
+    const minified = `query PRODUCTS{products(first:$first,after:$after){label displayName logo plans(first:$firstPlans){free}}}`;
+    expect(gqlMin(query)).toBe(minified);
+  });
+});

--- a/src/utils/gql-min.ts
+++ b/src/utils/gql-min.ts
@@ -1,3 +1,6 @@
+/**
+ *  Minifies a GraphQL string query to its smallest shape
+ */
 export default function gqlMin(query: string) {
   return query
     .trim()
@@ -5,3 +8,19 @@ export default function gqlMin(query: string) {
     .replace(/([^A-z\d])\s+/g, '$1') // remove whitespace trailing special chars (brackets, commas, colons, etc.)
     .replace(/\s+([^A-z\d])/g, '$1'); // remove whitespace leading special chars
 }
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Converts a GraphQL response body into a GET request with URL Params
+ */
+export function gqlSearch(requestBody: any) {
+  const minifiedRequest = Object.entries(requestBody).reduce(
+    (req, [key, value]) => ({
+      ...req,
+      [key]: key === 'query' ? gqlMin(value as string) : JSON.stringify(value),
+    }),
+    {}
+  );
+  return new URLSearchParams(minifiedRequest).toString();
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */

--- a/src/utils/gql-min.ts
+++ b/src/utils/gql-min.ts
@@ -1,0 +1,7 @@
+export default function gqlMin(query: string) {
+  return query
+    .trim()
+    .replace(/[\n\s]+/g, ' ') // remove newlines and indentation
+    .replace(/([^A-z\d])\s+/g, '$1') // remove whitespace trailing special chars (brackets, commas, colons, etc.)
+    .replace(/\s+([^A-z\d])/g, '$1'); // remove whitespace leading special chars
+}

--- a/src/utils/graphqlFetch.spec.ts
+++ b/src/utils/graphqlFetch.spec.ts
@@ -21,12 +21,12 @@ describe('graphqlFetch', () => {
         wait: () => 0,
         /* no endpoint */
       });
-      fetchMock.mock('https://api.manifold.co/graphql', {
+      fetchMock.mock('begin:https://api.manifold.co/graphql', {
         status: 200,
         body: { data: {} },
       });
       await fetcher({ query: '' });
-      expect(fetchMock.called('https://api.manifold.co/graphql')).toBe(true);
+      expect(fetchMock.called('begin:https://api.manifold.co/graphql')).toBe(true);
     });
 
     it('returns data from server', async () => {
@@ -41,14 +41,14 @@ describe('graphqlFetch', () => {
         getAuthToken: () => '1234',
       });
 
-      fetchMock.mock(graphqlEndpoint, {
+      fetchMock.mock(`begin:${graphqlEndpoint}`, {
         status: 200,
         body,
       });
 
       const result = await fetcher({ query: '' });
 
-      expect(fetchMock.called(graphqlEndpoint)).toBe(true);
+      expect(fetchMock.called(`begin:${graphqlEndpoint}`)).toBe(true);
       expect(result).toEqual(body);
     });
 
@@ -60,13 +60,13 @@ describe('graphqlFetch', () => {
         getAuthToken: () => '1234',
       });
 
-      fetchMock.mock(graphqlEndpoint, { throws: err });
+      fetchMock.mock(`begin:${graphqlEndpoint}`, { throws: err });
 
       expect.assertions(2);
       return fetcher({
         query: 'myQuery',
       }).catch(result => {
-        expect(fetchMock.called(graphqlEndpoint)).toBe(true);
+        expect(fetchMock.called(`begin:${graphqlEndpoint}`)).toBe(true);
         expect(result).toEqual(err);
       });
     });
@@ -81,7 +81,7 @@ describe('graphqlFetch', () => {
         getAuthToken: () => '1234',
       });
 
-      fetchMock.mock(graphqlEndpoint, {
+      fetchMock.mock(`begin:${graphqlEndpoint}`, {
         status: 200, // error code for malformed query
         body: { data: null, errors },
       });
@@ -103,7 +103,7 @@ describe('graphqlFetch', () => {
         getAuthToken: () => '1234',
       });
 
-      fetchMock.mock(graphqlEndpoint, { status: 422, body });
+      fetchMock.mock(`begin:${graphqlEndpoint}`, { status: 422, body });
 
       await fetcher({ query: '' });
       // graphql format
@@ -117,7 +117,7 @@ describe('graphqlFetch', () => {
         getAuthToken: () => '1234',
       });
 
-      fetchMock.mock(graphqlEndpoint, { status: 500, body: {} });
+      fetchMock.mock(`begin:${graphqlEndpoint}`, { status: 500, body: {} });
 
       await fetcher({ query: '' });
       // graphql format
@@ -143,7 +143,7 @@ describe('graphqlFetch', () => {
       });
 
       const response = { status: 200, body };
-      fetchMock.mock(graphqlEndpoint, response);
+      fetchMock.mock(`begin:${graphqlEndpoint}`, response);
 
       return fetcher({ query: '' }).catch(() => {
         expect(errorReporter).toHaveBeenCalledWith(body.errors);
@@ -160,14 +160,14 @@ describe('graphqlFetch', () => {
           getAuthToken: () => undefined,
         });
 
-        fetchMock.mock(graphqlEndpoint, {
+        fetchMock.mock(`begin:${graphqlEndpoint}`, {
           status: 200,
           body: { errors: [{ extensions: { type: 'AuthFailed' } }] },
         });
 
         expect.assertions(2);
         return fetcher({ query: '' }).catch(result => {
-          expect(fetchMock.called(graphqlEndpoint)).toBe(true);
+          expect(fetchMock.called(`begin:${graphqlEndpoint}`)).toBe(true);
           expect(result).toEqual(new Error('Auth token expired'));
         });
       });
@@ -183,7 +183,7 @@ describe('graphqlFetch', () => {
           setAuthToken,
         });
 
-        fetchMock.mock(graphqlEndpoint, {
+        fetchMock.mock(`begin:${graphqlEndpoint}`, {
           status: 200,
           body: { errors: [{ extensions: { type: 'AuthFailed' } }] },
         });
@@ -211,7 +211,7 @@ describe('graphqlFetch', () => {
             status: 200,
             body: { errors: [{ extensions: { type: 'AuthFailed' } }] },
           })
-          .mock(graphqlEndpoint, { status: 200, body }, { overwriteRoutes: false });
+          .mock(`begin:${graphqlEndpoint}`, { status: 200, body }, { overwriteRoutes: false });
 
         const fetch = fetcher({ query: '' });
 
@@ -247,14 +247,14 @@ describe('graphqlFetch', () => {
         getAuthToken: () => '1234',
       });
 
-      fetchMock.mock(graphqlEndpoint, {
+      fetchMock.mock(`begin:${graphqlEndpoint}`, {
         status: 200, // error code for DB error (e.g. nothing returned)
         body,
       });
 
       const result = await fetcher({ query: '' });
 
-      expect(fetchMock.called(graphqlEndpoint)).toBe(true);
+      expect(fetchMock.called(`begin:${graphqlEndpoint}`)).toBe(true);
       expect(result).toEqual(body);
     });
 
@@ -276,13 +276,13 @@ describe('graphqlFetch', () => {
         getAuthToken: () => '1234',
       });
 
-      fetchMock.mock(graphqlEndpoint, { status: 200, body });
+      fetchMock.mock(`begin:${graphqlEndpoint}`, { status: 200, body });
 
       expect.assertions(2);
       return fetcher({
         query: '',
       }).catch(e => {
-        expect(fetchMock.called(graphqlEndpoint)).toBe(true);
+        expect(fetchMock.called(`begin:${graphqlEndpoint}`)).toBe(true);
         expect(e.message).toEqual('Auth token expired');
       });
     });
@@ -298,10 +298,10 @@ describe('graphqlFetch', () => {
         getAuthToken: () => '1234',
       });
 
-      fetchMock.mock(graphqlEndpoint, { status: 422, body });
+      fetchMock.mock(`begin:${graphqlEndpoint}`, { status: 422, body });
 
       const result = await fetcher({ query: '' });
-      expect(fetchMock.called(graphqlEndpoint)).toBe(true);
+      expect(fetchMock.called(`begin:${graphqlEndpoint}`)).toBe(true);
       expect(result).toEqual(body);
     });
 
@@ -312,13 +312,13 @@ describe('graphqlFetch', () => {
         getAuthToken: () => '1234',
       });
 
-      fetchMock.mock(graphqlEndpoint, {
+      fetchMock.mock(`begin:${graphqlEndpoint}`, {
         status: 500, // error code for something that went wrong
         body: {},
       });
 
       const result = await fetcher({ query: '' });
-      expect(fetchMock.called(graphqlEndpoint)).toBe(true);
+      expect(fetchMock.called(`begin:${graphqlEndpoint}`)).toBe(true);
       expect(result).toEqual({
         data: null,
         errors: [{ message: 'Internal Server Error' }],
@@ -338,7 +338,7 @@ describe('graphqlFetch', () => {
         getAuthToken: () => '1234',
       });
 
-      fetchMock.mock(graphqlEndpoint, {
+      fetchMock.mock(`begin:${graphqlEndpoint}`, {
         status: 200, // error code for DB error (e.g. nothing returned)
         body,
       });
@@ -363,7 +363,7 @@ describe('graphqlFetch', () => {
         getAuthToken: () => '1234',
       });
 
-      fetchMock.mock(graphqlEndpoint, {
+      fetchMock.mock(`begin:${graphqlEndpoint}`, {
         status: 200, // error code for DB error (e.g. nothing returned)
         body,
       });
@@ -380,13 +380,40 @@ describe('graphqlFetch', () => {
   });
 
   describe('performance', () => {
+    it('uses GET', async () => {
+      const fetcher = createGraphqlFetch({
+        wait: () => 0,
+        endpoint: () => graphqlEndpoint,
+        getAuthToken: () => '1234',
+      });
+      fetchMock.mock(`begin:${graphqlEndpoint}`, {
+        status: 200,
+        body: { data: null, errors: null },
+      });
+      await fetcher({
+        query: `
+        query GET_PRODUCT {
+          product(label: $productLabel) {
+            label
+          }
+        }`,
+        variables: {
+          productLabel: 'dumper',
+        },
+      });
+      const url = fetchMock.calls()[0][0] as string;
+      const search = new URLSearchParams(url.split('?')[1]);
+      expect(search.get('query')).toEqual('query GET_PRODUCT{product(label:$productLabel){label}}');
+      expect(search.get('variables')).toEqual(JSON.stringify({ productLabel: 'dumper' }));
+    });
+
     it('keeps connection alive (speeds up Chrome)', async () => {
       const fetcher = createGraphqlFetch({
         wait: () => 0,
         endpoint: () => graphqlEndpoint,
         getAuthToken: () => '1234',
       });
-      fetchMock.mock(graphqlEndpoint, {
+      fetchMock.mock(`begin:${graphqlEndpoint}`, {
         status: 200,
         body: { data: null, errors: null },
       });


### PR DESCRIPTION
## Reason for change

![Screen Shot 2019-09-19 at 16 39 49](https://user-images.githubusercontent.com/1369770/65286246-1fb3c680-dafc-11e9-8989-3f45373c73cd.png)

Outlined here: https://github.com/manifoldco/engineering/issues/9392

TL;DR our load balancers & CDN will do better if requests are cacheable via URL.

Most of this PR is actually test changes, because our tests were trying to _exactly_ match URL rather than just the beginning domain. They were updated to match the beginning segment of a URL now for GraphQL.

## Testing

⚠️**This affects all the GraphQL queries** so test each component!!!

## Checklist

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [x] **Prop changes**: [docs][docs] were updated
- [x] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [x] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
