### PR TITLE
Use images instead of screenshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Updated Stencil to v1.6.1 (#606)
 - Owner ID no longer fetched to create/delete resources (#608)
 - Converted `<manifold-data-resize-button>` to use GraphQL
+- Updated `<manifold-product>` ahead of a GraphQL deprecation (#619)
 
 ### Breaking Changes:
 

--- a/src/components/manifold-image-gallery/manifold-image-gallery.css
+++ b/src/components/manifold-image-gallery/manifold-image-gallery.css
@@ -31,6 +31,7 @@
 }
 
 img {
+  display: block;
   width: 100%;
   height: 100%;
   object-fit: cover;

--- a/src/components/manifold-image-gallery/manifold-image-gallery.tsx
+++ b/src/components/manifold-image-gallery/manifold-image-gallery.tsx
@@ -18,7 +18,7 @@ const Thumbnail: FunctionalComponent<ThumbnailProps> = ({ isSelected, onClick, .
 
 @Component({
   tag: 'manifold-image-gallery',
-  styleUrl: 'image-gallery.css',
+  styleUrl: 'manifold-image-gallery.css',
   shadow: true,
 })
 export class ImageGallery {

--- a/src/components/manifold-product-details/manifold-product-details.e2e.ts
+++ b/src/components/manifold-product-details/manifold-product-details.e2e.ts
@@ -4,9 +4,9 @@ import { product } from '../../spec/mock/graphql';
 
 /* eslint-disable no-param-reassign, @typescript-eslint/no-explicit-any */
 
-const productWithoutScreenshots: Product = {
+const productWithoutImages: Product = {
   ...product,
-  screenshots: [],
+  images: [],
 };
 
 describe(`<manifold-product-details>`, () => {
@@ -48,7 +48,7 @@ describe(`<manifold-product-details>`, () => {
       (elm: any, props: any) => {
         elm.product = props.product;
       },
-      { product: productWithoutScreenshots }
+      { product: productWithoutImages }
     );
     await page.waitForChanges();
 

--- a/src/components/manifold-product-details/manifold-product-details.tsx
+++ b/src/components/manifold-product-details/manifold-product-details.tsx
@@ -19,7 +19,7 @@ export class ManifoldProductDetails {
   @logger()
   render() {
     if (this.product) {
-      const { tagline, valueProps, screenshots } = this.product;
+      const { images, tagline, valueProps } = this.product;
       return (
         <div>
           <h1 class="title" itemprop="tagline">
@@ -34,14 +34,8 @@ export class ManifoldProductDetails {
                 </li>
               ))}
           </ul>
-          {screenshots && screenshots.length > 0 && (
-            <manifold-image-gallery
-              images={[...screenshots]
-                .sort((image1, image2) => image1.order - image2.order)
-                .map(image => image.url)}
-            >
-              Screenshots
-            </manifold-image-gallery>
+          {images && images.length > 0 && (
+            <manifold-image-gallery images={images}>Screenshots</manifold-image-gallery>
           )}
         </div>
       );

--- a/src/components/manifold-product/manifold-product.tsx
+++ b/src/components/manifold-product/manifold-product.tsx
@@ -13,6 +13,7 @@ const query = gql`
       documentationUrl
       supportEmail
       displayName
+      images
       label
       logoUrl
       categories {
@@ -24,10 +25,6 @@ const query = gql`
         body
       }
       tagline
-      screenshots {
-        url
-        order
-      }
       provider {
         displayName
       }

--- a/src/spec/mock/graphql.ts
+++ b/src/spec/mock/graphql.ts
@@ -23,6 +23,7 @@ export const product: Product = {
   logoUrl: prodMock.body.logo_url,
   state: prodMock.body.state as ProductState,
   tagline: prodMock.body.tagline,
+  images: prodMock.body.images,
   supportEmail: prodMock.body.support_email,
   documentationUrl: prodMock.body.documentation_url,
   termsUrl: prodMock.body.terms.provided && prodMock.body.terms.url ? prodMock.body.terms.url : '',

--- a/src/spec/mock/jawsdb/graphqlProduct.json
+++ b/src/spec/mock/jawsdb/graphqlProduct.json
@@ -9,6 +9,12 @@
   "supportEmail": "support@jawsdb.com",
   "documentationUrl": "https://jawsdb.com/docs",
   "termsUrl": "",
+  "images": [
+    "https://cdn.manifold.co/providers/jawsdb/screenshots/ss1.PNG",
+    "https://cdn.manifold.co/providers/jawsdb/screenshots/ss2.PNG",
+    "https://cdn.manifold.co/providers/jawsdb/screenshots/ss3.PNG",
+    "https://cdn.manifold.co/providers/jawsdb/screenshots/ss4.PNG"
+  ],
   "categories": [
     {
       "__typename": "Category",


### PR DESCRIPTION
Discovered when opening #618 

## Reason for change

Our GraphQL API is **deprecating screenshots**. This replaces them with `images` before it’s too late.

Also fixes an image padding bug:

**Before**
![Screen Shot 2019-10-11 at 13 21 08](https://user-images.githubusercontent.com/1369770/66679222-f4b82080-ec2a-11e9-83f7-84ae4bec084b.png)

**After**
![Screen Shot 2019-10-11 at 13 26 56](https://user-images.githubusercontent.com/1369770/66679215-f08c0300-ec2a-11e9-88b8-e52424fdb3c6.png)


## Testing

Inspect the `<manifold-product>` Happo VRT diffs to ensure it displays properly.

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
