### PR TITLE
Align the alert icon to the top of the toast text

### DIFF
--- a/src/components/manifold-toast/manifold-toast.css
+++ b/src/components/manifold-toast/manifold-toast.css
@@ -119,6 +119,11 @@
     position: relative;
     padding-right: 4rem;
   }
+
+  & .alert {
+    align-self: flex-start;
+    padding-top: 0.25rem;
+  }
 }
 
 .close {

--- a/src/components/manifold-toast/manifold-toast.css
+++ b/src/components/manifold-toast/manifold-toast.css
@@ -120,6 +120,10 @@
     position: relative;
     padding-right: 4rem;
   }
+
+  & .content {
+    align-self: flex-start;
+  }
 }
 
 .close {

--- a/src/components/manifold-toast/manifold-toast.css
+++ b/src/components/manifold-toast/manifold-toast.css
@@ -110,6 +110,7 @@
   grid-column: 1;
   grid-column-gap: calc(var(--padding) - 0.125rem);
   grid-template-columns: min-content auto;
+  align-items: baseline;
   padding-top: var(--padding);
   padding-right: var(--padding);
   padding-bottom: var(--padding);
@@ -118,11 +119,6 @@
   &[data-dismissable] {
     position: relative;
     padding-right: 4rem;
-  }
-
-  & .alert {
-    align-self: flex-start;
-    padding-top: 0.25rem;
   }
 }
 

--- a/src/components/manifold-toast/manifold-toast.tsx
+++ b/src/components/manifold-toast/manifold-toast.tsx
@@ -101,7 +101,7 @@ export class ManifoldToast {
                 <manifold-icon icon={x} />
               </button>
             )}
-            <manifold-icon class="alert" icon={this.icon || this.alertTypeIcon} />
+            <manifold-icon icon={this.icon || this.alertTypeIcon} />
             <slot />
           </div>
         </p>

--- a/src/components/manifold-toast/manifold-toast.tsx
+++ b/src/components/manifold-toast/manifold-toast.tsx
@@ -102,7 +102,9 @@ export class ManifoldToast {
               </button>
             )}
             <manifold-icon icon={this.icon || this.alertTypeIcon} />
-            <slot />
+            <div class="content">
+              <slot />
+            </div>
           </div>
         </p>
       </Host>

--- a/src/components/manifold-toast/manifold-toast.tsx
+++ b/src/components/manifold-toast/manifold-toast.tsx
@@ -101,7 +101,7 @@ export class ManifoldToast {
                 <manifold-icon icon={x} />
               </button>
             )}
-            <manifold-icon icon={this.icon || this.alertTypeIcon} />
+            <manifold-icon class="alert" icon={this.icon || this.alertTypeIcon} />
             <slot />
           </div>
         </p>

--- a/stories/common.stories.js
+++ b/stories/common.stories.js
@@ -79,4 +79,21 @@ storiesOf('Common', module)
       >
         ${message}
       </manifold-toast>`;
+  })
+  .add('multi-line toast', () => {
+    const type = select(
+      'alert-type',
+      { default: '', error: 'error', warning: 'warning', success: 'success' },
+      ''
+    );
+    const dismissable = boolean('dismissable', true);
+    const message = text('message', 'This is a generic toast component.');
+    return `<manifold-toast
+        ${type ? `alert-type="${type}"` : ''}
+        ${dismissable ? 'dismissable' : ''}
+      >
+        ${message}
+        <br />
+        It spans multiple lines
+      </manifold-toast>`;
   });


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

The vertical alignment of the alert icon is currently centered, and when the toast text spans multiple lines, this becomes a bit awkward, as seen in the screenshot below. Per @megthesmith, we should align this icon towards the top. 

![image](https://user-images.githubusercontent.com/374078/65962872-383aaf80-e41f-11e9-9ec2-4d4c84a93801.png)


## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

You might try modifying or creating a toast within Storybook where the text spans multiple lines. Or you can have a look at the screenshot below, which is using a build that includes these changes.

![image](https://user-images.githubusercontent.com/374078/65981749-63cd9200-e43f-11e9-8b7b-1c9ac52ea822.png)


## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
