### PR TITLE
Fix flickering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [Unreleased]
 
 ## Changed
+
 - Removed `product-id` from `manifild-service-card` (#533)
 - Converted `manifold-service-card` to GraphQL (#533)
+
+## Fixed
+
+- Fixed loading flicker of resource components while provisioning/deprovisioning. (#539)
 
 ## [v0.5.11]
 

--- a/src/components/manifold-resource-container/manifold-resource-container.tsx
+++ b/src/components/manifold-resource-container/manifold-resource-container.tsx
@@ -37,7 +37,7 @@ export class ManifoldResourceContainer {
   @Prop() refetchUntilValid: boolean = false;
   @State() resource?: Gateway.Resource;
   @State() gqlData?: Resource;
-  @State() loading: boolean = false;
+  @State() loading: boolean = true;
   @State() timeout?: number;
 
   @Watch('resourceLabel') resourceChange(newName: string) {
@@ -65,7 +65,6 @@ export class ManifoldResourceContainer {
       return;
     }
 
-    this.loading = true;
     try {
       const response = await this.restFetch<Gateway.Resource & { product?: Product }>({
         service: 'gateway',
@@ -82,6 +81,8 @@ export class ManifoldResourceContainer {
       if (data && data.resource) {
         this.gqlData = data.resource;
       }
+
+      // Important: don’t set this to true again, otherwise polling will cause skeleton flashing
       this.loading = false;
     } catch (error) {
       // In case we actually want to keep fetching on an error

--- a/src/components/manifold-resource-container/manifold-resource-container.tsx
+++ b/src/components/manifold-resource-container/manifold-resource-container.tsx
@@ -80,10 +80,9 @@ export class ManifoldResourceContainer {
       this.resource = response;
       if (data && data.resource) {
         this.gqlData = data.resource;
+        // Once data has been loaded once, don’t re-show skeletons anywhere (even if re-polling)
+        this.loading = false;
       }
-
-      // Important: don’t set this to true again, otherwise polling will cause skeleton flashing
-      this.loading = false;
     } catch (error) {
       // In case we actually want to keep fetching on an error
       if (this.refetchUntilValid) {


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

As reported by Jeff, the `<manifold-resource-plan>` component would flicker because of `refetchUntilValid` setting `loading` to `true` at the beginning of a fetch. This PR changes that to only show the skeleton screens during the initial fetch, then never show them again.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [x] **Prop changes**: [docs][docs] were updated
- [x ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [x] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
