### PR TITLE
Ability to retrieve auth token from UI project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Added a `sidebar` slot to `<manifold-marketplace>` (#612)
+- Exposed `ensureAuthToken` function for making authenticated GraphQL calls directly from platforms
+  (#576)
 
 ### Removed
 

--- a/docs/docs/advanced/authentication.md
+++ b/docs/docs/advanced/authentication.md
@@ -196,6 +196,36 @@ minor performance boost (“minor” because typically our services detect an in
 within milliseconds, which does take time but in many instances your users may not notice a
 difference of milliseconds).
 
+## Using our GraphQL API
+
+If you are calling our GraphQL API directly from your client code, and the call that you're making
+requires authentication, you can ask us for the auth token by calling the `ensureAuthToken`
+function:
+
+```js
+import { ensureAuthToken } from '@manifoldco/ui';
+
+const authLink = setContext(async (_, { headers }) => {
+  const token = await ensureAuthToken();
+
+  return {
+    headers: {
+      ...headers,
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+      'content-type': 'application/json',
+      'access-control-allow-origin': '*',
+      Connection: 'keep-alive',
+    },
+  };
+});
+```
+
+This function will return the auth token as soon as authentication has completed. If the
+authentication process does not occur, the function will eventually timeout and throw an exception.
+The wait time defaults to 15 seconds, but is configurable through [the
+manifold-connection][connection] component. You should only use this function if the call you're
+making requires authentication, since public calls to our catalog don't require an auth token.
+
 [authentication]: https://docs.manifold.co/docs/platforms-auth-AzsO1HvPT1Hnojsrsb10L
 [connection]: /connection
 [oauth2]: https://www.oauth.com/oauth2-servers/access-tokens/authorization-code-request

--- a/docs/docs/advanced/authentication.md
+++ b/docs/docs/advanced/authentication.md
@@ -200,10 +200,19 @@ difference of milliseconds).
 
 If you are calling our GraphQL API directly from your client code, and the call that you're making
 requires authentication, you can ask us for the auth token by calling the `ensureAuthToken`
-function:
+function. Here's how you might use this with ApolloClient to add our token to your request headers:
 
 ```js
 import { ensureAuthToken } from '@manifoldco/ui';
+import ApolloClient from 'apollo-client';
+import { createHttpLink } from 'apollo-link-http';
+import { InMemoryCache } from 'apollo-cache-inmemory';
+import { setContext } from 'apollo-link-context';
+
+const cache = new InMemoryCache();
+const link = new createHttpLink({
+  uri: 'https://api.manifold.co/graphql',
+});
 
 const authLink = setContext(async (_, { headers }) => {
   const token = await ensureAuthToken();
@@ -218,6 +227,13 @@ const authLink = setContext(async (_, { headers }) => {
     },
   };
 });
+
+const manifoldAuthenticatedClient = new ApolloClient({
+  link: authLink.concat(link),
+  cache,
+});
+
+export default manifoldAuthenticatedClient;
 ```
 
 This function will return the auth token as soon as authentication has completed. If the

--- a/docs/docs/connection.md
+++ b/docs/docs/connection.md
@@ -31,3 +31,16 @@ The `<manifold-connection>` component is only needed once, and can be placed any
 API calls will not be made if this component is not present somewhere in the DOM.
 
 If you omit the `env` property, `manifold-connection` will point to production by default.
+
+## Authentication timeout
+
+Many API calls will require authentication. If no auth token is present, we will wait for the auth
+token to be received and then try the call again. This process will eventually timeout and throw an
+exception. The default wait time is 15 seconds, but this is can be configured by setting the
+`waitTime` property on this component.
+
+```html
+<manifold-connection waitTime="20">
+  <manifold-product product-label="ant-hill-stage"></manifold-product>
+</manifold-connection>
+```

--- a/docs/docs/connection.md
+++ b/docs/docs/connection.md
@@ -37,10 +37,10 @@ If you omit the `env` property, `manifold-connection` will point to production b
 Many API calls will require authentication. If no auth token is present, we will wait for the auth
 token to be received and then try the call again. This process will eventually timeout and throw an
 exception. The default wait time is 15 seconds, but this is can be configured by setting the
-`waitTime` property on this component.
+`wait-time` attribute on this component.
 
 ```html
-<manifold-connection waitTime="20">
+<manifold-connection wait-time="20">
   <manifold-product product-label="ant-hill-stage"></manifold-product>
 </manifold-connection>
 ```

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -79,7 +79,7 @@ export namespace Components {
   }
   interface ManifoldConnection {
     'env'?: 'local' | 'stage' | 'prod';
-    'waitTime'?: number;
+    'waitTime'?: number | string;
   }
   interface ManifoldCopyCredentials {
     /**
@@ -1121,7 +1121,7 @@ declare namespace LocalJSX {
   }
   interface ManifoldConnection {
     'env'?: 'local' | 'stage' | 'prod';
-    'waitTime'?: number;
+    'waitTime'?: number | string;
   }
   interface ManifoldCopyCredentials {
     /**

--- a/src/components/manifold-connection/manifold-connection.tsx
+++ b/src/components/manifold-connection/manifold-connection.tsx
@@ -8,7 +8,7 @@ import connection from '../../state/connection';
 @Component({ tag: 'manifold-connection' })
 export class ManifoldConnection {
   @Prop() env?: 'local' | 'stage' | 'prod';
-  @Prop() waitTime?: number;
+  @Prop() waitTime?: number | string;
 
   @loadMark()
   componentWillLoad() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
-import fetchAllPages from './utils/fetchAllPages';
 import connection from './state/connection';
 import { waitForAuthToken } from './utils/auth';
+
+export * from './components';
 
 export async function getAuthToken() {
   if (connection.authToken) {
@@ -11,7 +12,3 @@ export async function getAuthToken() {
 
   return connection.authToken;
 }
-
-export * from './components';
-
-export { fetchAllPages };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,17 @@
+import fetchAllPages from './utils/fetchAllPages';
+import connection from './state/connection';
+import { waitForAuthToken } from './utils/auth';
+
+export async function getAuthToken() {
+  if (connection.authToken) {
+    return connection.authToken;
+  }
+
+  await waitForAuthToken(() => connection.authToken, connection.waitTime, Promise.resolve);
+
+  return connection.authToken;
+}
+
+export * from './components';
+
+export { fetchAllPages };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { waitForAuthToken } from './utils/auth';
 
 export * from './components';
 
-export async function getAuthToken() {
+export async function ensureAuthToken() {
   if (connection.authToken) {
     return connection.authToken;
   }

--- a/src/state/connection.ts
+++ b/src/state/connection.ts
@@ -10,7 +10,7 @@ const INITIALIZED = 'manifold-connection-initialize';
 
 interface Initialization {
   env?: 'local' | 'stage' | 'prod';
-  waitTime?: number;
+  waitTime?: number | string;
   authToken?: string;
 }
 
@@ -25,7 +25,7 @@ export class ConnectionState {
 
   initialize = ({ env = 'prod', waitTime = baseWait }: Initialization) => {
     this.env = env;
-    this.waitTime = waitTime;
+    this.waitTime = typeof waitTime === 'number' ? waitTime : parseInt(waitTime, 10);
     this.initialized = true;
     const event = new CustomEvent(INITIALIZED);
     document.dispatchEvent(event);

--- a/src/utils/fetchAllPages.ts
+++ b/src/utils/fetchAllPages.ts
@@ -19,7 +19,7 @@ interface Args<Edge> {
   graphqlFetch?: GraphqlFetch;
 }
 
-class MissingPageInfo extends Error {
+export class MissingPageInfo extends Error {
   constructor(query: string) {
     const message = `
       You've requested all pages of a GraphQL connection, but you

--- a/src/utils/fetchAllPages.ts
+++ b/src/utils/fetchAllPages.ts
@@ -3,7 +3,7 @@ import { PageInfo, Query } from '../types/graphql';
 import { GraphqlFetch } from './graphqlFetch';
 
 interface Connection<Edge> {
-  pageInfo: PageInfo;
+  pageInfo?: PageInfo;
   edges: Edge[];
 }
 
@@ -17,6 +17,38 @@ interface Args<Edge> {
   nextPage: NextPage;
   getConnection: (q: Query) => Connection<Edge> | null | undefined;
   graphqlFetch?: GraphqlFetch;
+}
+
+class MissingPageInfo extends Error {
+  constructor(query: string) {
+    const message = `
+      You've requested all pages of a GraphQL connection, but you
+      forgot to request the pageInfo from the query. To request
+      pageInfo, add it as a sibling to the edges part of your query.
+      An example query looks like this:
+
+      query LIST_THINGS($first: Int!, $after: String!) {
+        things(first: $first, after: $after) {
+          edges {
+            node {
+              id
+              label
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+
+      Your query was:
+
+      ${query}
+    `;
+
+    super(message);
+  }
 }
 
 export default async function fetchAllPages<Edge>({
@@ -38,6 +70,10 @@ export default async function fetchAllPages<Edge>({
       hasPreviousPage: false,
     },
   };
+
+  if (!pageInfo) {
+    throw new MissingPageInfo(query);
+  }
 
   if (pageInfo.hasNextPage) {
     const next = { first: nextPage.first, after: pageInfo.endCursor || '' };


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

In the Render dashboard, we are using a thing called `manifoldClient` in order to make GraphQL calls directly to our API, but it uses an unreliable mechanism for retrieving the auth token.

This PR exposes a `ensureAuthToken` function that can be imported from `@manifoldco/ui`. This function is built on our `waitForAuthToken` logic, which means that it uses the same logic as our API calls do for making sure the auth token is present.

### Bonus

This solution came from experimenting with ways to solve the LogDNA check for Render more reliably. While I was trying different solutions, I realized that our `fetchAllPages` function expects callers to supply a query that asks for the `pageInfo`, but it doesn't have any way to enforce it.

This PR now includes a check for `pageInfo`, and if it doesn't exist, it will throw an error with a helpful message explaining how to assemble a query that includes the `pageInfo`. 

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

You might try this out in Render dashboard as follows:

```js
...

import { ensureAuthToken } from "@manifoldco/ui";
...

const authLink = setContext(async (_, { headers }) => {
  const token = await ensureAuthToken();

  return {
    headers: {
      ...headers,
      ...(token ? { authorization: `Bearer ${token}` } : {}),
      "content-type": "application/json",
      "access-control-allow-origin": "*",
      Connection: "keep-alive"
    }
  };
});
```

If you make this change, then making calls using the `manifoldClient` should always result in the auth token being retrieved correctly.

## Downside

None! Just kidding.

If we use the technique shown above in Render dashboard, it will mean that public API calls will require authentication. Currently, any page in Render dashboard that calls our API will authenticate the user, so this isn't a problem today. But if they ever wanted to show public stuff without authenticating the user first, the `manifoldClient` would barf :nauseated_face: 

We can get around this, though. If Render ever needs to make a call to the catalog, we can define two clients: one that relies on the auth token, and another that doesn't.

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
