### PR TITLE
increase toast-line-height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Changed number of skeleton products that load (#551)
+- Changed number of skeleton products that load (#551)git reset HEAD~1
+- Changed line height on `<manifold-toast>` componenet (#557)
 
 ## [v0.5.13]
 

--- a/src/components/manifold-toast/manifold-toast.css
+++ b/src/components/manifold-toast/manifold-toast.css
@@ -27,7 +27,7 @@
   margin-top: 0;
   margin-bottom: 0;
   color: var(--manifold-color-primary);
-  line-height: 1;
+  line-height: 1.3;
   will-change: height;
 
   /* hackiness below to vary the opacity of hex colors */
@@ -134,7 +134,7 @@
   padding: 0;
   color: currentColor;
   font-size: 1.125em;
-  line-height: 1;
+  line-height: 1.3;
   background: none;
   border: none;
   border-top-right-radius: var(--manifold-radius);


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change
Fixes: https://github.com/manifoldco/engineering/issues/9495

Meg noticed the toast text is a little squished. Lets bump it.
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

Have a look at storybook at this componenet and docs component. Does it look alright to you?
<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
