### PR TITLE
Convert the manifold-resource-deprovision component to graphQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `manifold-resource-container`. (#578)
 - Converted `manifold-resource-credentials` to use the GraphQL data fetched from the
   `manifold-resource-container`. (#584)
+- Converted `manifold-resource-deprovision` to use the GraphQL data fetched from the
+  `manifold-resource-container`. (#595)
 
 ## [v0.5.16]
 

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -530,7 +530,7 @@ export namespace Components {
     'loading': boolean;
   }
   interface ManifoldResourceDeprovision {
-    'data'?: Gateway.Resource;
+    'gqlData'?: Resource;
     'loading': boolean;
   }
   interface ManifoldResourceDetails {}
@@ -1617,7 +1617,7 @@ declare namespace LocalJSX {
     'loading'?: boolean;
   }
   interface ManifoldResourceDeprovision {
-    'data'?: Gateway.Resource;
+    'gqlData'?: Resource;
     'loading'?: boolean;
   }
   interface ManifoldResourceDetails {}

--- a/src/components/manifold-resource-credentials/manifold-resource-credentials.spec.ts
+++ b/src/components/manifold-resource-credentials/manifold-resource-credentials.spec.ts
@@ -8,7 +8,7 @@ import { ManifoldCredentialsView } from '../manifold-credentials-view/manifold-c
 
 global.setTimeout = jest.fn();
 
-describe('<manifold-resource-product>', () => {
+describe('<manifold-resource-credentials>', () => {
   let page: SpecPage;
   let element: HTMLManifoldResourceCredentialsElement;
   beforeEach(async () => {

--- a/src/components/manifold-resource-deprovision/manifold-resource-deprovision.spec.ts
+++ b/src/components/manifold-resource-deprovision/manifold-resource-deprovision.spec.ts
@@ -1,0 +1,51 @@
+import { newSpecPage, SpecPage } from '@stencil/core/testing';
+
+import { Resource } from '../../types/graphql';
+import { resource } from '../../spec/mock/graphql';
+import { ManifoldResourceDeprovision } from './manifold-resource-deprovision';
+import { ManifoldDataDeprovisionButton } from '../manifold-data-deprovision-button/manifold-data-deprovision-button';
+
+describe('<manifold-resource-deprovision>', () => {
+  let page: SpecPage;
+  let element: HTMLManifoldResourceDeprovisionElement;
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [ManifoldResourceDeprovision, ManifoldDataDeprovisionButton],
+      html: `<div></div>`,
+    });
+    element = page.doc.createElement('manifold-resource-deprovision');
+  });
+
+  it('Renders a skeleton if loading', async () => {
+    element.loading = true;
+    const root = page.root as HTMLElement;
+    root.appendChild(element);
+
+    await page.waitForChanges();
+
+    const button = element.querySelector('manifold-data-deprovision-button');
+    expect(button).toBeDefined();
+
+    if (button) {
+      expect(button.loading).toBeTruthy();
+    }
+  });
+
+  it('Renders a product card if not loading', async () => {
+    element.loading = false;
+    element.gqlData = resource as Resource;
+    const root = page.root as HTMLElement;
+    root.appendChild(element);
+
+    await page.waitForChanges();
+
+    const button = element.querySelector('manifold-data-deprovision-button');
+    expect(button).toBeDefined();
+
+    if (button) {
+      expect(button.loading).toBeFalsy();
+      expect(button.resourceId).toEqual(resource.id);
+      expect(button.resourceLabel).toEqual(resource.label);
+    }
+  });
+});

--- a/src/components/manifold-resource-deprovision/manifold-resource-deprovision.tsx
+++ b/src/components/manifold-resource-deprovision/manifold-resource-deprovision.tsx
@@ -1,13 +1,13 @@
 import { h, Component, Prop } from '@stencil/core';
 
 import ResourceTunnel from '../../data/resource';
-import { Gateway } from '../../types/gateway';
 import logger from '../../utils/logger';
 import loadMark from '../../utils/loadMark';
+import { Resource } from '../../types/graphql';
 
 @Component({ tag: 'manifold-resource-deprovision' })
 export class ManifoldResourceDeprovision {
-  @Prop() data?: Gateway.Resource;
+  @Prop() gqlData?: Resource;
   @Prop() loading: boolean = true;
 
   @loadMark()
@@ -17,8 +17,8 @@ export class ManifoldResourceDeprovision {
   render() {
     return (
       <manifold-data-deprovision-button
-        resourceId={this.data && this.data.id}
-        resourceLabel={this.data && this.data.label}
+        resourceId={this.gqlData && this.gqlData.id}
+        resourceLabel={this.gqlData && this.gqlData.label}
         loading={this.loading}
       >
         <slot />

--- a/src/components/manifold-resource-plan/manifold-resource-plan.spec.ts
+++ b/src/components/manifold-resource-plan/manifold-resource-plan.spec.ts
@@ -5,9 +5,9 @@ import { resource } from '../../spec/mock/graphql';
 import { ManifoldResourcePlan } from './manifold-resource-plan';
 import { ManifoldPlanDetails } from '../manifold-plan-details/manifold-plan-details';
 
-describe('<manifold-resource-product>', () => {
+describe('<manifold-resource-plan>', () => {
   let page: SpecPage;
-  let element: HTMLManifoldResourceProductElement;
+  let element: HTMLManifoldResourcePlanElement;
   beforeEach(async () => {
     page = await newSpecPage({
       components: [ManifoldResourcePlan, ManifoldPlanDetails],


### PR DESCRIPTION
Work is related to manifoldco/engineering#9192

<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

This converts the resource deprovision component to GraphQL.

## Testing

Test with storybook

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [x] **Prop changes**: [docs][docs] were updated
- [x] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [x] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
