### PR TITLE
place credentials on individual lines 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Top margin to credentials error messages
+- Place credentials on individual lines
 
 ## [v0.5.12]
 

--- a/src/components/manifold-credentials-view/manifold-credentials-view.tsx
+++ b/src/components/manifold-credentials-view/manifold-credentials-view.tsx
@@ -122,6 +122,7 @@ export class ManifoldCredentialsView {
                         <span class="env-key">{node.key}</span>,
                         '=',
                         <span class="env-value">{node.value}</span>,
+                        '\n',
                       ]
                     : null
                 )}

--- a/src/components/manifold-credentials/manifold-credentials.spec.tsx
+++ b/src/components/manifold-credentials/manifold-credentials.spec.tsx
@@ -19,7 +19,7 @@ const credentialsHTML = credentials
       credential && credential.node
         ? [
             ...secrets,
-            `<span class="env-key">${credential.node.key}</span>=<span class="env-value">${credential.node.value}</span>`,
+            `<span class="env-key">${credential.node.key}</span>=<span class="env-value">${credential.node.value}</span>\n`,
           ]
         : secrets,
     []


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

Fixes  [#9473](https://app.zenhub.com/workspaces/engineering-56990653b8516b1b4867e8b2/issues/manifoldco/engineering/9473)

We want our credential reading experience to include line breaks.
It had before and a regression was introduced. This fixes that regression.
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->
- [ ] have a look a storybook under resource details and peek at a credential (youll be plesently surprised I promise!)

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- n/a **Prop changes**: [docs][docs] were updated 
- n/a **Prop changes**: E2E tests were updated, testing from the highest level possible 
- coming soon from :mog: **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform

## Screenshot

<img width="1168" alt="Screen Shot 2019-09-27 at 1 32 34 PM" src="https://user-images.githubusercontent.com/15069938/65786856-fca59a00-e12d-11e9-9228-85faf327ff56.png">

