### PR TITLE
Include error messages on performance logs for REST and GraphQL calls

### DIFF
--- a/src/utils/graphqlFetch.ts
+++ b/src/utils/graphqlFetch.ts
@@ -25,6 +25,13 @@ export interface GraphqlError {
   };
 }
 
+interface GraphqlFetchEventDetail {
+  type: 'manifold-graphql-fetch-duration';
+  request: GraphqlArgs;
+  duration: number;
+  errors?: GraphqlError[];
+}
+
 // TODO remove this in favor of GraphQL documents
 export interface GraphqlData extends Query {
   data?: Resource; // CreateResourcePayload, etc.
@@ -85,7 +92,7 @@ export function createGraphqlFetch({
     }
 
     const fetchDuration = performance.now() - rttStart;
-    const detail = {
+    const detail: GraphqlFetchEventDetail = {
       type: 'manifold-graphql-fetch-duration',
       request,
       duration: fetchDuration,

--- a/src/utils/graphqlFetch.ts
+++ b/src/utils/graphqlFetch.ts
@@ -84,6 +84,25 @@ export function createGraphqlFetch({
       };
     }
 
+    const fetchDuration = performance.now() - rttStart;
+    const detail = {
+      type: 'manifold-graphql-fetch-duration',
+      request,
+      duration: fetchDuration,
+      errors: body.errors,
+    };
+
+    if (emitter) {
+      emitter.emit(detail);
+    } else {
+      document.dispatchEvent(
+        new CustomEvent('manifold-graphql-fetch-duration', {
+          bubbles: true,
+          detail,
+        })
+      );
+    }
+
     if (body.errors) {
       report(body.errors);
 
@@ -99,22 +118,6 @@ export function createGraphqlFetch({
 
         throw new Error('Auth token expired');
       }
-    }
-
-    const fetchDuration = performance.now() - rttStart;
-    if (emitter) {
-      emitter.emit({
-        type: 'manifold-graphql-fetch-duration',
-        request,
-        duration: fetchDuration,
-      });
-    } else {
-      document.dispatchEvent(
-        new CustomEvent('manifold-graphql-fetch-duration', {
-          bubbles: true,
-          detail: { request, duration: fetchDuration },
-        })
-      );
     }
 
     // return everything to the user


### PR DESCRIPTION
## Reason for change

Adds any error messages returned from the API to performance logs on REST and GraphQL calls

## Testing

In the storybook performance story, change the `product-label` attr to an invalid label, view logs in Datadog

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
