### PR TITLE
Fix manifold-plan docs

### DIFF
--- a/docs/docs/components/manifold-plan-selector.md
+++ b/docs/docs/components/manifold-plan-selector.md
@@ -9,7 +9,9 @@ example: |
 
 # Plan Selector
 
-Display the plans for a product.
+The plan selector component is a very important component for browsing all of a product’s plans and
+comparing features and prices. Simply select which product you’d like to view with a `product-label`
+and it will handle the rest:
 
 ```html
 <manifold-plan-selector product-label="jawsdb-mysql"></manifold-plan-selector>
@@ -19,8 +21,8 @@ You can find the `:product` label for each at `https://manifold.co/services/:pro
 
 ## CTA
 
-You can pass in your own button or link in the bottom-right of the component by passing in any
-element with `slot="cta"` as an attribute. [Read more about slots][slot].
+If you’d like to place a button in that empty space bottom-right, you can do so easily with any
+element that has `slot="cta"` on it. [Read more about slots][slot].
 
 ```jsx
 <manifold-plan-selector product-label="jawsdb-mysql">
@@ -65,59 +67,21 @@ The following events are emitted:
 
 ## Regions
 
-Most of our products are regionless, but some plans let users specify the region. In this case, you
-may optionally want to order the regions with the `regions` attribute:
+Most of our products are regionless, but some plans let users specify the region. If the plan
+supports it, you can show which regions display with the `regions` atribute with a list of
+comma-separated IDs:
 
 ```html
 <manifold-plan-selector
-  regions="aws-eu-west-1,aws-eu-west-2,aws-us-east-1,aws-us-east-2"
+  regions="235p16bz8n7qkjtvqyg599qtqa9ur,235wy26njfzf53k1d050k2eg9f5ey,235u7nm47cknwjyjdyqwxg070zfmm"
 ></manifold-plan-selector>
 ```
 
-Regions will be ordered in the order specified. Any regions not mentioned will come at the end,
-alphabetically. Any regions not supported by the plan will simply be ignored (in this sense, you
-could even pass the same ordered list to all plans regardless, if you’d like them always to display
-in the same order).
+For a list of all region IDs for a particular product, refer to our [GraphQL API][graphql-api]:
 
-### Supported regions
+<iframe src="https://graphqlbin.com/v2/gnyVCY" height="400" width="800"></iframe>
 
-| Label                | Name                                       |
-| :------------------- | :----------------------------------------- |
-| `aws-ap-northeast-1` | AWS - Asia Pacific Northeast 1 (Tokyo)     |
-| `aws-ap-northeast-2` | AWS - Asia Pacific Northeast 2 (Seoul)     |
-| `aws-ap-south-1`     | AWS - Asia South 1 (Mumbai)                |
-| `aws-ap-southeast-1` | AWS - Asia Pacific Southeast 1 (Singapore) |
-| `aws-ap-southeast-2` | AWS - Asia Pacific Southeast 2 (Sydney)    |
-| `aws-ca-central-1`   | AWS - CA Central 1 (Canada Central)        |
-| `aws-eu-central-1`   | AWS - EU Central 1 (Frankfurt)             |
-| `aws-eu-west-1`      | AWS - EU West 1 (Ireland)                  |
-| `aws-eu-west-2`      | AWS - EU West 2 (London)                   |
-| `aws-sa-east-1`      | AWS - South America East 1 (Sao Paulo)     |
-| `aws-us-east-1`      | AWS - US East 1 (N. Virginia)              |
-| `aws-us-east-2`      | AWS - US East 2 (Ohio)                     |
-| `aws-us-west-1`      | AWS - US West 1 (N. California)            |
-| `aws-us-west-2`      | AWS - US West 2 (Oregon)                   |
-| `do-ams2`            | DigitalOcean - Amsterdam 2                 |
-| `do-ams3`            | DigitalOcean - Amsterdam 3                 |
-| `do-blr1`            | DigitalOcean - Bangalore 1                 |
-| `do-fra1`            | DigitalOcean - Frankfurt 1                 |
-| `do-lon1`            | DigitalOcean - London 1                    |
-| `do-nyc1`            | DigitalOcean - New York 1                  |
-| `do-nyc2`            | DigitalOcean - New York 2                  |
-| `do-nyc3`            | DigitalOcean - New York 3                  |
-| `do-sfo1`            | DigitalOcean - San Francisco 1             |
-| `do-sfo2`            | DigitalOcean - San Francisco 2             |
-| `do-sgp1`            | DigitalOcean - Singapore 1                 |
-| `do-tor1`            | DigitalOcean - Toronto 1                   |
-| `gcp-eu-west-1`      | Google Cloud - Europe West 1               |
-| `gcp-eu-west-2`      | Google Cloud - Europe West 2               |
-| `gcp-eu-west-3`      | Google Cloud - Europe West 3               |
-| `gcp-us-central-1`   | Google Cloud - US Central 1                |
-| `gcp-us-east-1`      | Google Cloud - US East 1                   |
-| `gcp-us-east-4`      | Google Cloud - US East 4                   |
-| `gcp-us-west-1`      | Google Cloud - US West 1                   |
-| `gcp-us-west-2`      | Google Cloud - US West 2                   |
-| `rs-dallas-1`        | Rackspace - Dallas 1                       |
+_Note: `All Regions` will display if a product does not allow user-defined regions._
 
 ## Hide Until Ready
 
@@ -128,4 +92,5 @@ section][custom-loaders].
 
 [custom-loaders]: /advanced/authentication
 [custom-events]: https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent
+[graphql-api]: https://api.manifold.co
 [slot]: https://stenciljs.com/docs/templating-jsx/

--- a/docs/docs/components/manifold-plan.md
+++ b/docs/docs/components/manifold-plan.md
@@ -1,18 +1,25 @@
 ---
-title: Plan
+title: Plan Card
 path: /components/plan
 example: |
-  <manifold-plan product-label="jawsdb-mysql" plan-label="kitefin"></manifold-plan>
+  <manifold-plan
+    plan-id="235dznuxuchzx5nm10djvyja1zzvm"
+  ></manifold-plan>
 ---
 
-# Product
+# Plan Card
 
-Display the details for an individual plan.
+In most cases you’d want to use the [Plan Selector][plan-selector] component for neatly laying out
+all of a product’s plans for comparison. However, if you simply must, you can embed an individual
+plan’s details using this component.
 
 ```html
-<manifold-plan product-label="jawsdb-mysql" plan-label="kitefin"></manifold-plan>
+<manifold-plan plan-id="2352n96xxbyekac7xbvr5k4a5dqy8"></manifold-plan>
 ```
 
-## Product Label
+To find a particular plan ID, refer to our [GraphQL API][graphql-api]:
 
-You can find the `:product` label for each at `https://manifold.co/services/:product`.
+<iframe src="https://graphqlbin.com/v2/7pMzum" height="400" width="800"></iframe>
+
+[graphql-api]: https://api.manifold.co
+[plan-selector]: /components/plan-selector

--- a/docs/src/components/Entry.tsx
+++ b/docs/src/components/Entry.tsx
@@ -63,6 +63,11 @@ const Readme = styled.div`
     border-radius: 0.625rem;
   }
 
+  & iframe,
+  & img {
+    max-width: 100%;
+  }
+
   & h1,
   & h2,
   & h3,


### PR DESCRIPTION
## Reason for change

The Plan page of the docs was broken. Also it was missing a title. This fixes the example, and even embeds our GraphQL API 🎉 

![Screen Shot 2019-10-11 at 16 13 37](https://user-images.githubusercontent.com/1369770/66688044-28527500-ec42-11e9-88a6-aea6aa789e34.png)

This also adds some improvements to the plan selector docs as well.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
