### PR TITLE
Convert rename button to GraphQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Converted `<manifold-data-provision-button>` to use GraphQL data (#600)
+- Converted `<manifold-data-rename-button>` to use GraphQL (#596)
 
 ### Breaking Changes:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4691,9 +4691,9 @@
       }
     },
     "@types/babel__core": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",
-      "integrity": "sha512-cfCCrFmiGY/yq0NuKNxIQvZFy9kY/1immpSpTngOnyIbD4+eJOG5mxphhHDv3CHL9GltO4GcKr54kGBg3RNdbg==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
+      "integrity": "sha512-8fBo0UR2CcwWxeX7WIIgJ7lXjasFxoYgRnFHUj+hRvKkpiBJbxhdAPTCY6/ZKM0uxANFVzt4yObSLuTiTnazDA==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -4704,9 +4704,9 @@
       }
     },
     "@types/babel__generator": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
-      "integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.0.tgz",
+      "integrity": "sha512-c1mZUu4up5cp9KROs/QAw0gTeHrw/x7m52LcnvMxxOZ03DmLwPV0MlGmlgzV3cnSdjhJOZsj7E7FHeioai+egw==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
@@ -4956,18 +4956,18 @@
       "dev": true
     },
     "@types/yargs": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.2.tgz",
-      "integrity": "sha512-lwwgizwk/bIIU+3ELORkyuOgDjCh7zuWDFqRtPPhhVgq9N1F7CvLNKg1TX4f2duwtKQ0p044Au9r1PLIXHrIzQ==",
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.3.tgz",
+      "integrity": "sha512-K8/LfZq2duW33XW/tFwEAfnZlqIfVsoyRB3kfXdPXYhl0nfM8mmh7GS0jg7WrX2Dgq/0Ha/pR1PaR+BvmWwjiQ==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
       }
     },
     "@types/yargs-parser": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.0.0.tgz",
-      "integrity": "sha512-wBlsw+8n21e6eTd4yVv8YD/E3xq0O6nNnJIquutAsFGE7EyMKz7W6RNT6BRu1SmdgmlCZ9tb0X+j+D6HGr8pZw==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
+      "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -11132,9 +11132,9 @@
       }
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.2.tgz",
+      "integrity": "sha512-cIv17+GhL8pHHnRJzGu2wwcthL5sb8uDKBHvZ2Dtu5s1YNt0ljbzKbamnc+gr69y7bzwQiBdr5+hOpRd5pnOdg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -16170,9 +16170,9 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.19.0.tgz",
-      "integrity": "sha512-2S6E6ygpoqcECaagDbBopoSOPDv0pAZvTbnBgUY+6hq0/XDFDOLEMNlHF/SKJlzcaZ9ckiKjKDuueWI3FN/WXw==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.20.0.tgz",
+      "integrity": "sha512-bt48RDBy2eIwZPrkgbcwHtb51mj2nKvHOPMaSH2IsWiv7lOG9k9zhaRzpDZafrk05ajMc3cu+lSQYYOfH2DkVQ==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "jest-cli": "24.8.0",
     "postcss-preset-env": "^6.7.0",
     "prettier": "^1.18.2",
-    "puppeteer": "1.19.0",
+    "puppeteer": "1.20.0",
     "rollup-plugin-replace": "^2.2.0",
     "stylelint": "^10.1.0",
     "stylelint-config-prettier": "^6.0.0",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -207,6 +207,10 @@ export namespace Components {
   }
   interface ManifoldDataRenameButton {
     'disabled'?: boolean;
+    /**
+    * _(hidden)_
+    */
+    'graphqlFetch'?: GraphqlFetch;
     'loading'?: boolean;
     /**
     * The new label to give to the resource
@@ -220,10 +224,6 @@ export namespace Components {
     * The label of the resource to rename
     */
     'resourceLabel'?: string;
-    /**
-    * _(hidden)_
-    */
-    'restFetch'?: RestFetch;
   }
   interface ManifoldDataResourceList {
     /**
@@ -568,8 +568,8 @@ export namespace Components {
     'loading': boolean;
   }
   interface ManifoldResourceRename {
-    'data'?: Gateway.Resource;
     'disabled'?: boolean;
+    'gqlData'?: Resource;
     'loading': boolean;
     /**
     * The new label to give to the resource
@@ -1277,6 +1277,10 @@ declare namespace LocalJSX {
   }
   interface ManifoldDataRenameButton {
     'disabled'?: boolean;
+    /**
+    * _(hidden)_
+    */
+    'graphqlFetch'?: GraphqlFetch;
     'loading'?: boolean;
     /**
     * The new label to give to the resource
@@ -1294,10 +1298,6 @@ declare namespace LocalJSX {
     * The label of the resource to rename
     */
     'resourceLabel'?: string;
-    /**
-    * _(hidden)_
-    */
-    'restFetch'?: RestFetch;
   }
   interface ManifoldDataResourceList {
     /**
@@ -1655,8 +1655,8 @@ declare namespace LocalJSX {
     'loading'?: boolean;
   }
   interface ManifoldResourceRename {
-    'data'?: Gateway.Resource;
     'disabled'?: boolean;
+    'gqlData'?: Resource;
     'loading'?: boolean;
     /**
     * The new label to give to the resource

--- a/src/components/manifold-resource-rename/manifold-resource-rename.tsx
+++ b/src/components/manifold-resource-rename/manifold-resource-rename.tsx
@@ -1,13 +1,13 @@
 import { h, Component, Prop } from '@stencil/core';
 
 import ResourceTunnel from '../../data/resource';
-import { Gateway } from '../../types/gateway';
 import logger from '../../utils/logger';
 import loadMark from '../../utils/loadMark';
+import { Resource } from '../../types/graphql';
 
 @Component({ tag: 'manifold-resource-rename' })
 export class ManifoldResourceRename {
-  @Prop() data?: Gateway.Resource;
+  @Prop() gqlData?: Resource;
   @Prop() loading: boolean = true;
   @Prop() disabled?: boolean;
   /** The new label to give to the resource */
@@ -20,8 +20,8 @@ export class ManifoldResourceRename {
   render() {
     return (
       <manifold-data-rename-button
-        resourceId={this.data && this.data.id}
-        resourceLabel={this.data && this.data.label}
+        resourceId={this.gqlData && this.gqlData.id}
+        resourceLabel={this.gqlData && this.gqlData.label}
         loading={this.loading}
         disabled={this.disabled}
         newLabel={this.newLabel}
@@ -32,4 +32,4 @@ export class ManifoldResourceRename {
   }
 }
 
-ResourceTunnel.injectProps(ManifoldResourceRename, ['data', 'loading']);
+ResourceTunnel.injectProps(ManifoldResourceRename, ['gqlData', 'loading']);


### PR DESCRIPTION
## Reason for change
Converts `<manifold-data-rename-button>` to use GraphQL

![2019-10-08 13-43-55 2019-10-08 13_44_48](https://user-images.githubusercontent.com/1369770/66427744-dacfd100-e9d1-11e9-8441-870c6032b68c.gif)

## Testing
In order to test this, you need a **PLATFORM TOKEN** (grab one from `localStorage.manifold_api_token` from Render or TacoCloud). Then just use that for `manifold_api_token` in Storybook.

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [x] **Prop changes**: [docs][docs] were updated
- [x] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [x] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
