### PR TITLE
Convert the manifold-resource-credentials component to graphQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Converted `manifold-resource-product` to use the GraphQL data fetched from the
   `manifold-resource-container`. (#566)
+- Converted `manifold-resource-plan` to use the GraphQL data fetched from the
+  `manifold-resource-container`. (#578)
+- Converted `manifold-resource-credentials` to use the GraphQL data fetched from the
+  `manifold-resource-container`. (#584)
 
 ## [v0.5.16]
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1220,25 +1220,8 @@
       "version": "file:../pkg",
       "requires": {
         "@manifoldco/gql-zero": "^0.2.0",
-        "@stencil/state-tunnel": "^1.0.1",
-        "clipboard-polyfill": "^2.8.6"
-      },
-      "dependencies": {
-        "@manifoldco/gql-zero": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/@manifoldco/gql-zero/-/gql-zero-0.2.0.tgz",
-          "integrity": "sha512-s0nPkp5PUzvqK8SaIQEMw5AYArC4slq+YQ9xL9lG8QImMO1NIWfnrvwJRVAO+Ns5dmeZeAdXACX+1g2k27I0Yg=="
-        },
-        "@stencil/state-tunnel": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@stencil/state-tunnel/-/state-tunnel-1.0.1.tgz",
-          "integrity": "sha512-DYG8uROgL9hkjVTCtCfRBb0d3FwpiFB0muRrNZQ2X1Qo5hxMuNNji76/ILddqeq0AfgkKCW82xrMPDpy+rNIhQ=="
-        },
-        "clipboard-polyfill": {
-          "version": "2.8.6",
-          "resolved": "https://registry.npmjs.org/clipboard-polyfill/-/clipboard-polyfill-2.8.6.tgz",
-          "integrity": "sha512-kz/1ov+PXsBpGnW9XJH3dLWdYj12FpXqO89Dngm/GRPoI36E/tnYs6N0YPTEhxM9WHAlFiN5eoyIVuv5nzKXvg=="
-        }
+        "@manifoldco/shadowcat": "^0.1.6",
+        "@stencil/state-tunnel": "^1.0.1"
       }
     },
     "@mikaelkristiansson/domready": {

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -526,7 +526,7 @@ export namespace Components {
     'restFetch'?: RestFetch;
   }
   interface ManifoldResourceCredentials {
-    'data'?: Gateway.Resource;
+    'gqlData'?: Resource;
     'loading': boolean;
   }
   interface ManifoldResourceDeprovision {
@@ -1613,7 +1613,7 @@ declare namespace LocalJSX {
     'restFetch'?: RestFetch;
   }
   interface ManifoldResourceCredentials {
-    'data'?: Gateway.Resource;
+    'gqlData'?: Resource;
     'loading'?: boolean;
   }
   interface ManifoldResourceDeprovision {

--- a/src/components/manifold-resource-container/manifold-resource-container.tsx
+++ b/src/components/manifold-resource-container/manifold-resource-container.tsx
@@ -13,6 +13,8 @@ import { GraphqlFetch } from '../../utils/graphqlFetch';
 const query = gql`
   query RESOURCE($resourceLabel: String!) {
     resource(label: $resourceLabel) {
+      id
+      label
       plan {
         id
         label

--- a/src/components/manifold-resource-credentials/manifold-resource-credentials.spec.ts
+++ b/src/components/manifold-resource-credentials/manifold-resource-credentials.spec.ts
@@ -1,0 +1,52 @@
+import { newSpecPage, SpecPage } from '@stencil/core/testing';
+
+import { Resource } from '../../types/graphql';
+import { resource } from '../../spec/mock/graphql';
+import { ManifoldResourceCredentials } from './manifold-resource-credentials';
+import { ManifoldCredentials } from '../manifold-credentials/manifold-credentials';
+import { ManifoldCredentialsView } from '../manifold-credentials-view/manifold-credentials-view';
+
+describe('<manifold-resource-product>', () => {
+  let page: SpecPage;
+  let element: HTMLManifoldResourceCredentialsElement;
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [ManifoldResourceCredentials, ManifoldCredentials, ManifoldCredentialsView],
+      html: `<div></div>`,
+    });
+    element = page.doc.createElement('manifold-resource-credentials');
+  });
+
+  it('Renders a skeleton if loading', async () => {
+    element.loading = true;
+    const root = page.root as HTMLElement;
+    root.appendChild(element);
+
+    await page.waitForChanges();
+
+    const view = element.querySelector('manifold-credentials-view');
+    expect(view).toBeDefined();
+
+    if (view && view.shadowRoot) {
+      expect(view.shadowRoot.querySelector('span[class="spin"]')).toBeDefined();
+    }
+  });
+
+  it('Renders a product card if not loading', async () => {
+    element.loading = false;
+    element.gqlData = resource as Resource;
+    const root = page.root as HTMLElement;
+    root.appendChild(element);
+
+    await page.waitForChanges();
+
+    const view = element.querySelector('manifold-credentials-view');
+    expect(view).toBeDefined();
+
+    if (view && view.shadowRoot) {
+      expect(view.shadowRoot.querySelector('manifold-button[color="black"]')).toEqualText(
+        'Show credentials'
+      );
+    }
+  });
+});

--- a/src/components/manifold-resource-credentials/manifold-resource-credentials.spec.ts
+++ b/src/components/manifold-resource-credentials/manifold-resource-credentials.spec.ts
@@ -6,6 +6,8 @@ import { ManifoldResourceCredentials } from './manifold-resource-credentials';
 import { ManifoldCredentials } from '../manifold-credentials/manifold-credentials';
 import { ManifoldCredentialsView } from '../manifold-credentials-view/manifold-credentials-view';
 
+global.setTimeout = jest.fn();
+
 describe('<manifold-resource-product>', () => {
   let page: SpecPage;
   let element: HTMLManifoldResourceCredentialsElement;

--- a/src/components/manifold-resource-credentials/manifold-resource-credentials.tsx
+++ b/src/components/manifold-resource-credentials/manifold-resource-credentials.tsx
@@ -3,11 +3,11 @@ import { h, Component, Prop } from '@stencil/core';
 import ResourceTunnel from '../../data/resource';
 import logger from '../../utils/logger';
 import loadMark from '../../utils/loadMark';
-import { Gateway } from '../../types/gateway';
+import { Resource } from '../../types/graphql';
 
 @Component({ tag: 'manifold-resource-credentials' })
 export class ManifoldResourceCredentials {
-  @Prop() data?: Gateway.Resource;
+  @Prop() gqlData?: Resource;
   @Prop() loading: boolean = true;
 
   @loadMark()
@@ -15,8 +15,12 @@ export class ManifoldResourceCredentials {
 
   @logger()
   render() {
+    if (!this.gqlData || this.loading) {
+      return <manifold-credentials-view loading={true} />;
+    }
+
     return (
-      <manifold-credentials resourceLabel={this.data && this.data.label}>
+      <manifold-credentials resourceLabel={this.gqlData.label}>
         <manifold-forward-slot slot="show-button">
           <slot name="show-button" />
         </manifold-forward-slot>
@@ -28,4 +32,4 @@ export class ManifoldResourceCredentials {
   }
 }
 
-ResourceTunnel.injectProps(ManifoldResourceCredentials, ['data', 'loading']);
+ResourceTunnel.injectProps(ManifoldResourceCredentials, ['gqlData', 'loading']);


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

Work is related to manifoldco/engineering#9192

## Reason for change

This converts the resource credentials components to GraphQL and add some loading capabilities to the component.

## Testing

Test with storybook

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [x] **Prop changes**: [docs][docs] were updated
- [x] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [x] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
