### PR TITLE
Use label instead of name for resource display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## Changed
+
+- Deprecated friendly resource names in favor of kebab-case resource labels (#559)
+
 ## [v0.5.15]
 
 - Added `manifold-resource-load` event to `manifold-resource-container` (#556)

--- a/docs/docs/components/manifold-resource-card.md
+++ b/docs/docs/components/manifold-resource-card.md
@@ -25,9 +25,8 @@ The resource card can fetch the resource with either an ID or a resource label.
 
 ## Navigation
 
-By default, resource cards will only emit the `manifold-resource-click`
-event (above). But it can also be turned into an `<a>` tag by specifying
-`resource-link-format`:
+By default, resource cards will only emit the `manifold-resource-click` event (above). But it can
+also be turned into an `<a>` tag by specifying `resource-link-format`:
 
 ```html
 <manifold-resource-card resource-link-format="/resources/:resource"></manifold-resource-card>
@@ -36,15 +35,12 @@ event (above). But it can also be turned into an `<a>` tag by specifying
 
 `:label` will be replaced with the url-friendly slug for the product.
 
-Note that this will disable the custom events unless `preserve-event` is
-passed as well.
+Note that this will disable the custom events unless `preserve-event` is passed as well.
 
 ## Events
 
-This component emits [custom
-events](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent)
-when it updates. To listen to those events, add an event listener either on
-the component itself, or `document`:
+This component emits [custom events][custom-events] when it updates. To listen to those events, add
+an event listener either on the component itself, or `document`:
 
 ```js
 document.addEventListener('manifold-resource-click', { detail: { resourceLabel } } => {
@@ -55,17 +51,17 @@ document.addEventListener('manifold-resource-click', { detail: { resourceLabel }
 The following events are emitted:
 
 | Event Name                | Description                                      | Data                          |
-|---------------------------|--------------------------------------------------|-------------------------------|
+| ------------------------- | ------------------------------------------------ | ----------------------------- |
 | `manifold-resource-click` | Fires whenever a user has clicked on a resource. | `resourceId`, `resourceLabel` |
 
 ## Displaying without fetching
 
-The underlying `<manifold-resource-card-view>` component may be used to display the values for a resource without any fetch calls.
+The underlying `<manifold-resource-card-view>` component may be used to display the values for a
+resource without any fetch calls.
 
 ```html
 <manifold-resource-card-view
   label="my-resource"
-  name="my resource"
   logo="http://logo.png"
   resource-id="123456"
   resource-status="available"
@@ -85,10 +81,11 @@ The `<manifold-resource-card-view>` can display a loading status rather than the
 ```html
 <manifold-resource-card-view
   label="my-resource"
-  name="my resource"
   logo="http://logo.png"
   resource-id="123456"
   resource-status="unknown"
   loading
 ></manifold-resource-card-view>
 ```
+
+[custom-events]: https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -501,7 +501,6 @@ export namespace Components {
     'loading'?: boolean;
     'logo'?: string;
     'logoLabel'?: string;
-    'name'?: string;
     'preserveEvent'?: boolean;
     'resourceId'?: string;
     'resourceLinkFormat'?: string;
@@ -1587,7 +1586,6 @@ declare namespace LocalJSX {
     'loading'?: boolean;
     'logo'?: string;
     'logoLabel'?: string;
-    'name'?: string;
     'onManifold-resource-click'?: (event: CustomEvent<any>) => void;
     'preserveEvent'?: boolean;
     'resourceId'?: string;

--- a/src/components/manifold-resource-card-view/manifold-resource-card-view-happo.ts
+++ b/src/components/manifold-resource-card-view/manifold-resource-card-view-happo.ts
@@ -3,7 +3,6 @@ export const skeleton = async () => {
   card.label = 'loading';
   card.loading = true;
   card.logo = 'https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png';
-  card.name = 'loading';
 
   document.body.appendChild(card);
 
@@ -14,7 +13,6 @@ export const logDNA = async () => {
   const card = document.createElement('manifold-resource-card-view');
   card.label = 'custom-resource';
   card.logo = 'https://cdn.manifold.co/providers/logdna/logos/ftzzxwdr0c8wx6gh0ntf83fq4w.png';
-  card.name = 'logging';
   card.resourceId = 'test';
   card.resourceStatus = 'available';
 
@@ -26,7 +24,6 @@ export const logDNA = async () => {
 export const logoPlaceholder = async () => {
   const card = document.createElement('manifold-resource-card-view');
   card.label = 'custom-resource';
-  card.name = 'custom-resource';
   card.resourceId = 'test';
   card.resourceStatus = 'available';
 

--- a/src/components/manifold-resource-card-view/manifold-resource-card-view.spec.ts
+++ b/src/components/manifold-resource-card-view/manifold-resource-card-view.spec.ts
@@ -6,7 +6,6 @@ describe('<manifold-resource-card>', () => {
   it('dispatches click event', () => {
     const serviceCard = new ManifoldResourceCardView();
     serviceCard.label = Resource.body.label;
-    serviceCard.name = Resource.body.name;
     serviceCard.resourceId = Resource.id;
     serviceCard.logo = Product.body.logo_url;
     serviceCard.resourceStatus = 'available';
@@ -17,7 +16,6 @@ describe('<manifold-resource-card>', () => {
     serviceCard.onClick(new Event('click'));
     expect(mock.emit).toHaveBeenCalledWith({
       resourceId: Resource.id,
-      resourceName: Resource.body.name,
       resourceLabel: Resource.body.label,
     });
   });

--- a/src/components/manifold-resource-card-view/manifold-resource-card-view.tsx
+++ b/src/components/manifold-resource-card-view/manifold-resource-card-view.tsx
@@ -24,7 +24,6 @@ export class ManifoldResourceCardView {
   @Prop() restFetch?: RestFetch = connection.restFetch;
 
   @Prop() label?: string;
-  @Prop() name?: string;
   @Prop() logo?: string;
   @Prop() logoLabel?: string;
   @Prop() resourceId?: string;
@@ -78,7 +77,6 @@ export class ManifoldResourceCardView {
       const detail: EventDetail = {
         resourceId: this.resourceId,
         resourceLabel: this.label,
-        resourceName: this.name,
       };
       this.resourceClick.emit(detail);
     }
@@ -97,7 +95,7 @@ export class ManifoldResourceCardView {
         onClick={this.onClick}
       >
         <h3 class="name" itemprop="name">
-          {this.name || this.label}
+          {this.label}
         </h3>
         <div class="status">
           <manifold-resource-status-view size="xsmall" resourceState={this.resourceStatus} />

--- a/src/components/manifold-resource-card/manifold-resource-card.tsx
+++ b/src/components/manifold-resource-card/manifold-resource-card.tsx
@@ -64,7 +64,6 @@ export class ManifoldResourceCard {
     return this.resource ? (
       <manifold-resource-card-view
         label={this.resource.label}
-        name={this.resource.name}
         logo={this.resource.product && this.resource.product.logo_url}
         resourceId={this.resource.id}
         resourceStatus={this.resource.state}

--- a/src/components/manifold-resource-list/manifold-resource-list.tsx
+++ b/src/components/manifold-resource-list/manifold-resource-list.tsx
@@ -247,7 +247,6 @@ export class ManifoldResourceList {
           ? this.resources.map(resource => (
               <manifold-resource-card-view
                 label={resource.label}
-                name={resource.name}
                 logo={resource.logo}
                 logoLabel={resource.logoLabel}
                 resourceId={resource.id}
@@ -261,7 +260,6 @@ export class ManifoldResourceList {
                 label="my-loading-resource"
                 loading={true}
                 logo="myresource.png"
-                name="my-loading-resource"
               />
             ))}
         {!Array.isArray(this.resources) && <slot name="loading" />}


### PR DESCRIPTION
## Reason for change
fixes manifoldco/engineering#9503

**Before** (resource was renamed to conflict)
![](https://user-images.githubusercontent.com/57106/65840238-78e1de00-e2e4-11e9-89d2-a50cf3b07654.png)

**After** (resource was named to conflict, but resolved to `-2`)
![Screen Shot 2019-09-30 at 07 43 22](https://user-images.githubusercontent.com/1369770/65884379-001b6a00-e356-11e9-9607-f13921bd7df9.png)


## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [x] **Prop changes**: [docs][docs] were updated
- [x] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [x] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
