### PR TITLE
Add a nice little top margin to credentials errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Top margin to credentials error messages
+
 ## [v0.5.12]
 
 ## Added

--- a/src/components/manifold-credentials/manifold-credentials.tsx
+++ b/src/components/manifold-credentials/manifold-credentials.tsx
@@ -85,7 +85,9 @@ export class ManifoldCredentials {
       </manifold-credentials-view>,
       Array.isArray(this.errors)
         ? this.errors.map(({ message }) => (
-            <manifold-toast alert-type="error">{message}</manifold-toast>
+            <div style={{'margin-top': '1rem'}}>
+              <manifold-toast alert-type="error">{message}</manifold-toast>
+            </div>
           ))
         : null,
     ];

--- a/src/components/manifold-credentials/manifold-credentials.tsx
+++ b/src/components/manifold-credentials/manifold-credentials.tsx
@@ -85,7 +85,7 @@ export class ManifoldCredentials {
       </manifold-credentials-view>,
       Array.isArray(this.errors)
         ? this.errors.map(({ message }) => (
-            <div style={{'margin-top': '1rem'}}>
+            <div style={{ 'margin-top': '1rem' }}>
               <manifold-toast alert-type="error">{message}</manifold-toast>
             </div>
           ))


### PR DESCRIPTION
## Reason for change

Adds a `margin-top` to credentials errors so the toast has some room to breath.
Fixes https://app.zenhub.com/workspaces/engineering-56990653b8516b1b4867e8b2/issues/manifoldco/engineering/9466

## Testing

1. Copy this version of UI into render-dashboard
2. Create a new addon
3. Open new addon in two separate tabs
4. In tab 1, delete the addon
5. In tab 2, try to show credentials

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
