### PR TITLE
Update manifold-data-has-resource tests

### DIFF
--- a/src/components/manifold-data-has-resource/manifold-data-has-resource.spec.ts
+++ b/src/components/manifold-data-has-resource/manifold-data-has-resource.spec.ts
@@ -2,10 +2,9 @@ import { newSpecPage } from '@stencil/core/testing';
 import fetchMock from 'fetch-mock';
 
 import { ManifoldDataHasResource } from './manifold-data-has-resource';
+import { connections } from '../../utils/connections';
 import { resource } from '../../spec/mock/graphql';
 import { createGraphqlFetch } from '../../utils/graphqlFetch';
-
-const graphqlEndpoint = 'http://test.com/graphql';
 
 const singleResource = { data: { resource } };
 const multiResources = {
@@ -16,26 +15,42 @@ const multiResources = {
   },
 };
 
-async function setup(label?: string) {
+interface Setup {
+  onLoad?: (e: Event) => void;
+  label?: string;
+}
+
+async function setup({ onLoad, label }: Setup) {
   const page = await newSpecPage({
     components: [ManifoldDataHasResource],
-    html: `<div></div>`,
+    html: '<div></div>',
   });
-  const component = page.doc.createElement('manifold-data-has-resource');
-  component.graphqlFetch = createGraphqlFetch({ endpoint: () => graphqlEndpoint });
-  component.paused = true;
-  component.innerHTML = `
-    <div slot="loading"></div>
-    <div slot="has-resource"></div>
-    <div slot="no-resource"></div>
-  `;
-  if (label) {
-    component.label = label;
+
+  const loading = page.doc.createElement('div');
+  loading.slot = 'loading';
+  const hasResources = page.doc.createElement('div');
+  hasResources.slot = 'has-resource';
+  const noResource = page.doc.createElement('div');
+  noResource.slot = 'no-resource';
+
+  const element = page.doc.createElement('manifold-data-has-resource');
+  element.appendChild(loading);
+  element.appendChild(hasResources);
+  element.appendChild(noResource);
+
+  element.graphqlFetch = createGraphqlFetch({});
+  element.paused = true;
+  element.label = label;
+
+  if (onLoad) {
+    page.doc.addEventListener('manifold-hasResource-load', onLoad);
   }
-  (page.root as HTMLDivElement).appendChild(component);
+
+  const root = page.root as HTMLDivElement;
+  root.appendChild(element);
   await page.waitForChanges();
 
-  return { page, component };
+  return { page, element };
 }
 
 describe('<manifold-data-has-resource>', () => {
@@ -45,63 +60,66 @@ describe('<manifold-data-has-resource>', () => {
 
   describe('v0 slots', () => {
     it('loading', async () => {
+      // arbitrary, but enough time for the 1st render to complete
+      const response = new Promise(resolve => setTimeout(() => resolve(multiResources), 100));
       fetchMock.mock(
-        `begin:${graphqlEndpoint}`,
-        new Promise(resolve => setTimeout(() => resolve(multiResources), 100)) // arbitrary, but usually enough time for the 1st render to complete
+        `begin:${connections.prod.graphql}`,
+        response // arbitrary, but usually enough time for the 1st render to complete
       );
-      const { component } = await setup();
-      expect(component.shadowRoot).toEqualHtml(`<slot name="loading"></slot>`);
+
+      const { element } = await setup({});
+
+      expect(element.shadowRoot).toEqualHtml(`<slot name="loading"></slot>`);
+      await response;
     });
 
     it('has-resource', async () => {
-      fetchMock.mock(`begin:${graphqlEndpoint}`, multiResources);
-      const { component } = await setup();
-      expect(component.shadowRoot).toEqualHtml(`<slot name="has-resource"></slot>`);
+      fetchMock.mock(`begin:${connections.prod.graphql}`, multiResources);
+
+      const { element } = await setup({});
+
+      expect(element.shadowRoot).toEqualHtml(`<slot name="has-resource"></slot>`);
     });
 
     it('no-resource', async () => {
-      fetchMock.mock(`begin:${graphqlEndpoint}`, { data: { resources: { edges: [] } } });
-      const { component } = await setup();
-      expect(component.shadowRoot).toEqualHtml(`<slot name="no-resource"></slot>`);
+      fetchMock.mock(`begin:${connections.prod.graphql}`, { data: { resources: { edges: [] } } });
+
+      const { element } = await setup({});
+
+      expect(element.shadowRoot).toEqualHtml(`<slot name="no-resource"></slot>`);
     });
   });
 
   describe('v0 props', () => {
     it('label', async () => {
-      fetchMock.mock(`begin:${graphqlEndpoint}`, singleResource);
-      const { component } = await setup('my-resource');
-      expect(component.shadowRoot).toEqualHtml(`<slot name="has-resource"></slot>`);
+      fetchMock.mock(`begin:${connections.prod.graphql}`, singleResource);
+
+      const { element } = await setup({ label: 'my-resource' });
+
+      expect(element.shadowRoot).toEqualHtml(`<slot name="has-resource"></slot>`);
     });
   });
 
   describe('v0 events', () => {
-    it('load:', async () => {
-      fetchMock.mock(`begin:${graphqlEndpoint}`, multiResources);
+    it('load: has resources', async () => {
+      fetchMock.mock(`begin:${connections.prod.graphql}`, multiResources);
 
-      // event listener
       const mockLoad = jest.fn();
+      await setup({ onLoad: mockLoad });
 
-      const page = await newSpecPage({
-        components: [ManifoldDataHasResource],
-        html: '<div></div>',
-      });
-      page.doc.addEventListener('manifold-hasResource-load', mockLoad);
-      const component = page.doc.createElement('manifold-data-has-resource');
-      component.graphqlFetch = createGraphqlFetch({ endpoint: () => graphqlEndpoint });
-      component.paused = true;
-      component.label = 'my-resource';
-      (page.root as HTMLDivElement).appendChild(component);
-      await page.waitForChanges();
-
-      // wait for event
-      await new Promise(resolve => mockLoad.mockImplementation(() => resolve()));
       expect(mockLoad).toHaveBeenCalledWith(
-        expect.objectContaining({
-          detail: {
-            hasAnyResources: true,
-            resourceLabel: 'my-resource',
-          },
-        })
+        expect.objectContaining({ detail: { hasAnyResources: true } })
+      );
+    });
+
+    it('load: no resources', async () => {
+      fetchMock.mock(`begin:${connections.prod.graphql}`, { data: null });
+
+      const mockLoad = jest.fn();
+      await setup({ onLoad: mockLoad });
+
+      expect(mockLoad).toHaveBeenCalledWith(
+        expect.objectContaining({ detail: { hasAnyResources: false } })
       );
     });
   });

--- a/src/components/manifold-data-has-resource/manifold-data-has-resource.spec.ts
+++ b/src/components/manifold-data-has-resource/manifold-data-has-resource.spec.ts
@@ -58,15 +58,13 @@ describe('<manifold-data-has-resource>', () => {
     it('loading', async () => {
       // arbitrary, but enough time for the 1st render to complete
       const response = new Promise(resolve => setTimeout(() => resolve(multiResources), 100));
-      fetchMock.mock(
-        `begin:${graphqlEndpoint}`,
-        response // arbitrary, but usually enough time for the 1st render to complete
-      );
+      fetchMock.mock(`begin:${graphqlEndpoint}`, response);
 
-      const { component } = await setup({});
+      const { page, component } = await setup({});
 
       expect(component.shadowRoot).toEqualHtml(`<slot name="loading"></slot>`);
       await response;
+      await page.waitForChanges();
     });
 
     it('has-resource', async () => {
@@ -101,10 +99,11 @@ describe('<manifold-data-has-resource>', () => {
       fetchMock.mock(`begin:${graphqlEndpoint}`, multiResources);
 
       const mockLoad = jest.fn();
-      await setup({ onLoad: mockLoad });
+      const resourceLabel = 'my-resource';
+      await setup({ onLoad: mockLoad, label: resourceLabel });
 
       expect(mockLoad).toHaveBeenCalledWith(
-        expect.objectContaining({ detail: { hasAnyResources: true } })
+        expect.objectContaining({ detail: { hasAnyResources: true, resourceLabel } })
       );
     });
 
@@ -112,10 +111,11 @@ describe('<manifold-data-has-resource>', () => {
       fetchMock.mock(`begin:${graphqlEndpoint}`, { data: null });
 
       const mockLoad = jest.fn();
-      await setup({ onLoad: mockLoad });
+      const resourceLabel = 'my-resource';
+      await setup({ onLoad: mockLoad, label: resourceLabel });
 
       expect(mockLoad).toHaveBeenCalledWith(
-        expect.objectContaining({ detail: { hasAnyResources: false } })
+        expect.objectContaining({ detail: { hasAnyResources: false, resourceLabel } })
       );
     });
   });


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

1. We were missing a test for the event that gets fired when no resource was found
1. Waiting on the response during the test for the `loading` slot got rid of some unhandled promise rejection warnings.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
