### PR TITLE
Convert the manifold resource sso component to GraphQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Converted `manifold-resource-rename` to use the GraphQL data fetched from the
   `manifold-resource-container`. (#602)
 - Converted `<manifold-data-rename-button>` to use GraphQL (#596)
+- Converted `manifold-resource-sso` to use the GraphQL data fetched from the
+  `manifold-resource-container`. (#603)
 
 ### Breaking Changes:
 

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -573,7 +573,7 @@ export namespace Components {
     'newLabel': string;
   }
   interface ManifoldResourceSso {
-    'data'?: Gateway.Resource;
+    'gqlData'?: Resource;
     'loading': boolean;
   }
   interface ManifoldResourceStatus {
@@ -1642,7 +1642,7 @@ declare namespace LocalJSX {
     'newLabel'?: string;
   }
   interface ManifoldResourceSso {
-    'data'?: Gateway.Resource;
+    'gqlData'?: Resource;
     'loading'?: boolean;
   }
   interface ManifoldResourceStatus {

--- a/src/components/manifold-resource-sso/manifold-resource-sso.spec.ts
+++ b/src/components/manifold-resource-sso/manifold-resource-sso.spec.ts
@@ -1,0 +1,51 @@
+import { newSpecPage, SpecPage } from '@stencil/core/testing';
+
+import { Resource } from '../../types/graphql';
+import { resource } from '../../spec/mock/graphql';
+import { ManifoldResourceSso } from './manifold-resource-sso';
+import { ManifoldDataSsoButton } from '../manifold-data-sso-button/manifold-data-sso-button';
+
+describe('<manifold-resource-sso>', () => {
+  let page: SpecPage;
+  let element: HTMLManifoldResourceSsoElement;
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [ManifoldResourceSso, ManifoldDataSsoButton],
+      html: `<div></div>`,
+    });
+    element = page.doc.createElement('manifold-resource-sso');
+  });
+
+  it('Renders a skeleton if loading', async () => {
+    element.loading = true;
+    const root = page.root as HTMLElement;
+    root.appendChild(element);
+
+    await page.waitForChanges();
+
+    const button = element.querySelector('manifold-data-sso-button');
+    expect(button).toBeDefined();
+
+    if (button) {
+      expect(button.loading).toBeTruthy();
+    }
+  });
+
+  it('Renders if not loading', async () => {
+    element.loading = false;
+    element.gqlData = resource as Resource;
+    const root = page.root as HTMLElement;
+    root.appendChild(element);
+
+    await page.waitForChanges();
+
+    const button = element.querySelector('manifold-data-sso-button');
+    expect(button).toBeDefined();
+
+    if (button) {
+      expect(button.loading).toBeFalsy();
+      expect(button.resourceId).toEqual(resource.id);
+      expect(button.resourceLabel).toEqual(resource.label);
+    }
+  });
+});

--- a/src/components/manifold-resource-sso/manifold-resource-sso.spec.ts
+++ b/src/components/manifold-resource-sso/manifold-resource-sso.spec.ts
@@ -16,7 +16,7 @@ describe('<manifold-resource-sso>', () => {
     element = page.doc.createElement('manifold-resource-sso');
   });
 
-  it('Renders a skeleton if loading', async () => {
+  it('Renders a loading button if loading', async () => {
     element.loading = true;
     const root = page.root as HTMLElement;
     root.appendChild(element);
@@ -31,7 +31,7 @@ describe('<manifold-resource-sso>', () => {
     }
   });
 
-  it('Renders if not loading', async () => {
+  it('Renders a complete button if not loading', async () => {
     element.loading = false;
     element.gqlData = resource as Resource;
     const root = page.root as HTMLElement;

--- a/src/components/manifold-resource-sso/manifold-resource-sso.tsx
+++ b/src/components/manifold-resource-sso/manifold-resource-sso.tsx
@@ -1,13 +1,13 @@
 import { h, Component, Prop } from '@stencil/core';
 
 import ResourceTunnel from '../../data/resource';
-import { Gateway } from '../../types/gateway';
 import logger from '../../utils/logger';
 import loadMark from '../../utils/loadMark';
+import { Resource } from '../../types/graphql';
 
 @Component({ tag: 'manifold-resource-sso' })
 export class ManifoldResourceSso {
-  @Prop() data?: Gateway.Resource;
+  @Prop() gqlData?: Resource;
   @Prop() loading: boolean = true;
 
   @loadMark()
@@ -17,8 +17,8 @@ export class ManifoldResourceSso {
   render() {
     return (
       <manifold-data-sso-button
-        resourceId={this.data && this.data.id}
-        resourceLabel={this.data && this.data.label}
+        resourceId={this.gqlData && this.gqlData.id}
+        resourceLabel={this.gqlData && this.gqlData.label}
         loading={this.loading}
       >
         <slot />
@@ -27,4 +27,4 @@ export class ManifoldResourceSso {
   }
 }
 
-ResourceTunnel.injectProps(ManifoldResourceSso, ['data', 'loading']);
+ResourceTunnel.injectProps(ManifoldResourceSso, ['gqlData', 'loading']);


### PR DESCRIPTION
Work is related to manifoldco/engineering#9192

<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

Converted the container wrapper for the resource rename component to GraphQL.

## Testing

Test with Storybook.

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [x] **Prop changes**: [docs][docs] were updated
- [x] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [x] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
