### PR TITLE
add disabled attr to rename component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## Added
+
+- Added `disabled` attribute to `manifold-resource-rename`
+
 ### Fixed
 
 - Fixed local testing addresses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Added
 
-- Added `disabled` attribute to `manifold-resource-rename`
+- Added `disabled` attribute to `manifold-resource-rename` (#553)
 
 ### Fixed
 

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -205,6 +205,7 @@ export namespace Components {
     'restFetch'?: RestFetch;
   }
   interface ManifoldDataRenameButton {
+    'disabled'?: boolean;
     'loading'?: boolean;
     /**
     * The new label to give to the resource
@@ -574,6 +575,7 @@ export namespace Components {
   }
   interface ManifoldResourceRename {
     'data'?: Gateway.Resource;
+    'disabled'?: boolean;
     'loading': boolean;
     /**
     * The new label to give to the resource
@@ -1287,6 +1289,7 @@ declare namespace LocalJSX {
     'restFetch'?: RestFetch;
   }
   interface ManifoldDataRenameButton extends JSXBase.HTMLAttributes<HTMLManifoldDataRenameButtonElement> {
+    'disabled'?: boolean;
     'loading'?: boolean;
     /**
     * The new label to give to the resource
@@ -1671,6 +1674,7 @@ declare namespace LocalJSX {
   }
   interface ManifoldResourceRename extends JSXBase.HTMLAttributes<HTMLManifoldResourceRenameElement> {
     'data'?: Gateway.Resource;
+    'disabled'?: boolean;
     'loading'?: boolean;
     /**
     * The new label to give to the resource

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
@@ -45,6 +45,7 @@ export class ManifoldDataRenameButton {
   /** The id of the resource to rename, will be fetched if not set */
   @Prop({ mutable: true }) resourceId?: string = '';
   @Prop() loading?: boolean = false;
+  @Prop() disabled?: boolean;
   @Event({ eventName: 'manifold-renameButton-click', bubbles: true }) click: EventEmitter;
   @Event({ eventName: 'manifold-renameButton-invalid', bubbles: true }) invalid: EventEmitter;
   @Event({ eventName: 'manifold-renameButton-error', bubbles: true }) error: EventEmitter;
@@ -188,7 +189,7 @@ export class ManifoldDataRenameButton {
       <button
         type="submit"
         onClick={() => this.rename()}
-        disabled={!this.resourceId && !this.loading}
+        disabled={(!this.resourceId && !this.loading) || this.disabled}
       >
         <slot />
       </button>

--- a/src/components/manifold-resource-rename/manifold-resource-rename.tsx
+++ b/src/components/manifold-resource-rename/manifold-resource-rename.tsx
@@ -9,6 +9,7 @@ import loadMark from '../../utils/loadMark';
 export class ManifoldResourceRename {
   @Prop() data?: Gateway.Resource;
   @Prop() loading: boolean = true;
+  @Prop() disabled?: boolean;
   /** The new label to give to the resource */
   @Prop() newLabel: string = '';
 
@@ -22,6 +23,7 @@ export class ManifoldResourceRename {
         resourceId={this.data && this.data.id}
         resourceLabel={this.data && this.data.label}
         loading={this.loading}
+        disabled={this.disabled}
         newLabel={this.newLabel}
       >
         <slot />


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
- add ability to disable rename button with an attribute. This will be used to prevent the form from submitting on a validation error.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [x] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
