### PR TITLE
Add better loading state to manifold-credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fixed local testing addresses.
 - Fixed console warning about `loading="lazy"` (#552)
+- Prevent actions on `<manifold-credentials>` while awaiting a resourceLabel (#554)
 
 ### Changed
 

--- a/src/components/manifold-credentials/manifold-credentials.tsx
+++ b/src/components/manifold-credentials/manifold-credentials.tsx
@@ -27,7 +27,7 @@ export class ManifoldCredentials {
 
   @Method()
   async showCredentials() {
-    if (!this.graphqlFetch) {
+    if (!this.graphqlFetch || !this.resourceLabel) {
       return;
     }
 
@@ -73,7 +73,7 @@ export class ManifoldCredentials {
     return [
       <manifold-credentials-view
         credentials={this.credentials}
-        loading={this.loading}
+        loading={this.loading || !this.resourceLabel}
         onCredentialsRequested={this.credentialsRequested}
       >
         <manifold-forward-slot slot="show-button">


### PR DESCRIPTION
## Reason for change
This prevents actions on `<manifold-credentials>` until it’s given a `resource-label`.

This also helps `<manifold-resource-credentials>` display in a loading state until the resource is available.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
