### PR TITLE
v0.5.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-- Added a time to first meaningful render event to be consumed by `<manifold-performance>` component
+## [v0.5.11]
 
 ### Added
 
 - Ability to authenticate and refresh manually, bypassing OAuth. (#495)
+- Added a time to first meaningful render event to be consumed by `<manifold-performance>` component
+  (#501)
 
 ### Changed
 


### PR DESCRIPTION
## Reason for change

### Added

- Ability to authenticate and refresh manually, bypassing OAuth. (#495)
- Added a time to first meaningful render event to be consumed by `<manifold-performance>` component
  (#501)

### Changed

- Changed `manifold-marketplace` to use GraphQL. (#489)
- Improved Storybook stories (#500)
- `@manifoldco/shadowcat` is now part of UI. (#498)
- `<manifold-data-provision-button>` will now work even if given an undefined resource label. The
  API will auto-generate the label if omitted. (#503)

### Fixed

- Fixed `<manifold-button>` borders (#500)
- `<manifold-credentials>` now uses GraphQL (#490)
- `<manifold-marketplace>` fetches products in one request (#522)

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [x] **Prop changes**: [docs][docs] were updated
- [x] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
