### PR TITLE
have connecition decorator use graphql when available to get identity

### DIFF
--- a/stories/data/connectionDecorator.js
+++ b/stories/data/connectionDecorator.js
@@ -1,8 +1,7 @@
 import { text, radios } from '@storybook/addon-knobs';
 import { gql } from '@manifoldco/gql-zero';
 
-// Creates a fake token provider and manifold connection that adds the api token from localstorage
-// with an expiriy date a week from when it is created. 6.04e8 is a week in milliseconds.
+// Creates a fake token provider and manifold connection that adds the api token from localstorage.
 export const manifoldConnectionDecorator = storyFn => {
   const token = text('manifold_api_token', localStorage.getItem('manifold_api_token') || '');
   const options = { Production: 'prod', Staging: 'stage' };
@@ -11,15 +10,40 @@ export const manifoldConnectionDecorator = storyFn => {
   localStorage.setItem('manifold_api_token', token); // update localStorage to persist
 
   // grab user ID from Manifold (we need this in other stories)
-  if (token && !localStorage.getItem('manifold_user_id')) {
-    // TODO: use GraphQL once we’re using platform tokens
-    fetch('https://api.identity.manifold.co/v1/self', {
-      headers: { authorization: `Bearer ${token}`, 'Content-type': 'application/json' },
-    })
-      .then(data => data.json())
-      .then(({ id }) => {
-        localStorage.setItem('manifold_user_id', id);
+  if (
+    token &&
+    (!localStorage.getItem('manifold_user_id') ||
+      localStorage.getItem('manifold_user_id') === 'undefined')
+  ) {
+    (async () => {
+      const graphQLPayload = await fetch('https://api.manifold.co/graphql', {
+        method: 'POST',
+        headers: { authorization: `Bearer ${token}`, 'Content-type': 'application/json' },
+        body: JSON.stringify({
+          query: gql`
+            query GET_PROFILE_ID {
+              profile {
+                id
+              }
+            }
+          `,
+        }),
       });
+
+      const { data, errors } = graphQLPayload.json();
+      if (data) {
+        const { id } = data.profile;
+        localStorage.setItem('manifold_user_id', id);
+      }
+      if (errors) {
+        const identityPayload = await fetch('https://api.identity.manifold.co/v1/self', {
+          headers: { authorization: `Bearer ${token}`, 'Content-type': 'application/json' },
+        });
+
+        const { id } = identityPayload.json();
+        localStorage.setItem('manifold_user_id', id);
+      }
+    })();
   }
 
   return `


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

We were waiting until we had graphql ready to get owner id for things. Now that its ready we can do that. We still fall back to identity incase folks are using manifold api token.
Also the string undefined was not being checked for; add that check.
<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

Use story book with both a old manifold api token and a manifold platform token.
<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
