### PR TITLE
Let manifold-product emit an event when the request is complete

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1547,6 +1547,7 @@ declare namespace LocalJSX {
     * _(hidden)_
     */
     'graphqlFetch'?: GraphqlFetch;
+    'onManifold-product-load'?: (event: CustomEvent<Product | undefined | null>) => void;
     /**
     * _(optional)_ Hide the CTA on the left?
     */

--- a/src/components/manifold-product/manifold-product.spec.ts
+++ b/src/components/manifold-product/manifold-product.spec.ts
@@ -45,7 +45,7 @@ describe('<manifold-product>', () => {
 
   it('fetches the product by label on change', async () => {
     const productLabel = 'product-label';
-    fetchMock.once('*', 200);
+    fetchMock.once('*', { status: 200, body: {} });
 
     const root = page.root as HTMLElement;
     element.productLabel = productLabel;

--- a/src/components/manifold-product/manifold-product.tsx
+++ b/src/components/manifold-product/manifold-product.tsx
@@ -1,4 +1,4 @@
-import { h, Component, Prop, State, Element, Watch } from '@stencil/core';
+import { h, Component, Prop, State, Element, Watch, Event, EventEmitter } from '@stencil/core';
 import { gql } from '@manifoldco/gql-zero';
 
 import { Product } from '../../types/graphql';
@@ -43,6 +43,8 @@ export class ManifoldProduct {
   /** _(optional)_ Hide the CTA on the left? */
   @Prop() productLabel?: string;
   @State() product?: Product;
+  @Event({ eventName: 'manifold-product-load' }) loaded: EventEmitter<Product | undefined | null>;
+
   @Watch('productLabel') productChange(newLabel: string) {
     this.fetchProduct(newLabel);
   }
@@ -63,6 +65,7 @@ export class ManifoldProduct {
     const { data } = await this.graphqlFetch({ query, variables });
 
     this.product = (data && data.product) || undefined;
+    this.loaded.emit(data && data.product);
   };
 
   @logger()


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

This is needed to support a full page view for product details in Render. Mainly, we need to be able to detect if a product was not found as a result of navigating to a URL with a bad product name, e.g. `addon/details/foo`. Additionally, when the product is found, emitting the product data will allow Render to add the product display name in their button, e.g. "Choose LogDNA".

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

All tests should pass.

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
