### PR TITLE
fix local testing address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Fixed local testing addresses.
+
 ## [v0.5.13]
 
 ### Fixed

--- a/src/utils/connections.ts
+++ b/src/utils/connections.ts
@@ -21,7 +21,7 @@ export const connections: Connections = {
     provisioning: 'http://api.provisioning.arigato.tools/v1',
     connector: 'http://api.connector.arigato.tools/v1',
     graphql: 'http://graphql.arigato.tools/graphql',
-    oauth: 'https://login.arigato.tools/signin/oauth/web', // does this work?
+    oauth: 'http://login.arigato.tools/signin/oauth/web',
   },
   stage: {
     billing: 'https://api.billing.stage.manifold.co/v1',


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

This addr was not working locally because we don't have https locally.
We need to change it to the correct one to support local testing.
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->
using it with a local marketplace/platform according to this: https://app.gitbook.com/@manifold/s/engineering/~/drafts/-LnICEOmZfPp1x6oce9X/primary/playbooks/testing-your-code-against-a-platform  [X]

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
