### PR TITLE
Remove ownerId from provision button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Converted `<manifold-data-deprovision-button>` to use GraphQL (#604)
 - Converted `<manifold-plan-cost>` to GraphQL (#605)
 - Updated Stencil to v1.6.1 (#606)
+- Owner ID no longer fetched to create/delete resources (#608)
 
 ### Breaking Changes:
 

--- a/docs/docs/data/manifold-data-provision-button.md
+++ b/docs/docs/data/manifold-data-provision-button.md
@@ -35,8 +35,6 @@ function updateButton({ detail: { features, planId, productLabel, regionId } }) 
   provisionButton.productLabel = productLabel;
   provisionButton.regionId = regionId;
   provisionButton.resourceLabel = resourceLabel;
-
-  // provisionButton.ownerId = '[ownerID]'; // OPTIONAL: only needed if provisioning for a different user (current user must have authorization to do so)
 }
 
 document.addEventListener('manifold-planSelector-load', updateButton);

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -187,7 +187,6 @@ export namespace Components {
     * _(hidden)_
     */
     'graphqlFetch'?: GraphqlFetch;
-    'ownerId'?: string;
     /**
     * Plan to provision (slug)
     */
@@ -1242,7 +1241,6 @@ declare namespace LocalJSX {
     'onManifold-provisionButton-error'?: (event: CustomEvent<any>) => void;
     'onManifold-provisionButton-invalid'?: (event: CustomEvent<any>) => void;
     'onManifold-provisionButton-success'?: (event: CustomEvent<any>) => void;
-    'ownerId'?: string;
     /**
     * Plan to provision (slug)
     */

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.spec.ts
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.spec.ts
@@ -10,7 +10,6 @@ const graphqlEndpoint = 'http://test.com/graphql';
 const profile = { profile: { id: '1234' } };
 
 interface Props {
-  ownerId?: string;
   planId?: string;
   productId?: string;
   productLabel?: string;
@@ -31,7 +30,6 @@ async function setup(props: Props) {
     wait: () => 10,
     setAuthToken: jest.fn(),
   });
-  component.ownerId = props.ownerId;
   component.planId = props.planId || 'plan-id';
   component.productId = props.productId;
   component.productLabel = props.productLabel;
@@ -75,26 +73,8 @@ describe('<manifold-data-provision-button>', () => {
   afterEach(() => fetchMock.restore());
 
   describe('v0 API', () => {
-    it('[owner-id]: fetches if missing', async () => {
-      await setup({ productLabel: 'my-product' });
-      expect(fetchMock.called(`begin:${graphqlEndpoint}`)).toBe(true);
-    });
-
-    it('[owner-id]: doesn’t fetch if set', async () => {
-      const { page } = await setup({ ownerId: '5678', productId: 'product-id' });
-      const provisionButton =
-        page.root && page.root.querySelector('manifold-data-provision-button');
-      if (!provisionButton) {
-        throw new Error('provision button not found');
-      }
-
-      expect(fetchMock.called(graphqlEndpoint)).toBe(false);
-      expect(provisionButton.ownerId).toEqual('5678');
-    });
-
     it('[product-label]: fetches product by label', async () => {
-      const { page } = await setup({ ownerId: 'owner-id', productLabel: 'test-product' });
-
+      const { page } = await setup({ productLabel: 'test-product' });
       const provisionButton =
         page.root && page.root.querySelector('manifold-data-provision-button');
       if (!provisionButton) {
@@ -104,7 +84,7 @@ describe('<manifold-data-provision-button>', () => {
     });
 
     it('[product-label]: doesn’t fetch if missing', async () => {
-      await setup({ ownerId: 'owner-id' });
+      await setup({});
       expect(fetchMock.called(`begin:${graphqlEndpoint}`)).toBe(false);
     });
 
@@ -116,13 +96,7 @@ describe('<manifold-data-provision-button>', () => {
 
         const mockClick = jest.fn();
 
-        const { page } = await setup({
-          ownerId: 'owner-id',
-          planId,
-          productLabel,
-          resourceLabel,
-        });
-
+        const { page } = await setup({ planId, productLabel, resourceLabel });
         const button = page.root && page.root.querySelector('button');
         if (!button) {
           throw new Error('button not found in document');
@@ -149,7 +123,7 @@ describe('<manifold-data-provision-button>', () => {
 
         const mockClick = jest.fn();
 
-        const { page } = await setup({ ownerId: 'owner-id', productLabel });
+        const { page } = await setup({ productLabel });
         const button = page.root && page.root.querySelector('button');
         if (!button) {
           throw new Error('button not found in document');
@@ -176,7 +150,7 @@ describe('<manifold-data-provision-button>', () => {
 
         const mockClick = jest.fn();
 
-        const { page } = await setup({ ownerId: 'owner-id', productLabel, resourceLabel });
+        const { page } = await setup({ productLabel, resourceLabel });
         const button = page.root && page.root.querySelector('button');
         if (!button) {
           throw new Error('button not found in document');
@@ -205,7 +179,7 @@ describe('<manifold-data-provision-button>', () => {
 
         const mockClick = jest.fn();
 
-        const { page } = await setup({ ownerId: 'owner-id', productLabel, resourceLabel });
+        const { page } = await setup({ productLabel, resourceLabel });
         const button = page.root && page.root.querySelector('button');
         if (!button) {
           throw new Error('button not found in document');
@@ -233,7 +207,7 @@ describe('<manifold-data-provision-button>', () => {
         const resourceLabel = 'error-resource';
         const productLabel = 'product-label';
 
-        const { page } = await setup({ ownerId: 'owner-id', productLabel, resourceLabel });
+        const { page } = await setup({ productLabel, resourceLabel });
         const button = page.root && page.root.querySelector('button');
         if (!button) {
           throw new Error('button not found in document');
@@ -264,7 +238,7 @@ describe('<manifold-data-provision-button>', () => {
         const resourceLabel = 'success-resource';
         const productLabel = 'success-product';
 
-        const { page } = await setup({ ownerId: 'owner-id', productLabel, resourceLabel });
+        const { page } = await setup({ productLabel, resourceLabel });
         const button = page.root && page.root.querySelector('button');
         if (!button) {
           throw new Error('button not found in document');
@@ -295,7 +269,7 @@ describe('<manifold-data-provision-button>', () => {
         const planId = 'plan-id';
         const productLabel = 'success-product';
 
-        const { page } = await setup({ ownerId: 'owner-id', productLabel });
+        const { page } = await setup({ productLabel });
         const button = page.root && page.root.querySelector('button');
         if (!button) {
           throw new Error('button not found in document');

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
@@ -49,14 +49,6 @@ const planRegionsQuery = gql`
   }
 `;
 
-const profileIdQuery = gql`
-  query PROFILE_ID {
-    profile {
-      id
-    }
-  }
-`;
-
 const productIdQuery = gql`
   query GET_PRODUCT_ID($productLabel: String!) {
     product(label: $productLabel) {
@@ -66,18 +58,11 @@ const productIdQuery = gql`
 `;
 
 const createResourceMutation = gql`
-  mutation CREATE_RESOURCE(
-    $ownerId: ID!
-    $planId: ID!
-    $productId: ID!
-    $regionId: ID!
-    $resourceLabel: String!
-  ) {
+  mutation CREATE_RESOURCE($planId: ID!, $productId: ID!, $regionId: ID!, $resourceLabel: String!) {
     createResource(
       input: {
         displayName: $resourceLabel
         label: $resourceLabel
-        ownerId: $ownerId
         planId: $planId
         productId: $productId
         regionId: $regionId
@@ -104,7 +89,6 @@ export class ManifoldDataProvisionButton {
   @Prop() planId?: string;
   /** The label of the resource to provision */
   @Prop() resourceLabel?: string;
-  @Prop({ mutable: true }) ownerId?: string = '';
   /** Region to provision (ID) */
   @Prop({ mutable: true }) regionId?: string;
   @State() provisioning: boolean = false;
@@ -130,10 +114,6 @@ export class ManifoldDataProvisionButton {
     if (this.productLabel && !this.productId) {
       this.fetchProductId(this.productLabel);
     }
-    // fetch owner ID
-    if (!this.ownerId) {
-      this.fetchProfileId();
-    }
     // if resource missing, fetch (will only save if there’s only 1 region)
     if (this.planId && !this.regionId) {
       this.updateRegions(this.planId);
@@ -142,11 +122,6 @@ export class ManifoldDataProvisionButton {
 
   async provision() {
     if (!this.graphqlFetch) {
-      return;
-    }
-
-    if (!this.ownerId) {
-      console.error('Property “ownerId” is missing');
       return;
     }
 
@@ -183,7 +158,6 @@ export class ManifoldDataProvisionButton {
     const { data, errors } = await this.graphqlFetch({
       query: createResourceMutation,
       variables: {
-        ownerId: this.ownerId,
         planId: this.planId,
         productId: this.productId,
         regionId: this.regionId,
@@ -226,18 +200,6 @@ export class ManifoldDataProvisionButton {
 
     if (data && data.product) {
       this.productId = data.product.id;
-    }
-  }
-
-  async fetchProfileId() {
-    if (!this.graphqlFetch || this.ownerId) {
-      return;
-    }
-
-    const { data } = await this.graphqlFetch({ query: profileIdQuery });
-
-    if (data && data.profile) {
-      this.ownerId = data.profile.id;
     }
   }
 


### PR DESCRIPTION
## Reason for change

Per an earlier discussion, this removes the `ownerId` fetching for creating/deleting a resource. The current implementation doubles the workload of our backend unnecessarily, and introduces the possibility for error.

We’ll likely re-implement `ownerId` again in the future for platforms, but in a different pattern. In that light I think removing this is necessary for an easier path forward.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [x] **Prop changes**: [docs][docs] were updated
- [x] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [x] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
