### PR TITLE
Manifold connection missing in the getting started docs

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -32,7 +32,7 @@ In any setup, you can use our CDN for UI:
 <!-- latest (beware of breaking changes!) -->
 <script src="https://js.cdn.manifold.co/@manifoldco/ui/dist/manifold.js"></script>
 <!-- specific version -->
-<script src="https://js.cdn.manifold.co/@manifoldco/ui@0.6.0/dist/manifold.js"></script>
+<script src="https://js.cdn.manifold.co/@manifoldco/ui@0.6.0/dist/manifold/manifold.js"></script>
 ```
 
 ### HTML (ES Modules)
@@ -46,7 +46,9 @@ In any setup, you can use our CDN for UI:
   />
 </head>
 <body>
-  <manifold-marketplace></manifold-marketplace>
+  <manifold-connection>
+    <manifold-marketplace />
+  </manifold-connection>
   <script type="module">
     import { defineCustomElements } from 'https://js.cdn.manifold.co/@manifoldco/ui/dist/esm/es2017/manifold.define.js';
     defineCustomElements(window);
@@ -65,7 +67,9 @@ In any setup, you can use our CDN for UI:
   />
 </head>
 <body>
-  <manifold-marketplace></manifold-marketplace>
+  <manifold-connection>
+    <manifold-marketplace />
+  </manifold-connection>
   <script src="https://js.cdn.manifold.co/@manifoldco/ui/dist/manifold.js"></script>
 </body>
 ```
@@ -85,7 +89,11 @@ import(/* webpackChunkName: "manifold-ui" */ '@manifoldco/ui/dist/loader').then(
   ({ defineCustomElements }) => defineCustomElements(window)
 );
 
-const App = () => <manifold-marketplace />;
+const App = () => (
+  <manifold-connection>
+    <manifold-marketplace />
+  </manifold-connection>
+);
 
 ReactDOM.render(<App />, document.getElementById('root'));
 ```
@@ -100,7 +108,11 @@ import { defineCustomElements } from '@manifoldco/ui/dist/loader';
 
 defineCustomElements(window);
 
-const App = () => <manifold-marketplace />;
+const App = () => (
+  <manifold-connection>
+    <manifold-marketplace />
+  </manifold-connection>
+);
 
 ReactDOM.render(<App />, document.getElementById('root'));
 ```

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -47,7 +47,7 @@ In any setup, you can use our CDN for UI:
 </head>
 <body>
   <manifold-connection>
-    <manifold-marketplace />
+    <manifold-marketplace></manifold-marketplace>
   </manifold-connection>
   <script type="module">
     import { defineCustomElements } from 'https://js.cdn.manifold.co/@manifoldco/ui/dist/esm/es2017/manifold.define.js';
@@ -68,7 +68,7 @@ In any setup, you can use our CDN for UI:
 </head>
 <body>
   <manifold-connection>
-    <manifold-marketplace />
+    <manifold-marketplace></manifold-marketplace>
   </manifold-connection>
   <script src="https://js.cdn.manifold.co/@manifoldco/ui/dist/manifold.js"></script>
 </body>
@@ -91,7 +91,7 @@ import(/* webpackChunkName: "manifold-ui" */ '@manifoldco/ui/dist/loader').then(
 
 const App = () => (
   <manifold-connection>
-    <manifold-marketplace />
+    <manifold-marketplace></manifold-marketplace>
   </manifold-connection>
 );
 
@@ -110,7 +110,7 @@ defineCustomElements(window);
 
 const App = () => (
   <manifold-connection>
-    <manifold-marketplace />
+    <manifold-marketplace></manifold-marketplace>
   </manifold-connection>
 );
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -32,7 +32,7 @@ In any setup, you can use our CDN for UI:
 <!-- latest (beware of breaking changes!) -->
 <script src="https://js.cdn.manifold.co/@manifoldco/ui/dist/manifold.js"></script>
 <!-- specific version -->
-<script src="https://js.cdn.manifold.co/@manifoldco/ui@0.6.0/dist/manifold/manifold.js"></script>
+<script src="https://js.cdn.manifold.co/@manifoldco/ui@0.6.0/dist/manifold.js"></script>
 ```
 
 ### HTML (ES Modules)


### PR DESCRIPTION


<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

I noticed the getting started docs weren't working as expected while writing the blog post. This PR makes sure the marketplace loads correctly.

I'm not sure if this warrants a Changelog update?

## Testing

Follow the document's getting started instructions in a sandbox environment.

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [x] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
