### PR TITLE
Change number of skeleton products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Changed number of skeleton products that load
+- Changed number of skeleton products that load (#551)
 
 ## [v0.5.13]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+
 - Fixed local testing addresses.
+
+### Changed
+
+- Changed number of skeleton products that load
 
 ## [v0.5.13]
 

--- a/src/components/manifold-marketplace/manifold-marketplace.tsx
+++ b/src/components/manifold-marketplace/manifold-marketplace.tsx
@@ -159,8 +159,8 @@ export class ManifoldMarketplace {
   @logger()
   render() {
     const accurateSkeletonCount =
-      this.products && this.products.length < skeletonProducts.length
-        ? skeletonProducts.slice(0, this.products.length)
+      this.parsedProducts.length < skeletonProducts.length
+        ? skeletonProducts.slice(0, this.parsedProducts.length)
         : skeletonProducts;
 
     return (

--- a/src/components/manifold-marketplace/manifold-marketplace.tsx
+++ b/src/components/manifold-marketplace/manifold-marketplace.tsx
@@ -160,7 +160,7 @@ export class ManifoldMarketplace {
   render() {
     const accurateSkeletonCount =
       this.products && this.products.length < skeletonProducts.length
-        ? skeletonProducts.splice(0, this.products.length)
+        ? skeletonProducts.slice(0, this.products.length)
         : skeletonProducts;
 
     return (

--- a/src/components/manifold-marketplace/manifold-marketplace.tsx
+++ b/src/components/manifold-marketplace/manifold-marketplace.tsx
@@ -158,6 +158,11 @@ export class ManifoldMarketplace {
 
   @logger()
   render() {
+    const accurateSkeletonCount =
+      this.products && this.products.length < skeletonProducts.length
+        ? skeletonProducts.splice(0, this.products.length)
+        : skeletonProducts;
+
     return (
       <manifold-marketplace-grid
         featured={this.parsedFeatured}
@@ -169,7 +174,7 @@ export class ManifoldMarketplace {
         productLinkFormat={this.productLinkFormat}
         products={this.parsedProducts}
         skeleton={this.isLoading}
-        services={this.isLoading ? skeletonProducts.map(transformSkeleton) : this.services}
+        services={this.isLoading ? accurateSkeletonCount.map(transformSkeleton) : this.services}
         templateLinkFormat={this.templateLinkFormat}
       />
     );

--- a/src/components/manifold-marketplace/manifold-marketplace.tsx
+++ b/src/components/manifold-marketplace/manifold-marketplace.tsx
@@ -159,7 +159,7 @@ export class ManifoldMarketplace {
   @logger()
   render() {
     const accurateSkeletonCount =
-      this.parsedProducts.length < skeletonProducts.length
+      this.parsedProducts.length > 0 && this.parsedProducts.length < skeletonProducts.length
         ? skeletonProducts.slice(0, this.parsedProducts.length)
         : skeletonProducts;
 


### PR DESCRIPTION
## Reason for change

Changes the number of skeleton products on load

![2019-09-29 09-44-20 2019-09-29 09_44_59](https://user-images.githubusercontent.com/1369770/65834961-dc94e880-e29d-11e9-936f-0d45ef5e3bd0.gif)


## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
