### PR TITLE
Convert deprovision button to GraphQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Converted `manifold-resource-plan` to use the GraphQL data fetched from the
+  `manifold-resource-container`. (#578)
+- Converted `manifold-resource-credentials` to use the GraphQL data fetched from the
+  `manifold-resource-container`. (#584)
+- Converted `manifold-resource-deprovision` to use the GraphQL data fetched from the
+  `manifold-resource-container`. (#595)
 - Converted `<manifold-data-provision-button>` to use GraphQL data (#600)
 - Converted `manifold-resource-rename` to use the GraphQL data fetched from the
   `manifold-resource-container`. (#602)
 - Converted `<manifold-data-rename-button>` to use GraphQL (#596)
 - Converted `manifold-resource-sso` to use the GraphQL data fetched from the
   `manifold-resource-container`. (#603)
+- Converted `<manifold-data-deprovision-button>` to use GraphQL (#604)
 
 ### Breaking Changes:
 
@@ -30,12 +37,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Converted `manifold-resource-product` to use the GraphQL data fetched from the
   `manifold-resource-container`. (#566)
-- Converted `manifold-resource-plan` to use the GraphQL data fetched from the
-  `manifold-resource-container`. (#578)
-- Converted `manifold-resource-credentials` to use the GraphQL data fetched from the
-  `manifold-resource-container`. (#584)
-- Converted `manifold-resource-deprovision` to use the GraphQL data fetched from the
-  `manifold-resource-container`. (#595)
 
 ## [v0.5.16]
 

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -116,10 +116,6 @@ export namespace Components {
     'graphqlFetch'?: GraphqlFetch;
     'loading'?: boolean;
     /**
-    * Pass in an ownerId if desired
-    */
-    'ownerId'?: string;
-    /**
     * resource ID
     */
     'resourceId'?: string;
@@ -1166,10 +1162,6 @@ declare namespace LocalJSX {
     'onManifold-deprovisionButton-click'?: (event: CustomEvent<any>) => void;
     'onManifold-deprovisionButton-error'?: (event: CustomEvent<any>) => void;
     'onManifold-deprovisionButton-success'?: (event: CustomEvent<any>) => void;
-    /**
-    * Pass in an ownerId if desired
-    */
-    'ownerId'?: string;
     /**
     * resource ID
     */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -110,16 +110,23 @@ export namespace Components {
     'loading': boolean;
   }
   interface ManifoldDataDeprovisionButton {
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'graphqlFetch'?: GraphqlFetch;
     'loading'?: boolean;
+    /**
+    * Pass in an ownerId if desired
+    */
+    'ownerId'?: string;
+    /**
+    * resource ID
+    */
     'resourceId'?: string;
     /**
     * The label of the resource to deprovision
     */
     'resourceLabel'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'restFetch'?: RestFetch;
   }
   interface ManifoldDataHasResource {
     /**
@@ -1151,19 +1158,26 @@ declare namespace LocalJSX {
     'onCredentialsRequested'?: (event: CustomEvent<any>) => void;
   }
   interface ManifoldDataDeprovisionButton {
+    /**
+    * _(hidden)_ Passed by `<manifold-connection>`
+    */
+    'graphqlFetch'?: GraphqlFetch;
     'loading'?: boolean;
     'onManifold-deprovisionButton-click'?: (event: CustomEvent<any>) => void;
     'onManifold-deprovisionButton-error'?: (event: CustomEvent<any>) => void;
     'onManifold-deprovisionButton-success'?: (event: CustomEvent<any>) => void;
+    /**
+    * Pass in an ownerId if desired
+    */
+    'ownerId'?: string;
+    /**
+    * resource ID
+    */
     'resourceId'?: string;
     /**
     * The label of the resource to deprovision
     */
     'resourceLabel'?: string;
-    /**
-    * _(hidden)_ Passed by `<manifold-connection>`
-    */
-    'restFetch'?: RestFetch;
   }
   interface ManifoldDataHasResource {
     /**

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
@@ -6,7 +6,6 @@ import { createGraphqlFetch, GraphqlError } from '../../utils/graphqlFetch';
 import { resource } from '../../spec/mock/graphql';
 
 interface Props {
-  ownerId?: string;
   resourceId?: string;
   resourceLabel?: string;
 }
@@ -26,7 +25,6 @@ async function setup(props: Props) {
     wait: () => 10,
     setAuthToken: jest.fn(),
   });
-  component.ownerId = props.ownerId;
   component.resourceId = props.resourceId;
   component.resourceLabel = props.resourceLabel;
 
@@ -65,16 +63,12 @@ describe('<manifold-data-deprovision-button>', () => {
 
   describe('v0 props', () => {
     it('[resource-label]: fetches ID', async () => {
-      await setup({ ownerId: 'owner-id', resourceLabel: 'resource-label' });
+      await setup({ resourceLabel: 'resource-label' });
       expect(fetchMock.called(`begin:${graphqlEndpoint}`)).toBe(true);
     });
 
     it('[resource-id]: doesn’t fetch ID if set', async () => {
-      await setup({
-        ownerId: 'owner-id',
-        resourceId: 'resource-id',
-        resourceLabel: 'resource-label',
-      });
+      await setup({ resourceId: 'resource-id', resourceLabel: 'resource-label' });
       expect(fetchMock.called(`begin:${graphqlEndpoint}`)).toBe(false);
     });
   });
@@ -83,7 +77,7 @@ describe('<manifold-data-deprovision-button>', () => {
     it('click', async () => {
       const resourceLabel = 'click-label';
 
-      const { page } = await setup({ ownerId: 'owner-id', resourceId: resource.id, resourceLabel });
+      const { page } = await setup({ resourceId: resource.id, resourceLabel });
       const button = page.root && page.root.querySelector('button');
       if (!button) {
         throw new Error('button not found in document');
@@ -110,7 +104,7 @@ describe('<manifold-data-deprovision-button>', () => {
       const resourceId = 'error-id';
       const resourceLabel = 'error-label';
 
-      const { page } = await setup({ ownerId: 'owner-id', resourceId, resourceLabel });
+      const { page } = await setup({ resourceId, resourceLabel });
       const button = page.root && page.root.querySelector('button');
       if (!button) {
         throw new Error('button not found in document');
@@ -138,11 +132,7 @@ describe('<manifold-data-deprovision-button>', () => {
 
     it('success', async () => {
       const resourceId = 'success-id';
-      const { page } = await setup({
-        ownerId: 'owner-id',
-        resourceId,
-        resourceLabel: 'success-label',
-      });
+      const { page } = await setup({ resourceId, resourceLabel: 'success-label' });
       const button = page.root && page.root.querySelector('button');
       if (!button) {
         throw new Error('button not found in document');

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
@@ -1,8 +1,8 @@
 import { h, Component, Prop, Element, Watch, Event, EventEmitter } from '@stencil/core';
+import { gql } from '@manifoldco/gql-zero';
 
 import connection from '../../state/connection';
-import { Marketplace } from '../../types/marketplace';
-import { RestFetch } from '../../utils/restFetch';
+import { GraphqlFetch } from '../../utils/graphqlFetch';
 import logger from '../../utils/logger';
 import loadMark from '../../utils/loadMark';
 
@@ -18,34 +18,68 @@ interface ErrorMessage {
   resourceId?: string;
 }
 
+const resourceIdQuery = gql`
+  query RESOURCE_ID($resourceLabel: String!) {
+    resource(label: $resourceLabel) {
+      id
+    }
+  }
+`;
+
+const deleteMutation = gql`
+  mutation DELETE_RESOURCE($resourceId: ID!, $ownerId: ID) {
+    deleteResource(input: { resourceId: $resourceId, ownerId: $ownerId }) {
+      data {
+        id
+        label
+      }
+    }
+  }
+`;
+
+const profileIdQuery = gql`
+  query PROFILE_ID {
+    profile {
+      id
+    }
+  }
+`;
+
 @Component({ tag: 'manifold-data-deprovision-button' })
 export class ManifoldDataDeprovisionButton {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
-  @Prop() restFetch?: RestFetch = connection.restFetch;
+  @Prop() graphqlFetch?: GraphqlFetch = connection.graphqlFetch;
+  /** Pass in an ownerId if desired */
+  @Prop({ mutable: true }) ownerId?: string;
+  /** resource ID */
+  @Prop({ mutable: true }) resourceId?: string = '';
   /** The label of the resource to deprovision */
   @Prop() resourceLabel?: string;
-  @Prop({ mutable: true }) resourceId?: string = '';
   @Prop() loading?: boolean = false;
   @Event({ eventName: 'manifold-deprovisionButton-click', bubbles: true }) click: EventEmitter;
   @Event({ eventName: 'manifold-deprovisionButton-error', bubbles: true }) error: EventEmitter;
   @Event({ eventName: 'manifold-deprovisionButton-success', bubbles: true }) success: EventEmitter;
 
   @Watch('resourceLabel') labelChange(newLabel: string) {
-    if (!this.resourceId) {
-      this.fetchResourceId(newLabel);
-    }
+    // fetch new ID regardless on label change
+    this.fetchResourceId(newLabel);
   }
 
   @loadMark()
   componentWillLoad() {
+    // fetch resource ID
     if (this.resourceLabel && !this.resourceId) {
       this.fetchResourceId(this.resourceLabel);
+    }
+    // fetch owner ID
+    if (!this.ownerId) {
+      this.fetchProfileId();
     }
   }
 
   async deprovision() {
-    if (!this.restFetch || this.loading) {
+    if (!this.graphqlFetch || this.loading) {
       return;
     }
 
@@ -54,52 +88,68 @@ export class ManifoldDataDeprovisionButton {
       return;
     }
 
-    // We use Gateway b/c it’s much easier to provision w/o generating a base32 ID
     this.click.emit({
       resourceId: this.resourceId,
       resourceLabel: this.resourceLabel || '',
     });
 
-    try {
-      await this.restFetch({
-        service: 'gateway',
-        endpoint: `/id/resource/${this.resourceId}`,
-        options: { method: 'DELETE' },
-      });
-      const success: SuccessMessage = {
-        message: `${this.resourceLabel} successfully deprovisioned`,
-        resourceLabel: this.resourceLabel || '',
+    const { data, errors } = await this.graphqlFetch({
+      query: deleteMutation,
+      variables: {
         resourceId: this.resourceId,
+        ownerId: this.ownerId,
+      },
+    });
+
+    if (data && data.data) {
+      // success
+      const success: SuccessMessage = {
+        message: `${data.data.label} successfully deleted`,
+        resourceLabel: data.data.label,
+        resourceId: data.data.id,
       };
       this.success.emit(success);
-    } catch (e) {
-      const error: ErrorMessage = {
-        message: e.message,
-        resourceLabel: this.resourceLabel || '',
-        resourceId: this.resourceId,
-      };
+    }
 
-      this.error.emit(error);
-      throw error;
+    if (errors) {
+      errors.forEach(({ message }) => {
+        const error: ErrorMessage = {
+          message,
+          resourceLabel: this.resourceLabel || '',
+          resourceId: this.resourceId,
+        };
+        this.error.emit(error);
+      });
+    }
+  }
+
+  async fetchProfileId() {
+    if (!this.graphqlFetch || this.ownerId) {
+      return;
+    }
+
+    const { data } = await this.graphqlFetch({ query: profileIdQuery });
+
+    if (data && data.profile) {
+      this.ownerId = data.profile.id;
     }
   }
 
   async fetchResourceId(resourceLabel: string) {
-    if (!this.restFetch) {
+    if (!this.graphqlFetch) {
       return;
     }
 
-    const response = await this.restFetch<Marketplace.Resource[]>({
-      service: 'marketplace',
-      endpoint: `/resources/?me&label=${resourceLabel}`,
+    const { data } = await this.graphqlFetch({
+      query: resourceIdQuery,
+      variables: {
+        resourceLabel,
+      },
     });
 
-    if (!response || !response.length) {
-      console.error(`${resourceLabel} product not found`);
-      return;
+    if (data && data.resource) {
+      this.resourceId = data.resource.id;
     }
-
-    this.resourceId = response[0].id;
   }
 
   @logger()
@@ -108,7 +158,7 @@ export class ManifoldDataDeprovisionButton {
       <button
         type="submit"
         onClick={() => this.deprovision()}
-        disabled={!this.resourceId && !this.loading}
+        disabled={!this.resourceId || !this.ownerId}
       >
         <slot />
       </button>

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
@@ -27,20 +27,12 @@ const resourceIdQuery = gql`
 `;
 
 const deleteMutation = gql`
-  mutation DELETE_RESOURCE($resourceId: ID!, $ownerId: ID) {
-    deleteResource(input: { resourceId: $resourceId, ownerId: $ownerId }) {
+  mutation DELETE_RESOURCE($resourceId: ID!) {
+    deleteResource(input: { resourceId: $resourceId }) {
       data {
         id
         label
       }
-    }
-  }
-`;
-
-const profileIdQuery = gql`
-  query PROFILE_ID {
-    profile {
-      id
     }
   }
 `;
@@ -50,8 +42,6 @@ export class ManifoldDataDeprovisionButton {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() graphqlFetch?: GraphqlFetch = connection.graphqlFetch;
-  /** Pass in an ownerId if desired */
-  @Prop({ mutable: true }) ownerId?: string;
   /** resource ID */
   @Prop({ mutable: true }) resourceId?: string = '';
   /** The label of the resource to deprovision */
@@ -71,10 +61,6 @@ export class ManifoldDataDeprovisionButton {
     // fetch resource ID
     if (this.resourceLabel && !this.resourceId) {
       this.fetchResourceId(this.resourceLabel);
-    }
-    // fetch owner ID
-    if (!this.ownerId) {
-      this.fetchProfileId();
     }
   }
 
@@ -97,7 +83,6 @@ export class ManifoldDataDeprovisionButton {
       query: deleteMutation,
       variables: {
         resourceId: this.resourceId,
-        ownerId: this.ownerId,
       },
     });
 
@@ -123,18 +108,6 @@ export class ManifoldDataDeprovisionButton {
     }
   }
 
-  async fetchProfileId() {
-    if (!this.graphqlFetch || this.ownerId) {
-      return;
-    }
-
-    const { data } = await this.graphqlFetch({ query: profileIdQuery });
-
-    if (data && data.profile) {
-      this.ownerId = data.profile.id;
-    }
-  }
-
   async fetchResourceId(resourceLabel: string) {
     if (!this.graphqlFetch) {
       return;
@@ -155,11 +128,7 @@ export class ManifoldDataDeprovisionButton {
   @logger()
   render() {
     return (
-      <button
-        type="submit"
-        onClick={() => this.deprovision()}
-        disabled={!this.resourceId || !this.ownerId}
-      >
+      <button type="submit" onClick={() => this.deprovision()} disabled={!this.resourceId}>
         <slot />
       </button>
     );

--- a/src/components/manifold-resource-deprovision/manifold-resource-deprovision.tsx
+++ b/src/components/manifold-resource-deprovision/manifold-resource-deprovision.tsx
@@ -27,4 +27,4 @@ export class ManifoldResourceDeprovision {
   }
 }
 
-ResourceTunnel.injectProps(ManifoldResourceDeprovision, ['data', 'loading']);
+ResourceTunnel.injectProps(ManifoldResourceDeprovision, ['gqlData', 'loading']);


### PR DESCRIPTION
## Reason for change

Converts `<manifold-data-deprovision-button>` to GraphQL.

![2019-10-08 15-08-51 2019-10-08 15_09_27](https://user-images.githubusercontent.com/1369770/66433482-a6faa880-e9dd-11e9-9235-9ef96ee734a9.gif)


## Testing

In order to test this, you need a **PLATFORM TOKEN** (grab one from `localStorage.manifold_api_token` from Render or TacoCloud). Then just use that for `manifold_api_token` in Storybook.


## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
