### PR TITLE
Convert the `manifold-resource-product` component to GraphQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## Changed
+
+- Converted `manifold-resource-product` to use the GraphQL data fetched from the `manifold-resource-container`.
+
 ## [v0.5.16]
 
 ## Added

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -14,6 +14,7 @@ import {
   PlanConnection,
   Product,
   ProductEdge,
+  Resource,
 } from './types/graphql';
 import {
   Gateway,
@@ -564,7 +565,7 @@ export namespace Components {
   }
   interface ManifoldResourcePlan {}
   interface ManifoldResourceProduct {
-    'data'?: Gateway.Resource;
+    'gqlData'?: Resource;
     'loading': boolean;
   }
   interface ManifoldResourceRename {
@@ -1652,7 +1653,7 @@ declare namespace LocalJSX {
   }
   interface ManifoldResourcePlan extends JSXBase.HTMLAttributes<HTMLManifoldResourcePlanElement> {}
   interface ManifoldResourceProduct extends JSXBase.HTMLAttributes<HTMLManifoldResourceProductElement> {
-    'data'?: Gateway.Resource;
+    'gqlData'?: Resource;
     'loading'?: boolean;
   }
   interface ManifoldResourceRename extends JSXBase.HTMLAttributes<HTMLManifoldResourceRenameElement> {

--- a/src/components/manifold-resource-container/manifold-resource-container.spec.ts
+++ b/src/components/manifold-resource-container/manifold-resource-container.spec.ts
@@ -16,6 +16,7 @@ const GraphqlResource = {
         product: {
           id: '1234',
           displayName: 'Product',
+          tagline: 'Amazing product',
           label: 'product',
           logoUrl: 'https://fillmurray.com/200/200',
         },
@@ -40,9 +41,11 @@ describe('<manifold-resource-credentials>', () => {
       endpoint: () => graphqlEndpoint,
     });
   });
+
   afterEach(() => {
     fetchMock.restore();
   });
+
   it('fetches resource on label change', () => {
     const newResource = 'new-resource';
     const resourceCreds = new ManifoldResourceContainer();
@@ -51,6 +54,7 @@ describe('<manifold-resource-credentials>', () => {
     resourceCreds.resourceChange(newResource);
     expect(resourceCreds.fetchResource).toHaveBeenCalledWith(newResource);
   });
+
   it('fetches resource on refetch change', () => {
     const resourceCreds = new ManifoldResourceContainer();
     resourceCreds.fetchResource = jest.fn();
@@ -58,6 +62,7 @@ describe('<manifold-resource-credentials>', () => {
     resourceCreds.refreshChange(true);
     expect(resourceCreds.fetchResource).toHaveBeenCalledWith('old-resource');
   });
+
   it('will fetch the resource on load', async () => {
     const resourceLabel = 'test-resource';
     fetchMock.mock(`${connections.prod.gateway}/resources/me/${resourceLabel}`, GatewayResource);
@@ -71,6 +76,7 @@ describe('<manifold-resource-credentials>', () => {
     );
     expect(fetchMock.called(graphqlEndpoint)).toBe(true);
   });
+
   it('will not fetch the resource if the component has no resource label', async () => {
     const resourceLabel = 'test-resource';
     fetchMock.mock(`${connections.prod.gateway}/resources/me/${resourceLabel}`, GatewayResource);
@@ -83,6 +89,7 @@ describe('<manifold-resource-credentials>', () => {
     );
     expect(fetchMock.called(graphqlEndpoint)).toBe(false);
   });
+
   it('will refetch the resource after load if given an invalid resource', async () => {
     const resourceLabel = 'test-resource';
     // @ts-ignore
@@ -104,6 +111,7 @@ describe('<manifold-resource-credentials>', () => {
     expect(fetchMock.called(graphqlEndpoint)).toBe(true);
     expect(window.setTimeout).toHaveBeenCalledTimes(1);
   });
+
   it('will refetch the resource after load if it received an error', async () => {
     const resourceLabel = 'test-resource';
     // @ts-ignore

--- a/src/components/manifold-resource-container/manifold-resource-container.tsx
+++ b/src/components/manifold-resource-container/manifold-resource-container.tsx
@@ -17,6 +17,7 @@ const query = gql`
         product {
           id
           displayName
+          tagline
           label
           logoUrl
         }

--- a/src/components/manifold-resource-product/manifold-resource-product-happo.ts
+++ b/src/components/manifold-resource-product/manifold-resource-product-happo.ts
@@ -1,3 +1,5 @@
+import { Resource } from '../../types/graphql';
+
 export const skeleton = () => {
   const resourceProduct = document.createElement('manifold-resource-product');
   document.body.appendChild(resourceProduct);
@@ -21,9 +23,7 @@ export const loadedResource = () => {
 
   const resourceProduct = document.createElement('manifold-resource-product');
   resourceProduct.loading = false;
-  // TODO: Make good mocks or rethink the types, this ignore stops the compiler from wanting a complete resource
-  // @ts-ignore
-  resourceProduct.gqlData = GraphqlResource;
+  resourceProduct.gqlData = GraphqlResource as Resource;
 
   document.body.appendChild(resourceProduct);
   return resourceProduct.componentOnReady();

--- a/src/components/manifold-resource-product/manifold-resource-product-happo.ts
+++ b/src/components/manifold-resource-product/manifold-resource-product-happo.ts
@@ -3,3 +3,28 @@ export const skeleton = () => {
   document.body.appendChild(resourceProduct);
   return resourceProduct.componentOnReady();
 };
+
+export const loadedResource = () => {
+  const GraphqlResource = {
+    id: '1234',
+    plan: {
+      id: '1234',
+      product: {
+        id: '1234',
+        displayName: 'Product',
+        tagline: 'Amazing product',
+        label: 'product',
+        logoUrl: 'https://fillmurray.com/200/200',
+      },
+    },
+  };
+
+  const resourceProduct = document.createElement('manifold-resource-product');
+  resourceProduct.loading = false;
+  // TODO: Make good mocks or rethink the types, this ignore stops the compiler from wanting a complete resource
+  // @ts-ignore
+  resourceProduct.gqlData = GraphqlResource;
+
+  document.body.appendChild(resourceProduct);
+  return resourceProduct.componentOnReady();
+};

--- a/src/components/manifold-resource-product/manifold-resource-product.spec.ts
+++ b/src/components/manifold-resource-product/manifold-resource-product.spec.ts
@@ -1,0 +1,64 @@
+import { newSpecPage, SpecPage } from '@stencil/core/testing';
+
+import { ManifoldResourceProduct } from './manifold-resource-product';
+
+const GraphqlResource = {
+  id: '1234',
+  plan: {
+    id: '1234',
+    product: {
+      id: '1234',
+      displayName: 'Product',
+      tagline: 'Amazing product',
+      label: 'product',
+      logoUrl: 'https://fillmurray.com/200/200',
+    },
+  },
+};
+
+describe('<manifold-resource-product>', () => {
+  let page: SpecPage;
+  let element: HTMLManifoldResourceProductElement;
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [ManifoldResourceProduct],
+      html: `<div></div>`,
+    });
+    element = page.doc.createElement('manifold-resource-product');
+  });
+
+  it('Renders a skeleton if loading', async () => {
+    element.loading = true;
+    const root = page.root as HTMLElement;
+    root.appendChild(element);
+
+    await page.waitForChanges();
+
+    expect(element).toEqualHtml(`
+      <manifold-resource-product>
+        <manifold-service-card-view description="This is a loading product..." logo="loading.jpg" name="loading..." skeleton="">
+          <manifold-forward-slot slot="cta"></manifold-forward-slot>
+        </manifold-service-card-view>
+      </manifold-resource-product>
+    `);
+  });
+
+  it('Renders a product card if not loading', async () => {
+    element.loading = false;
+    // TODO: Make good mocks or rethink the types, this ignore stops the compiler from wanting a complete resource
+    // @ts-ignore
+    element.gqlData = GraphqlResource;
+    const root = page.root as HTMLElement;
+    root.appendChild(element);
+
+    await page.waitForChanges();
+
+    expect(element).toEqualHtml(`
+      <manifold-resource-product>
+        <manifold-service-card-view description="Amazing product" logo="https://fillmurray.com/200/200" name="Product" productid="1234" productlabel="product">
+            <manifold-forward-slot slot="cta"></manifold-forward-slot>
+        </manifold-service-card-view>
+      </manifold-resource-product>
+    `);
+  });
+});

--- a/src/components/manifold-resource-product/manifold-resource-product.spec.ts
+++ b/src/components/manifold-resource-product/manifold-resource-product.spec.ts
@@ -1,5 +1,6 @@
 import { newSpecPage, SpecPage } from '@stencil/core/testing';
 
+import { Resource } from '../../types/graphql';
 import { ManifoldResourceProduct } from './manifold-resource-product';
 
 const GraphqlResource = {
@@ -45,9 +46,7 @@ describe('<manifold-resource-product>', () => {
 
   it('Renders a product card if not loading', async () => {
     element.loading = false;
-    // TODO: Make good mocks or rethink the types, this ignore stops the compiler from wanting a complete resource
-    // @ts-ignore
-    element.gqlData = GraphqlResource;
+    element.gqlData = GraphqlResource as Resource;
     const root = page.root as HTMLElement;
     root.appendChild(element);
 

--- a/src/components/manifold-resource-product/manifold-resource-product.tsx
+++ b/src/components/manifold-resource-product/manifold-resource-product.tsx
@@ -1,13 +1,13 @@
 import { h, Component, Prop } from '@stencil/core';
 
 import ResourceTunnel from '../../data/resource';
-import { Gateway } from '../../types/gateway';
+import { Product, Resource } from '../../types/graphql';
 import logger from '../../utils/logger';
 import loadMark from '../../utils/loadMark';
 
 @Component({ tag: 'manifold-resource-product' })
 export class ManifoldResourceProduct {
-  @Prop() data?: Gateway.Resource;
+  @Prop() gqlData?: Resource;
   @Prop() loading: boolean = true;
 
   @loadMark()
@@ -15,25 +15,36 @@ export class ManifoldResourceProduct {
 
   @logger()
   render() {
-    return this.data && this.data.product ? (
+    let product: Product | null | undefined;
+    if (!this.loading && this.gqlData) {
+      if (this.gqlData.plan) {
+        product = this.gqlData.plan.product;
+      }
+    }
+
+    if (this.loading || !product) {
+      return (
+        // ☠
+        <manifold-service-card-view
+          skeleton={true}
+          description="This is a loading product..."
+          logo="loading.jpg"
+          name="loading..."
+        >
+          <manifold-forward-slot slot="cta">
+            <slot name="cta" />
+          </manifold-forward-slot>
+        </manifold-service-card-view>
+      );
+    }
+
+    return (
       <manifold-service-card-view
-        description={this.data.product.tagline}
-        logo={this.data.product.logo_url}
-        name={this.data.product.name}
-        productId={this.data.product.id}
-        productLabel={this.data.product.label}
-      >
-        <manifold-forward-slot slot="cta">
-          <slot name="cta" />
-        </manifold-forward-slot>
-      </manifold-service-card-view>
-    ) : (
-      // ☠
-      <manifold-service-card-view
-        skeleton={true}
-        description="This is a loading product..."
-        logo="loading.jpg"
-        name="loading..."
+        description={product.tagline}
+        logo={product.logoUrl}
+        name={product.displayName}
+        productId={product.id}
+        productLabel={product.label}
       >
         <manifold-forward-slot slot="cta">
           <slot name="cta" />
@@ -43,4 +54,4 @@ export class ManifoldResourceProduct {
   }
 }
 
-ResourceTunnel.injectProps(ManifoldResourceProduct, ['data', 'loading']);
+ResourceTunnel.injectProps(ManifoldResourceProduct, ['gqlData', 'loading']);


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->
Work is related to manifoldco/engineering#9192

## Reason for change

The container still partially uses REST, I am converting it in smaller steps to not create a giant untestable PR.

## Testing

Test using storybook, the component should work like it used to.

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [x] **Prop changes**: [docs][docs] were updated
- [x] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [x] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
