### PR TITLE
Authenticate less often

### DIFF
--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -18,6 +18,7 @@ export class ManifoldAuthToken {
   @Prop() token?: string;
   @Prop() authType?: AuthType = 'oauth';
   @State() tick?: string;
+  @State() internalToken?: string = connection.authToken;
   @Event({ eventName: 'manifold-token-receive', bubbles: true })
   manifoldOauthTokenChange: EventEmitter<{ token: string }>;
   @Event({ eventName: 'manifold-token-clear', bubbles: true }) clear: EventEmitter;
@@ -33,6 +34,7 @@ export class ManifoldAuthToken {
     this.setExternalToken(this.token);
     if (this.subscribe) {
       this.unsubscribe = this.subscribe((oldToken?: string, newToken?: string) => {
+        this.internalToken = newToken;
         if (oldToken && !newToken) {
           // changing this to any new string will cause a token refresh. getTime() does that wonderfully.
           this.tick = new Date().getTime().toString();
@@ -72,7 +74,8 @@ export class ManifoldAuthToken {
   @logger()
   render() {
     return (
-      this.authType === 'oauth' && (
+      this.authType === 'oauth' &&
+      !this.internalToken && (
         <manifold-oauth tick={this.tick} onReceiveManifoldToken={this.setInternalToken} />
       )
     );


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
Short version: We're authenticating more often than we need to!

Longer version: When using OAuth, if the `manifold-auth-token` component gets removed from the DOM and then re-added, currently we will try to re-authenticate. This happens often in Render, because every route that requires a Manifold API token is wrapped in a decorator that renders `manifold-auth-token`.

Solution: if the connection state already has an auth token, don't render the iframe! If that token turns out to be expired, that's ok. It will be cleared, and then the iframe will be rendered again.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

Things should work as normal and tests should pass. Ideally we should try this out in Render with a short-lived token, so we can make sure that OAuth is initiated after the API tells us that our token is expired. However, testing short-lived tokens is not easy. It would be nice if it were easier!

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
