### PR TITLE
Check renamed resource label before emitting event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Top margin to credentials error messages
 - Place credentials on individual lines
 
+### Fixed
+
+- Fixed success event after a resource rename to include potentially modified label
+
 ## [v0.5.12]
 
 ## Added

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
@@ -305,7 +305,7 @@ describe('<manifold-data-rename-button>', () => {
     });
 
     it('success', async () => {
-      const newLabel = 'logdna';  // Test relies on logdna here because fetchMock returns the logdna mock resource
+      const newLabel = 'logdna'; // Test relies on logdna here because fetchMock returns the logdna mock resource
       const resourceId = 'success-id';
       const resourceLabel = 'success-label';
 

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
@@ -305,7 +305,7 @@ describe('<manifold-data-rename-button>', () => {
     });
 
     it('success', async () => {
-      const newLabel = 'success-next';
+      const newLabel = 'logdna';  // Test relies on logdna here because fetchMock returns the logdna mock resource
       const resourceId = 'success-id';
       const resourceLabel = 'success-label';
 

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
@@ -105,7 +105,7 @@ export class ManifoldDataRenameButton {
     };
 
     // rename
-    await this.restFetch({
+    const renamedResource = await this.restFetch<Marketplace.Resource>({
       service: 'marketplace',
       endpoint: `/resources/${this.resourceId}`,
       body,
@@ -121,6 +121,10 @@ export class ManifoldDataRenameButton {
       this.error.emit(errorMessage);
       return Promise.reject(errorMessage);
     });
+    if (renamedResource) {
+      this.newLabel = renamedResource.body.label;
+      resourceDetails.newLabel = this.newLabel;
+    }
 
     // Poll until rename complete
     await this.pollRename();


### PR DESCRIPTION
## Reason for change

Checks response body of the rename PATCH for a modified label in case of name collision.

## Testing

Rename a render addon to use an existing name, redirect should be to new label + `-1`

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
