### PR TITLE
Simplify getAuthToken in connection

### DIFF
--- a/src/state/connection.ts
+++ b/src/state/connection.ts
@@ -60,16 +60,7 @@ export class ConnectionState {
     this.authToken = token;
   };
 
-  getAuthToken = () => this.accessToken;
-
-  get accessToken() {
-    if (this.authToken) {
-      const [token] = this.authToken.split('|');
-      return token;
-    }
-
-    return undefined;
-  }
+  getAuthToken = () => this.authToken;
 
   restFetch = createRestFetch({
     endpoints: () => connections[this.env],


### PR DESCRIPTION
## Reason for change

We no longer use expiry in tokens. This doesn’t functionally change how it works; it just simplifies the logic to make it easier to follow.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [x] **Prop changes**: [docs][docs] were updated
- [x] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [x] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
