### PR TITLE
Add TestCafe and a test for filtering in marketplace

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,4 +13,7 @@ jobs:
     name: Run e2e tests with test cafe
     runs-on: ubuntu-18.04
     steps:
-      - run: npm run testcafe
+      - name: Install dependencies
+        run: npm install
+      - name: Run TestCafe
+        run: npm run testcafe

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  deployment_status:
+    branches:
+      - sslotsky/test-cafe
+        
+jobs:
+  test:
+    env:
+      DEPLOY_URL: ${{ github.event.deployment_status.deployment_url }}
+    if: github.event.deployment_status.state == 'success' && github.event.deployment_status.creator.login == 'now'
+    name: Run e2e tests with test cafe
+    runs-on: ubuntu-18.04
+    steps:
+      - run: npm run testcafe

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,12 +4,14 @@ on:
   deployment_status:
     branches:
       - sslotsky/test-cafe
-        
+
 jobs:
   test:
     env:
       DEPLOY_URL: ${{ github.event.deployment_status.deployment_url }}
-    if: github.event.deployment_status.state == 'success' && github.event.deployment_status.creator.login == 'now'
+    if:
+      github.event.deployment_status.state == 'SUCCESS' &&
+      github.event.deployment_status.creator.login == 'now'
     name: Run e2e tests with test cafe
     runs-on: ubuntu-18.04
     steps:

--- a/e2e/catalog-test.ts
+++ b/e2e/catalog-test.ts
@@ -1,0 +1,22 @@
+import { Selector } from 'testcafe';
+
+fixture`marketplace`.page`http://localhost:6006/?path=/story/catalog--marketplace`;
+
+test('filtering', async t => {
+  const iframe = Selector('iframe#storybook-preview-iframe');
+  const filter = Selector(() =>
+    document.querySelector('manifold-marketplace-grid').shadowRoot.querySelector('input.search')
+  );
+  const title = Selector(() =>
+    document
+      .querySelector('manifold-marketplace-grid')
+      .shadowRoot.querySelector('manifold-service-card-view')
+      .shadowRoot.querySelector('h3.name')
+  );
+
+  await t
+    .switchToIframe(iframe)
+    .typeText(filter, 'auth', { paste: true })
+    .expect(title.innerText)
+    .eql('OAuth.io');
+});

--- a/e2e/catalog-test.ts
+++ b/e2e/catalog-test.ts
@@ -1,6 +1,6 @@
 import { Selector } from 'testcafe';
 
-fixture`marketplace`.page`http://localhost:6006/?path=/story/catalog--marketplace`;
+fixture`marketplace`.page`${process.env.DEPLOY_URL}/?path=/story/catalog--marketplace`;
 
 test('filtering', async t => {
   const iframe = Selector('iframe#storybook-preview-iframe');

--- a/package-lock.json
+++ b/package-lock.json
@@ -2973,9 +2973,9 @@
       }
     },
     "@stencil/core": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-1.6.1.tgz",
-      "integrity": "sha512-XnC/8O2znZTOrcBvOdnz/oK8EM7xDaDJnLyUAmIHp0XhDrYVk6W8sjoHfmwReEEWqm4nrb8ta7Vkfdp6ToeAvw==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-1.7.2.tgz",
+      "integrity": "sha512-P/FKf4dEhxCOGYjg7BSczLWXIKGJG4wbym7sj98z+8GXSpVqpldg+wkzadN+kaUiZTMdNQ/p5rDNFI0KXyx/QQ==",
       "dev": true,
       "requires": {
         "typescript": "3.6.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -782,9 +782,9 @@
       }
     },
     "@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.6.2.tgz",
-      "integrity": "sha512-xBdB+XOs+lgbZc2/4F5BVDVcDNS4tcSKQc96KmlqLEAwz6tpYPEvPdmDfvVG0Ssn8lAhronaRs6Z6KSexIpK5g==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.6.3.tgz",
+      "integrity": "sha512-jTkk7/uE6H2s5w6VlMHeWuH+Pcy2lmdwFoeWCVnvIrDUnB5gQqTVI8WfmEAhF2CDEarGrknZcmSFg1+bkfCoSw==",
       "dev": true,
       "requires": {
         "regexpu-core": "^4.6.0"
@@ -830,9 +830,9 @@
       }
     },
     "@babel/plugin-transform-react-constant-elements": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.6.0.tgz",
-      "integrity": "sha512-np/nPuII8DHOZWB3u8u+NSeKlEz0eBrOlnVksIQog4C9NGVzXO+NLxMcXn4Eu4GMFzOw2W6Tyo6L3+Wv8z9Y5w==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.6.3.tgz",
+      "integrity": "sha512-1/YogSSU7Tby9rq2VCmhuRg+6pxsHy2rI7w/oo8RKoBt6uBUFG+mk6x13kK+FY1/ggN92HAfg7ADd1v1+NCOKg==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
@@ -936,9 +936,9 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.2.tgz",
-      "integrity": "sha512-Ru7+mfzy9M1/YTEtlDS8CD45jd22ngb9tXnn64DvQK3ooyqSw9K4K9DUWmYknTTVk4TqygL9dqCrZgm1HMea/Q==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.3.tgz",
+      "integrity": "sha512-CWQkn7EVnwzlOdR5NOm2+pfgSNEZmvGjOhlCHBDq0J8/EStr+G+FvPEiz9B56dR6MoiUFjXhfE4hjLoAKKJtIQ==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
@@ -957,7 +957,7 @@
         "@babel/plugin-transform-arrow-functions": "^7.2.0",
         "@babel/plugin-transform-async-to-generator": "^7.5.0",
         "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-        "@babel/plugin-transform-block-scoping": "^7.6.2",
+        "@babel/plugin-transform-block-scoping": "^7.6.3",
         "@babel/plugin-transform-classes": "^7.5.5",
         "@babel/plugin-transform-computed-properties": "^7.2.0",
         "@babel/plugin-transform-destructuring": "^7.6.0",
@@ -972,7 +972,7 @@
         "@babel/plugin-transform-modules-commonjs": "^7.6.0",
         "@babel/plugin-transform-modules-systemjs": "^7.5.0",
         "@babel/plugin-transform-modules-umd": "^7.2.0",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.6.2",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.6.3",
         "@babel/plugin-transform-new-target": "^7.4.4",
         "@babel/plugin-transform-object-super": "^7.5.5",
         "@babel/plugin-transform-parameters": "^7.4.4",
@@ -985,7 +985,7 @@
         "@babel/plugin-transform-template-literals": "^7.4.4",
         "@babel/plugin-transform-typeof-symbol": "^7.2.0",
         "@babel/plugin-transform-unicode-regex": "^7.6.2",
-        "@babel/types": "^7.6.0",
+        "@babel/types": "^7.6.3",
         "browserslist": "^4.6.0",
         "core-js-compat": "^3.1.1",
         "invariant": "^2.2.2",
@@ -1004,9 +1004,9 @@
           }
         },
         "@babel/plugin-transform-block-scoping": {
-          "version": "7.6.2",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.2.tgz",
-          "integrity": "sha512-zZT8ivau9LOQQaOGC7bQLQOT4XPkPXgN2ERfUgk1X8ql+mVkLc4E8eKk+FO3o0154kxzqenWCorfmEXpEZcrSQ==",
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.3.tgz",
+          "integrity": "sha512-7hvrg75dubcO3ZI2rjYTzUrEuh1E9IyDEhhB6qfcooxhDA33xx2MasuLVgdxzcP6R/lipAC6n9ub9maNW6RKdw==",
           "dev": true,
           "requires": {
             "@babel/helper-plugin-utils": "^7.0.0",
@@ -1023,9 +1023,9 @@
           }
         },
         "@babel/types": {
-          "version": "7.6.1",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
-          "integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
+          "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -1051,15 +1051,15 @@
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.277",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.277.tgz",
-          "integrity": "sha512-Czmsrgng89DOgJlIknnw9bn5431QdtnUwGp5YYiPwU1DbZQUxCLF+rc1ZC09VNAdalOPcvH6AE8BaA0H5HjI/w==",
+          "version": "1.3.282",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.282.tgz",
+          "integrity": "sha512-irSaDeCGgfMu1OA30bhqIBr+dx+pDJjRbwCpob7YWqVZbzXblybNzPGklVnWqv4EXxbkEAzQYqiNCqNTgu00lQ==",
           "dev": true
         },
         "node-releases": {
-          "version": "1.1.34",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.34.tgz",
-          "integrity": "sha512-fNn12JTEfniTuCqo0r9jXgl44+KxRH/huV7zM/KAGOKxDKrHr6EbT7SSs4B+DNxyBE2mks28AD+Jw6PkfY5uwA==",
+          "version": "1.1.35",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.35.tgz",
+          "integrity": "sha512-JGcM/wndCN/2elJlU0IGdVEJQQnJwsLbgPCFd2pY7V0mxf17bZ0Gb/lgOtL29ZQhvEX5shnVhxQyZz3ex94N8w==",
           "dev": true,
           "requires": {
             "semver": "^6.3.0"
@@ -3459,9 +3459,9 @@
       }
     },
     "@storybook/core": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-5.2.3.tgz",
-      "integrity": "sha512-sktjYY8pH4kQGFRKjXwtwwShdG3ajjHkrnw8oh3R383MRPom7i9owx5yHHMuQedLCXIwAg84s2DzO01I2URTcg==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-5.2.4.tgz",
+      "integrity": "sha512-r5kDgZETNawHxpsAPw+h+pRk6l/mJhsSHeDo9/OdYtYFW7lmk2gadViXOTM+6gIWc6vQ8y750bgkahmyIIY0nQ==",
       "dev": true,
       "requires": {
         "@babel/plugin-proposal-class-properties": "^7.3.3",
@@ -3469,15 +3469,15 @@
         "@babel/plugin-syntax-dynamic-import": "^7.2.0",
         "@babel/plugin-transform-react-constant-elements": "^7.2.0",
         "@babel/preset-env": "^7.4.5",
-        "@storybook/addons": "5.2.3",
-        "@storybook/channel-postmessage": "5.2.3",
-        "@storybook/client-api": "5.2.3",
-        "@storybook/client-logger": "5.2.3",
-        "@storybook/core-events": "5.2.3",
-        "@storybook/node-logger": "5.2.3",
-        "@storybook/router": "5.2.3",
-        "@storybook/theming": "5.2.3",
-        "@storybook/ui": "5.2.3",
+        "@storybook/addons": "5.2.4",
+        "@storybook/channel-postmessage": "5.2.4",
+        "@storybook/client-api": "5.2.4",
+        "@storybook/client-logger": "5.2.4",
+        "@storybook/core-events": "5.2.4",
+        "@storybook/node-logger": "5.2.4",
+        "@storybook/router": "5.2.4",
+        "@storybook/theming": "5.2.4",
+        "@storybook/ui": "5.2.4",
         "airbnb-js-shims": "^1 || ^2",
         "ansi-to-html": "^0.6.11",
         "autoprefixer": "^9.4.9",
@@ -3534,141 +3534,32 @@
         "webpack-hot-middleware": "^2.25.0"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.6.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
-          "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
-          "dev": true,
-          "requires": {
-            "regenerator-runtime": "^0.13.2"
-          },
-          "dependencies": {
-            "regenerator-runtime": {
-              "version": "0.13.3",
-              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-              "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
-              "dev": true
-            }
-          }
-        },
-        "@emotion/cache": {
-          "version": "10.0.19",
-          "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.19.tgz",
-          "integrity": "sha512-BoiLlk4vEsGBg2dAqGSJu0vJl/PgVtCYLBFJaEO8RmQzPugXewQCXZJNXTDFaRlfCs0W+quesayav4fvaif5WQ==",
-          "dev": true,
-          "requires": {
-            "@emotion/sheet": "0.9.3",
-            "@emotion/stylis": "0.8.4",
-            "@emotion/utils": "0.11.2",
-            "@emotion/weak-memoize": "0.2.4"
-          }
-        },
-        "@emotion/core": {
-          "version": "10.0.21",
-          "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.21.tgz",
-          "integrity": "sha512-U9zbc7ovZ2ceIwbLXYZPJy6wPgnOdTNT4jENZ31ee6v2lojetV5bTbCVk6ciT8G3wQRyVaTTfUCH9WCrMzpRIw==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.5.5",
-            "@emotion/cache": "^10.0.17",
-            "@emotion/css": "^10.0.14",
-            "@emotion/serialize": "^0.11.10",
-            "@emotion/sheet": "0.9.3",
-            "@emotion/utils": "0.11.2"
-          }
-        },
-        "@emotion/css": {
-          "version": "10.0.14",
-          "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.14.tgz",
-          "integrity": "sha512-MozgPkBEWvorcdpqHZE5x1D/PLEHUitALQCQYt2wayf4UNhpgQs2tN0UwHYS4FMy5ROBH+0ALyCFVYJ/ywmwlg==",
-          "dev": true,
-          "requires": {
-            "@emotion/serialize": "^0.11.8",
-            "@emotion/utils": "0.11.2",
-            "babel-plugin-emotion": "^10.0.14"
-          }
-        },
-        "@emotion/hash": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.3.tgz",
-          "integrity": "sha512-14ZVlsB9akwvydAdaEnVnvqu6J2P6ySv39hYyl/aoB6w/V+bXX0tay8cF6paqbgZsN2n5Xh15uF4pE+GvE+itw==",
-          "dev": true
-        },
-        "@emotion/memoize": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.3.tgz",
-          "integrity": "sha512-2Md9mH6mvo+ygq1trTeVp2uzAKwE2P7In0cRpD/M9Q70aH8L+rxMLbb3JCN2JoSWsV2O+DdFjfbbXoMoLBczow==",
-          "dev": true
-        },
-        "@emotion/serialize": {
-          "version": "0.11.11",
-          "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.11.tgz",
-          "integrity": "sha512-YG8wdCqoWtuoMxhHZCTA+egL0RSGdHEc+YCsmiSBPBEDNuVeMWtjEWtGrhUterSChxzwnWBXvzSxIFQI/3sHLw==",
-          "dev": true,
-          "requires": {
-            "@emotion/hash": "0.7.3",
-            "@emotion/memoize": "0.7.3",
-            "@emotion/unitless": "0.7.4",
-            "@emotion/utils": "0.11.2",
-            "csstype": "^2.5.7"
-          }
-        },
-        "@emotion/sheet": {
-          "version": "0.9.3",
-          "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.3.tgz",
-          "integrity": "sha512-c3Q6V7Df7jfwSq5AzQWbXHa5soeE4F5cbqi40xn0CzXxWW9/6Mxq48WJEtqfWzbZtW9odZdnRAkwCQwN12ob4A==",
-          "dev": true
-        },
-        "@emotion/stylis": {
-          "version": "0.8.4",
-          "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.4.tgz",
-          "integrity": "sha512-TLmkCVm8f8gH0oLv+HWKiu7e8xmBIaokhxcEKPh1m8pXiV/akCiq50FvYgOwY42rjejck8nsdQxZlXZ7pmyBUQ==",
-          "dev": true
-        },
-        "@emotion/unitless": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.4.tgz",
-          "integrity": "sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ==",
-          "dev": true
-        },
-        "@emotion/utils": {
-          "version": "0.11.2",
-          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.2.tgz",
-          "integrity": "sha512-UHX2XklLl3sIaP6oiMmlVzT0J+2ATTVpf0dHQVyPJHTkOITvXfaSqnRk6mdDhV9pR8T/tHc3cex78IKXssmzrA==",
-          "dev": true
-        },
-        "@emotion/weak-memoize": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.4.tgz",
-          "integrity": "sha512-6PYY5DVdAY1ifaQW6XYTnOMihmBVT27elqSjEoodchsGjzYlEsTQMcEhSud99kVawatyTZRTiVkJ/c6lwbQ7nA==",
-          "dev": true
-        },
         "@storybook/addons": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.2.3.tgz",
-          "integrity": "sha512-LTkUJB8ZDc4++yt9acNHNjlnGWCyNtP+NVYPDvg7zFOaMip21Pj4T0pg9UwYxdqrFBWz9tVz7DJeXroS3egXxg==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.2.4.tgz",
+          "integrity": "sha512-Q+bnVlBA308qnELxnh18hBDRSUgltR9KbV537285dUL/okv/NC6n51mxJwIaG+ksBW2wU+5e6tqSayaKF3uHLw==",
           "dev": true,
           "requires": {
-            "@storybook/api": "5.2.3",
-            "@storybook/channels": "5.2.3",
-            "@storybook/client-logger": "5.2.3",
-            "@storybook/core-events": "5.2.3",
+            "@storybook/api": "5.2.4",
+            "@storybook/channels": "5.2.4",
+            "@storybook/client-logger": "5.2.4",
+            "@storybook/core-events": "5.2.4",
             "core-js": "^3.0.1",
             "global": "^4.3.2",
             "util-deprecate": "^1.0.2"
           }
         },
         "@storybook/api": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.2.3.tgz",
-          "integrity": "sha512-2csxa/d64rXy4Dwoc7YjbPeNUJRgcI/wJUo30CLujk2stEFzDnKeMPR1mlHMCIFDW+KDxJ28bW59VPxwrqJFjw==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.2.4.tgz",
+          "integrity": "sha512-KqAB+NkHIHdwu749NDP+7i44jy1bFgpq7GTJlG+sx/XLZHQveK/8yn109g9bXHFth7SvdXI1+9GA/apzwBU/Mw==",
           "dev": true,
           "requires": {
-            "@storybook/channels": "5.2.3",
-            "@storybook/client-logger": "5.2.3",
-            "@storybook/core-events": "5.2.3",
-            "@storybook/router": "5.2.3",
-            "@storybook/theming": "5.2.3",
+            "@storybook/channels": "5.2.4",
+            "@storybook/client-logger": "5.2.4",
+            "@storybook/core-events": "5.2.4",
+            "@storybook/router": "5.2.4",
+            "@storybook/theming": "5.2.4",
             "core-js": "^3.0.1",
             "fast-deep-equal": "^2.0.1",
             "global": "^4.3.2",
@@ -3684,39 +3575,39 @@
           }
         },
         "@storybook/channel-postmessage": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-5.2.3.tgz",
-          "integrity": "sha512-ixlpr6aAYoRM72cKwEWU/W0rWzOn3mYqb/eUdIaz3Da5BtFGKm3yEFguII0l1my82uhMm5/d3UNfoh0rO3pUyg==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-5.2.4.tgz",
+          "integrity": "sha512-ic7/Ho8z2/aOMjoEbr5p8rijOfO3SZdJnwMvDdUxrqvYq7yACZWidPo3w2+iBwQi9HLqEsWesP1c2doJBxVGRw==",
           "dev": true,
           "requires": {
-            "@storybook/channels": "5.2.3",
-            "@storybook/client-logger": "5.2.3",
+            "@storybook/channels": "5.2.4",
+            "@storybook/client-logger": "5.2.4",
             "core-js": "^3.0.1",
             "global": "^4.3.2",
             "telejson": "^3.0.2"
           }
         },
         "@storybook/channels": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.2.3.tgz",
-          "integrity": "sha512-13Mlb+XbE0mHXiLLHdg0w9byhRy/bE605U7U96PGQp2cwX4lf+4jpViO2mDCsndAFRc0+2hexXPTkwgzvZzq0A==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.2.4.tgz",
+          "integrity": "sha512-/r39yEZ5QiGdiq95DhXBypdBo7urkD3Sp1WDyK48uGkZ0gdHWSPy3BBy8OJhEhfNz7nVisTiVIBr4gIrubKDjw==",
           "dev": true,
           "requires": {
             "core-js": "^3.0.1"
           }
         },
         "@storybook/client-api": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-5.2.3.tgz",
-          "integrity": "sha512-anXxcf2z+KQAk94xxdbeG1N6nTEWXj087XHQ22L3pOoX9TRzfG71UjL0/S7vj4EFUiXVHj8d6YUFwLb5LwpUIw==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-5.2.4.tgz",
+          "integrity": "sha512-SOwzEFHoNapURhNqdcI7HA76o5tkWvs2+2s++i/S7xsAd3KyefIVDOdqSMlAxJkxZb8Mlrb3UNRxlrpA8SZqNA==",
           "dev": true,
           "requires": {
-            "@storybook/addons": "5.2.3",
-            "@storybook/channel-postmessage": "5.2.3",
-            "@storybook/channels": "5.2.3",
-            "@storybook/client-logger": "5.2.3",
-            "@storybook/core-events": "5.2.3",
-            "@storybook/router": "5.2.3",
+            "@storybook/addons": "5.2.4",
+            "@storybook/channel-postmessage": "5.2.4",
+            "@storybook/channels": "5.2.4",
+            "@storybook/client-logger": "5.2.4",
+            "@storybook/core-events": "5.2.4",
+            "@storybook/router": "5.2.4",
             "common-tags": "^1.8.0",
             "core-js": "^3.0.1",
             "eventemitter3": "^4.0.0",
@@ -3729,27 +3620,27 @@
           }
         },
         "@storybook/client-logger": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.2.3.tgz",
-          "integrity": "sha512-Z1irXW4jiFs7rClgqJqYOgg5op51ynV6dVuoIqxkSC0MrOG5s/VbX7T+ojGPXKyQWD4XYGw66Hnw9jouSfXL9g==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.2.4.tgz",
+          "integrity": "sha512-ofp6QQPQZBU+RvlAH5KpZRsfAFHecCZDnl/7YG6FwjHseJr3jHTYmBGGjJDMHFHq+Q7FGQu/yVb9lMFgoQ43QQ==",
           "dev": true,
           "requires": {
             "core-js": "^3.0.1"
           }
         },
         "@storybook/core-events": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.2.3.tgz",
-          "integrity": "sha512-sZEv93yE1o+/UJdhtqQ6vo2EauZ90FjN/L8F7CR7iqDEZzqo9g77Idg9LSgcN3TAeXcGAWVSrPb1vkK7H96L2g==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.2.4.tgz",
+          "integrity": "sha512-nQknCmaz2S2HW6PSGcuFzve7Y1Js2Cb268vUG0ZMNtJZwFawqYc+KSQHqmOY0pVm8dyROTcWCudPA0k+hk6N5Q==",
           "dev": true,
           "requires": {
             "core-js": "^3.0.1"
           }
         },
         "@storybook/router": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.2.3.tgz",
-          "integrity": "sha512-sOu6y2GySaY82SdXfF3yOn0IJTKMqd2BDOSGEno7PWWtSenHFQWY+z99C9k0dLBTkjRes5tPcgm0OJ7RdQVRDQ==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.2.4.tgz",
+          "integrity": "sha512-GL7eGdj5oYST0mE9fThJB9ye9tTTgrP+aP3okZ6MeMGtNytb7bmJRpAD2E4ouuPTQVppyHI5re8g/HUxUNOT1g==",
           "dev": true,
           "requires": {
             "@reach/router": "^1.2.1",
@@ -3762,14 +3653,14 @@
           }
         },
         "@storybook/theming": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.2.3.tgz",
-          "integrity": "sha512-3/0bo8CaoaHDYZaexydpYcwP6WW8BKRqSQBGXJY9y0TLhwY2Who5nPX9XdOLyu9d7lN//PRZlt8JnZynuncxoQ==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.2.4.tgz",
+          "integrity": "sha512-2ZlqBrmnm8N0352Fnu2+GB3pEsHL4Eb2eKxV0VLLgkjJuAlm7CK6+I/e4ZknQWxwYm2pQj1y6ta68A62fGBYyA==",
           "dev": true,
           "requires": {
             "@emotion/core": "^10.0.14",
             "@emotion/styled": "^10.0.14",
-            "@storybook/client-logger": "5.2.3",
+            "@storybook/client-logger": "5.2.4",
             "common-tags": "^1.8.0",
             "core-js": "^3.0.1",
             "deep-object-diff": "^1.1.0",
@@ -3779,24 +3670,6 @@
             "polished": "^3.3.1",
             "prop-types": "^15.7.2",
             "resolve-from": "^5.0.0"
-          }
-        },
-        "babel-plugin-emotion": {
-          "version": "10.0.21",
-          "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.21.tgz",
-          "integrity": "sha512-03o+T6sfVAJhNDcSdLapgv4IeewcFPzxlvBUVdSf7o5PI57ZSxoDvmy+ZulVWSu+rOWAWkEejNcsb29TuzJHbg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-module-imports": "^7.0.0",
-            "@emotion/hash": "0.7.3",
-            "@emotion/memoize": "0.7.3",
-            "@emotion/serialize": "^0.11.11",
-            "babel-plugin-macros": "^2.0.0",
-            "babel-plugin-syntax-jsx": "^6.18.0",
-            "convert-source-map": "^1.5.0",
-            "escape-string-regexp": "^1.0.5",
-            "find-root": "^1.1.0",
-            "source-map": "^0.5.7"
           }
         },
         "find-cache-dir": {
@@ -3877,12 +3750,6 @@
             "find-up": "^4.0.0"
           }
         },
-        "process": {
-          "version": "0.11.10",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-          "dev": true
-        },
         "qs": {
           "version": "6.9.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.0.tgz",
@@ -3909,40 +3776,6 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
-        },
-        "telejson": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/telejson/-/telejson-3.0.3.tgz",
-          "integrity": "sha512-gUOh6wox1zJjbGMg+e26NquZcp/F18EbIaqVvjiGqikRqVB4fYEAM8Nyin8smgwX30XhaRBOg+kCj4vInmvwAg==",
-          "dev": true,
-          "requires": {
-            "@types/is-function": "^1.0.0",
-            "global": "^4.4.0",
-            "is-function": "^1.0.1",
-            "is-regex": "^1.0.4",
-            "is-symbol": "^1.0.2",
-            "isobject": "^4.0.0",
-            "lodash": "^4.17.15",
-            "memoizerific": "^1.11.3"
-          },
-          "dependencies": {
-            "global": {
-              "version": "4.4.0",
-              "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
-              "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-              "dev": true,
-              "requires": {
-                "min-document": "^2.19.0",
-                "process": "^0.11.10"
-              }
-            },
-            "lodash": {
-              "version": "4.17.15",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-              "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-              "dev": true
-            }
-          }
         }
       }
     },
@@ -3956,13 +3789,13 @@
       }
     },
     "@storybook/html": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@storybook/html/-/html-5.2.3.tgz",
-      "integrity": "sha512-w9RAYacx7KQhXGrWYHeyqIKkfnEzCFr2FzEacyoTwX8rpyOUGE/Yv6WOcMLQqjriVeFwNRPx20gETYmzouo+XA==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@storybook/html/-/html-5.2.4.tgz",
+      "integrity": "sha512-a0SXw9v285t+PFIDZXsKtbQpABlhBwABopZHn5JeaIsyeNWKWzwCVtAtNzqCyBMwF6Rx/1LWcqHPRztc3PBijQ==",
       "dev": true,
       "requires": {
-        "@storybook/addons": "5.2.3",
-        "@storybook/core": "5.2.3",
+        "@storybook/addons": "5.2.4",
+        "@storybook/core": "5.2.4",
         "@types/webpack-env": "^1.13.9",
         "common-tags": "^1.8.0",
         "core-js": "^3.0.1",
@@ -3971,141 +3804,32 @@
         "regenerator-runtime": "^0.12.1"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.6.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
-          "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
-          "dev": true,
-          "requires": {
-            "regenerator-runtime": "^0.13.2"
-          },
-          "dependencies": {
-            "regenerator-runtime": {
-              "version": "0.13.3",
-              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-              "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
-              "dev": true
-            }
-          }
-        },
-        "@emotion/cache": {
-          "version": "10.0.19",
-          "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.19.tgz",
-          "integrity": "sha512-BoiLlk4vEsGBg2dAqGSJu0vJl/PgVtCYLBFJaEO8RmQzPugXewQCXZJNXTDFaRlfCs0W+quesayav4fvaif5WQ==",
-          "dev": true,
-          "requires": {
-            "@emotion/sheet": "0.9.3",
-            "@emotion/stylis": "0.8.4",
-            "@emotion/utils": "0.11.2",
-            "@emotion/weak-memoize": "0.2.4"
-          }
-        },
-        "@emotion/core": {
-          "version": "10.0.21",
-          "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.21.tgz",
-          "integrity": "sha512-U9zbc7ovZ2ceIwbLXYZPJy6wPgnOdTNT4jENZ31ee6v2lojetV5bTbCVk6ciT8G3wQRyVaTTfUCH9WCrMzpRIw==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.5.5",
-            "@emotion/cache": "^10.0.17",
-            "@emotion/css": "^10.0.14",
-            "@emotion/serialize": "^0.11.10",
-            "@emotion/sheet": "0.9.3",
-            "@emotion/utils": "0.11.2"
-          }
-        },
-        "@emotion/css": {
-          "version": "10.0.14",
-          "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.14.tgz",
-          "integrity": "sha512-MozgPkBEWvorcdpqHZE5x1D/PLEHUitALQCQYt2wayf4UNhpgQs2tN0UwHYS4FMy5ROBH+0ALyCFVYJ/ywmwlg==",
-          "dev": true,
-          "requires": {
-            "@emotion/serialize": "^0.11.8",
-            "@emotion/utils": "0.11.2",
-            "babel-plugin-emotion": "^10.0.14"
-          }
-        },
-        "@emotion/hash": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.3.tgz",
-          "integrity": "sha512-14ZVlsB9akwvydAdaEnVnvqu6J2P6ySv39hYyl/aoB6w/V+bXX0tay8cF6paqbgZsN2n5Xh15uF4pE+GvE+itw==",
-          "dev": true
-        },
-        "@emotion/memoize": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.3.tgz",
-          "integrity": "sha512-2Md9mH6mvo+ygq1trTeVp2uzAKwE2P7In0cRpD/M9Q70aH8L+rxMLbb3JCN2JoSWsV2O+DdFjfbbXoMoLBczow==",
-          "dev": true
-        },
-        "@emotion/serialize": {
-          "version": "0.11.11",
-          "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.11.tgz",
-          "integrity": "sha512-YG8wdCqoWtuoMxhHZCTA+egL0RSGdHEc+YCsmiSBPBEDNuVeMWtjEWtGrhUterSChxzwnWBXvzSxIFQI/3sHLw==",
-          "dev": true,
-          "requires": {
-            "@emotion/hash": "0.7.3",
-            "@emotion/memoize": "0.7.3",
-            "@emotion/unitless": "0.7.4",
-            "@emotion/utils": "0.11.2",
-            "csstype": "^2.5.7"
-          }
-        },
-        "@emotion/sheet": {
-          "version": "0.9.3",
-          "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.3.tgz",
-          "integrity": "sha512-c3Q6V7Df7jfwSq5AzQWbXHa5soeE4F5cbqi40xn0CzXxWW9/6Mxq48WJEtqfWzbZtW9odZdnRAkwCQwN12ob4A==",
-          "dev": true
-        },
-        "@emotion/stylis": {
-          "version": "0.8.4",
-          "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.4.tgz",
-          "integrity": "sha512-TLmkCVm8f8gH0oLv+HWKiu7e8xmBIaokhxcEKPh1m8pXiV/akCiq50FvYgOwY42rjejck8nsdQxZlXZ7pmyBUQ==",
-          "dev": true
-        },
-        "@emotion/unitless": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.4.tgz",
-          "integrity": "sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ==",
-          "dev": true
-        },
-        "@emotion/utils": {
-          "version": "0.11.2",
-          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.2.tgz",
-          "integrity": "sha512-UHX2XklLl3sIaP6oiMmlVzT0J+2ATTVpf0dHQVyPJHTkOITvXfaSqnRk6mdDhV9pR8T/tHc3cex78IKXssmzrA==",
-          "dev": true
-        },
-        "@emotion/weak-memoize": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.4.tgz",
-          "integrity": "sha512-6PYY5DVdAY1ifaQW6XYTnOMihmBVT27elqSjEoodchsGjzYlEsTQMcEhSud99kVawatyTZRTiVkJ/c6lwbQ7nA==",
-          "dev": true
-        },
         "@storybook/addons": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.2.3.tgz",
-          "integrity": "sha512-LTkUJB8ZDc4++yt9acNHNjlnGWCyNtP+NVYPDvg7zFOaMip21Pj4T0pg9UwYxdqrFBWz9tVz7DJeXroS3egXxg==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.2.4.tgz",
+          "integrity": "sha512-Q+bnVlBA308qnELxnh18hBDRSUgltR9KbV537285dUL/okv/NC6n51mxJwIaG+ksBW2wU+5e6tqSayaKF3uHLw==",
           "dev": true,
           "requires": {
-            "@storybook/api": "5.2.3",
-            "@storybook/channels": "5.2.3",
-            "@storybook/client-logger": "5.2.3",
-            "@storybook/core-events": "5.2.3",
+            "@storybook/api": "5.2.4",
+            "@storybook/channels": "5.2.4",
+            "@storybook/client-logger": "5.2.4",
+            "@storybook/core-events": "5.2.4",
             "core-js": "^3.0.1",
             "global": "^4.3.2",
             "util-deprecate": "^1.0.2"
           }
         },
         "@storybook/api": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.2.3.tgz",
-          "integrity": "sha512-2csxa/d64rXy4Dwoc7YjbPeNUJRgcI/wJUo30CLujk2stEFzDnKeMPR1mlHMCIFDW+KDxJ28bW59VPxwrqJFjw==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.2.4.tgz",
+          "integrity": "sha512-KqAB+NkHIHdwu749NDP+7i44jy1bFgpq7GTJlG+sx/XLZHQveK/8yn109g9bXHFth7SvdXI1+9GA/apzwBU/Mw==",
           "dev": true,
           "requires": {
-            "@storybook/channels": "5.2.3",
-            "@storybook/client-logger": "5.2.3",
-            "@storybook/core-events": "5.2.3",
-            "@storybook/router": "5.2.3",
-            "@storybook/theming": "5.2.3",
+            "@storybook/channels": "5.2.4",
+            "@storybook/client-logger": "5.2.4",
+            "@storybook/core-events": "5.2.4",
+            "@storybook/router": "5.2.4",
+            "@storybook/theming": "5.2.4",
             "core-js": "^3.0.1",
             "fast-deep-equal": "^2.0.1",
             "global": "^4.3.2",
@@ -4121,36 +3845,36 @@
           }
         },
         "@storybook/channels": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.2.3.tgz",
-          "integrity": "sha512-13Mlb+XbE0mHXiLLHdg0w9byhRy/bE605U7U96PGQp2cwX4lf+4jpViO2mDCsndAFRc0+2hexXPTkwgzvZzq0A==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.2.4.tgz",
+          "integrity": "sha512-/r39yEZ5QiGdiq95DhXBypdBo7urkD3Sp1WDyK48uGkZ0gdHWSPy3BBy8OJhEhfNz7nVisTiVIBr4gIrubKDjw==",
           "dev": true,
           "requires": {
             "core-js": "^3.0.1"
           }
         },
         "@storybook/client-logger": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.2.3.tgz",
-          "integrity": "sha512-Z1irXW4jiFs7rClgqJqYOgg5op51ynV6dVuoIqxkSC0MrOG5s/VbX7T+ojGPXKyQWD4XYGw66Hnw9jouSfXL9g==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.2.4.tgz",
+          "integrity": "sha512-ofp6QQPQZBU+RvlAH5KpZRsfAFHecCZDnl/7YG6FwjHseJr3jHTYmBGGjJDMHFHq+Q7FGQu/yVb9lMFgoQ43QQ==",
           "dev": true,
           "requires": {
             "core-js": "^3.0.1"
           }
         },
         "@storybook/core-events": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.2.3.tgz",
-          "integrity": "sha512-sZEv93yE1o+/UJdhtqQ6vo2EauZ90FjN/L8F7CR7iqDEZzqo9g77Idg9LSgcN3TAeXcGAWVSrPb1vkK7H96L2g==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.2.4.tgz",
+          "integrity": "sha512-nQknCmaz2S2HW6PSGcuFzve7Y1Js2Cb268vUG0ZMNtJZwFawqYc+KSQHqmOY0pVm8dyROTcWCudPA0k+hk6N5Q==",
           "dev": true,
           "requires": {
             "core-js": "^3.0.1"
           }
         },
         "@storybook/router": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.2.3.tgz",
-          "integrity": "sha512-sOu6y2GySaY82SdXfF3yOn0IJTKMqd2BDOSGEno7PWWtSenHFQWY+z99C9k0dLBTkjRes5tPcgm0OJ7RdQVRDQ==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.2.4.tgz",
+          "integrity": "sha512-GL7eGdj5oYST0mE9fThJB9ye9tTTgrP+aP3okZ6MeMGtNytb7bmJRpAD2E4ouuPTQVppyHI5re8g/HUxUNOT1g==",
           "dev": true,
           "requires": {
             "@reach/router": "^1.2.1",
@@ -4163,14 +3887,14 @@
           }
         },
         "@storybook/theming": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.2.3.tgz",
-          "integrity": "sha512-3/0bo8CaoaHDYZaexydpYcwP6WW8BKRqSQBGXJY9y0TLhwY2Who5nPX9XdOLyu9d7lN//PRZlt8JnZynuncxoQ==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.2.4.tgz",
+          "integrity": "sha512-2ZlqBrmnm8N0352Fnu2+GB3pEsHL4Eb2eKxV0VLLgkjJuAlm7CK6+I/e4ZknQWxwYm2pQj1y6ta68A62fGBYyA==",
           "dev": true,
           "requires": {
             "@emotion/core": "^10.0.14",
             "@emotion/styled": "^10.0.14",
-            "@storybook/client-logger": "5.2.3",
+            "@storybook/client-logger": "5.2.4",
             "common-tags": "^1.8.0",
             "core-js": "^3.0.1",
             "deep-object-diff": "^1.1.0",
@@ -4181,36 +3905,6 @@
             "prop-types": "^15.7.2",
             "resolve-from": "^5.0.0"
           }
-        },
-        "babel-plugin-emotion": {
-          "version": "10.0.21",
-          "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.21.tgz",
-          "integrity": "sha512-03o+T6sfVAJhNDcSdLapgv4IeewcFPzxlvBUVdSf7o5PI57ZSxoDvmy+ZulVWSu+rOWAWkEejNcsb29TuzJHbg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-module-imports": "^7.0.0",
-            "@emotion/hash": "0.7.3",
-            "@emotion/memoize": "0.7.3",
-            "@emotion/serialize": "^0.11.11",
-            "babel-plugin-macros": "^2.0.0",
-            "babel-plugin-syntax-jsx": "^6.18.0",
-            "convert-source-map": "^1.5.0",
-            "escape-string-regexp": "^1.0.5",
-            "find-root": "^1.1.0",
-            "source-map": "^0.5.7"
-          }
-        },
-        "isobject": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
-          "dev": true
-        },
-        "process": {
-          "version": "0.11.10",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-          "dev": true
         },
         "qs": {
           "version": "6.9.0",
@@ -4229,47 +3923,13 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
-        },
-        "telejson": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/telejson/-/telejson-3.0.3.tgz",
-          "integrity": "sha512-gUOh6wox1zJjbGMg+e26NquZcp/F18EbIaqVvjiGqikRqVB4fYEAM8Nyin8smgwX30XhaRBOg+kCj4vInmvwAg==",
-          "dev": true,
-          "requires": {
-            "@types/is-function": "^1.0.0",
-            "global": "^4.4.0",
-            "is-function": "^1.0.1",
-            "is-regex": "^1.0.4",
-            "is-symbol": "^1.0.2",
-            "isobject": "^4.0.0",
-            "lodash": "^4.17.15",
-            "memoizerific": "^1.11.3"
-          },
-          "dependencies": {
-            "global": {
-              "version": "4.4.0",
-              "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
-              "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-              "dev": true,
-              "requires": {
-                "min-document": "^2.19.0",
-                "process": "^0.11.10"
-              }
-            },
-            "lodash": {
-              "version": "4.17.15",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-              "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-              "dev": true
-            }
-          }
         }
       }
     },
     "@storybook/node-logger": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-5.2.3.tgz",
-      "integrity": "sha512-5p+5ltLdr7cZTSCG+vdIMDLHq5AAaL/CQ/bygjl+Rw/RSpvBO5Rg8hryszFyhogToHJbn2JinUbypLA+P6tcuQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-5.2.4.tgz",
+      "integrity": "sha512-4OOzce02IAfrRv+Y7h3icyw6WIuDekpWF2eYjgYVVvAJYklCEwgeBTBCY0/2TJjPPTBDPUKHVP1Bdz3Vpci9pA==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
@@ -4331,19 +3991,19 @@
       }
     },
     "@storybook/ui": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-5.2.3.tgz",
-      "integrity": "sha512-SNyo5oxupb105N4Rz8O5/iJMs/THrmdvP+vsN7CpOTxebM01rHyvk51cNUwHKG1QwlZmpXL8GbtWlbvqL2d/gQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-5.2.4.tgz",
+      "integrity": "sha512-zsS43k1h4bWEW6oj9FNHlUL3niHoJJ8v7iqYbRtVM12rxrYhV3K8TGVG3LCuNB75i3Be0Myy+/RHA4x9kco08A==",
       "dev": true,
       "requires": {
-        "@storybook/addons": "5.2.3",
-        "@storybook/api": "5.2.3",
-        "@storybook/channels": "5.2.3",
-        "@storybook/client-logger": "5.2.3",
-        "@storybook/components": "5.2.3",
-        "@storybook/core-events": "5.2.3",
-        "@storybook/router": "5.2.3",
-        "@storybook/theming": "5.2.3",
+        "@storybook/addons": "5.2.4",
+        "@storybook/api": "5.2.4",
+        "@storybook/channels": "5.2.4",
+        "@storybook/client-logger": "5.2.4",
+        "@storybook/components": "5.2.4",
+        "@storybook/core-events": "5.2.4",
+        "@storybook/router": "5.2.4",
+        "@storybook/theming": "5.2.4",
         "copy-to-clipboard": "^3.0.8",
         "core-js": "^3.0.1",
         "core-js-pure": "^3.0.1",
@@ -4371,133 +4031,32 @@
         "util-deprecate": "^1.0.2"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.6.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
-          "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
-          "dev": true,
-          "requires": {
-            "regenerator-runtime": "^0.13.2"
-          }
-        },
-        "@emotion/cache": {
-          "version": "10.0.19",
-          "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.19.tgz",
-          "integrity": "sha512-BoiLlk4vEsGBg2dAqGSJu0vJl/PgVtCYLBFJaEO8RmQzPugXewQCXZJNXTDFaRlfCs0W+quesayav4fvaif5WQ==",
-          "dev": true,
-          "requires": {
-            "@emotion/sheet": "0.9.3",
-            "@emotion/stylis": "0.8.4",
-            "@emotion/utils": "0.11.2",
-            "@emotion/weak-memoize": "0.2.4"
-          }
-        },
-        "@emotion/core": {
-          "version": "10.0.21",
-          "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.21.tgz",
-          "integrity": "sha512-U9zbc7ovZ2ceIwbLXYZPJy6wPgnOdTNT4jENZ31ee6v2lojetV5bTbCVk6ciT8G3wQRyVaTTfUCH9WCrMzpRIw==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.5.5",
-            "@emotion/cache": "^10.0.17",
-            "@emotion/css": "^10.0.14",
-            "@emotion/serialize": "^0.11.10",
-            "@emotion/sheet": "0.9.3",
-            "@emotion/utils": "0.11.2"
-          }
-        },
-        "@emotion/css": {
-          "version": "10.0.14",
-          "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.14.tgz",
-          "integrity": "sha512-MozgPkBEWvorcdpqHZE5x1D/PLEHUitALQCQYt2wayf4UNhpgQs2tN0UwHYS4FMy5ROBH+0ALyCFVYJ/ywmwlg==",
-          "dev": true,
-          "requires": {
-            "@emotion/serialize": "^0.11.8",
-            "@emotion/utils": "0.11.2",
-            "babel-plugin-emotion": "^10.0.14"
-          }
-        },
-        "@emotion/hash": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.3.tgz",
-          "integrity": "sha512-14ZVlsB9akwvydAdaEnVnvqu6J2P6ySv39hYyl/aoB6w/V+bXX0tay8cF6paqbgZsN2n5Xh15uF4pE+GvE+itw==",
-          "dev": true
-        },
-        "@emotion/memoize": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.3.tgz",
-          "integrity": "sha512-2Md9mH6mvo+ygq1trTeVp2uzAKwE2P7In0cRpD/M9Q70aH8L+rxMLbb3JCN2JoSWsV2O+DdFjfbbXoMoLBczow==",
-          "dev": true
-        },
-        "@emotion/serialize": {
-          "version": "0.11.11",
-          "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.11.tgz",
-          "integrity": "sha512-YG8wdCqoWtuoMxhHZCTA+egL0RSGdHEc+YCsmiSBPBEDNuVeMWtjEWtGrhUterSChxzwnWBXvzSxIFQI/3sHLw==",
-          "dev": true,
-          "requires": {
-            "@emotion/hash": "0.7.3",
-            "@emotion/memoize": "0.7.3",
-            "@emotion/unitless": "0.7.4",
-            "@emotion/utils": "0.11.2",
-            "csstype": "^2.5.7"
-          }
-        },
-        "@emotion/sheet": {
-          "version": "0.9.3",
-          "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.3.tgz",
-          "integrity": "sha512-c3Q6V7Df7jfwSq5AzQWbXHa5soeE4F5cbqi40xn0CzXxWW9/6Mxq48WJEtqfWzbZtW9odZdnRAkwCQwN12ob4A==",
-          "dev": true
-        },
-        "@emotion/stylis": {
-          "version": "0.8.4",
-          "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.4.tgz",
-          "integrity": "sha512-TLmkCVm8f8gH0oLv+HWKiu7e8xmBIaokhxcEKPh1m8pXiV/akCiq50FvYgOwY42rjejck8nsdQxZlXZ7pmyBUQ==",
-          "dev": true
-        },
-        "@emotion/unitless": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.4.tgz",
-          "integrity": "sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ==",
-          "dev": true
-        },
-        "@emotion/utils": {
-          "version": "0.11.2",
-          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.2.tgz",
-          "integrity": "sha512-UHX2XklLl3sIaP6oiMmlVzT0J+2ATTVpf0dHQVyPJHTkOITvXfaSqnRk6mdDhV9pR8T/tHc3cex78IKXssmzrA==",
-          "dev": true
-        },
-        "@emotion/weak-memoize": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.4.tgz",
-          "integrity": "sha512-6PYY5DVdAY1ifaQW6XYTnOMihmBVT27elqSjEoodchsGjzYlEsTQMcEhSud99kVawatyTZRTiVkJ/c6lwbQ7nA==",
-          "dev": true
-        },
         "@storybook/addons": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.2.3.tgz",
-          "integrity": "sha512-LTkUJB8ZDc4++yt9acNHNjlnGWCyNtP+NVYPDvg7zFOaMip21Pj4T0pg9UwYxdqrFBWz9tVz7DJeXroS3egXxg==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.2.4.tgz",
+          "integrity": "sha512-Q+bnVlBA308qnELxnh18hBDRSUgltR9KbV537285dUL/okv/NC6n51mxJwIaG+ksBW2wU+5e6tqSayaKF3uHLw==",
           "dev": true,
           "requires": {
-            "@storybook/api": "5.2.3",
-            "@storybook/channels": "5.2.3",
-            "@storybook/client-logger": "5.2.3",
-            "@storybook/core-events": "5.2.3",
+            "@storybook/api": "5.2.4",
+            "@storybook/channels": "5.2.4",
+            "@storybook/client-logger": "5.2.4",
+            "@storybook/core-events": "5.2.4",
             "core-js": "^3.0.1",
             "global": "^4.3.2",
             "util-deprecate": "^1.0.2"
           }
         },
         "@storybook/api": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.2.3.tgz",
-          "integrity": "sha512-2csxa/d64rXy4Dwoc7YjbPeNUJRgcI/wJUo30CLujk2stEFzDnKeMPR1mlHMCIFDW+KDxJ28bW59VPxwrqJFjw==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.2.4.tgz",
+          "integrity": "sha512-KqAB+NkHIHdwu749NDP+7i44jy1bFgpq7GTJlG+sx/XLZHQveK/8yn109g9bXHFth7SvdXI1+9GA/apzwBU/Mw==",
           "dev": true,
           "requires": {
-            "@storybook/channels": "5.2.3",
-            "@storybook/client-logger": "5.2.3",
-            "@storybook/core-events": "5.2.3",
-            "@storybook/router": "5.2.3",
-            "@storybook/theming": "5.2.3",
+            "@storybook/channels": "5.2.4",
+            "@storybook/client-logger": "5.2.4",
+            "@storybook/core-events": "5.2.4",
+            "@storybook/router": "5.2.4",
+            "@storybook/theming": "5.2.4",
             "core-js": "^3.0.1",
             "fast-deep-equal": "^2.0.1",
             "global": "^4.3.2",
@@ -4513,31 +4072,31 @@
           }
         },
         "@storybook/channels": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.2.3.tgz",
-          "integrity": "sha512-13Mlb+XbE0mHXiLLHdg0w9byhRy/bE605U7U96PGQp2cwX4lf+4jpViO2mDCsndAFRc0+2hexXPTkwgzvZzq0A==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.2.4.tgz",
+          "integrity": "sha512-/r39yEZ5QiGdiq95DhXBypdBo7urkD3Sp1WDyK48uGkZ0gdHWSPy3BBy8OJhEhfNz7nVisTiVIBr4gIrubKDjw==",
           "dev": true,
           "requires": {
             "core-js": "^3.0.1"
           }
         },
         "@storybook/client-logger": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.2.3.tgz",
-          "integrity": "sha512-Z1irXW4jiFs7rClgqJqYOgg5op51ynV6dVuoIqxkSC0MrOG5s/VbX7T+ojGPXKyQWD4XYGw66Hnw9jouSfXL9g==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.2.4.tgz",
+          "integrity": "sha512-ofp6QQPQZBU+RvlAH5KpZRsfAFHecCZDnl/7YG6FwjHseJr3jHTYmBGGjJDMHFHq+Q7FGQu/yVb9lMFgoQ43QQ==",
           "dev": true,
           "requires": {
             "core-js": "^3.0.1"
           }
         },
         "@storybook/components": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-5.2.3.tgz",
-          "integrity": "sha512-EiWKa3xONP2BPxrssiRdvKELhF2tO14HVL131CCFY+Zg/ylExzWWWVSBun7vYcKhkI52K5lmvC1vFSsB6Gmlhw==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-5.2.4.tgz",
+          "integrity": "sha512-APhw+XGag0RTCRJ8eCWKVr8dLt9SRqnS8LtzcZJbokCYRxRTFzhmX2eVEE1v+d0gHib1/yh2COxOjMzv3m/rQA==",
           "dev": true,
           "requires": {
-            "@storybook/client-logger": "5.2.3",
-            "@storybook/theming": "5.2.3",
+            "@storybook/client-logger": "5.2.4",
+            "@storybook/theming": "5.2.4",
             "@types/react-syntax-highlighter": "10.1.0",
             "core-js": "^3.0.1",
             "global": "^4.3.2",
@@ -4557,18 +4116,18 @@
           }
         },
         "@storybook/core-events": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.2.3.tgz",
-          "integrity": "sha512-sZEv93yE1o+/UJdhtqQ6vo2EauZ90FjN/L8F7CR7iqDEZzqo9g77Idg9LSgcN3TAeXcGAWVSrPb1vkK7H96L2g==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.2.4.tgz",
+          "integrity": "sha512-nQknCmaz2S2HW6PSGcuFzve7Y1Js2Cb268vUG0ZMNtJZwFawqYc+KSQHqmOY0pVm8dyROTcWCudPA0k+hk6N5Q==",
           "dev": true,
           "requires": {
             "core-js": "^3.0.1"
           }
         },
         "@storybook/router": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.2.3.tgz",
-          "integrity": "sha512-sOu6y2GySaY82SdXfF3yOn0IJTKMqd2BDOSGEno7PWWtSenHFQWY+z99C9k0dLBTkjRes5tPcgm0OJ7RdQVRDQ==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.2.4.tgz",
+          "integrity": "sha512-GL7eGdj5oYST0mE9fThJB9ye9tTTgrP+aP3okZ6MeMGtNytb7bmJRpAD2E4ouuPTQVppyHI5re8g/HUxUNOT1g==",
           "dev": true,
           "requires": {
             "@reach/router": "^1.2.1",
@@ -4581,14 +4140,14 @@
           }
         },
         "@storybook/theming": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.2.3.tgz",
-          "integrity": "sha512-3/0bo8CaoaHDYZaexydpYcwP6WW8BKRqSQBGXJY9y0TLhwY2Who5nPX9XdOLyu9d7lN//PRZlt8JnZynuncxoQ==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.2.4.tgz",
+          "integrity": "sha512-2ZlqBrmnm8N0352Fnu2+GB3pEsHL4Eb2eKxV0VLLgkjJuAlm7CK6+I/e4ZknQWxwYm2pQj1y6ta68A62fGBYyA==",
           "dev": true,
           "requires": {
             "@emotion/core": "^10.0.14",
             "@emotion/styled": "^10.0.14",
-            "@storybook/client-logger": "5.2.3",
+            "@storybook/client-logger": "5.2.4",
             "common-tags": "^1.8.0",
             "core-js": "^3.0.1",
             "deep-object-diff": "^1.1.0",
@@ -4599,36 +4158,6 @@
             "prop-types": "^15.7.2",
             "resolve-from": "^5.0.0"
           }
-        },
-        "babel-plugin-emotion": {
-          "version": "10.0.21",
-          "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.21.tgz",
-          "integrity": "sha512-03o+T6sfVAJhNDcSdLapgv4IeewcFPzxlvBUVdSf7o5PI57ZSxoDvmy+ZulVWSu+rOWAWkEejNcsb29TuzJHbg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-module-imports": "^7.0.0",
-            "@emotion/hash": "0.7.3",
-            "@emotion/memoize": "0.7.3",
-            "@emotion/serialize": "^0.11.11",
-            "babel-plugin-macros": "^2.0.0",
-            "babel-plugin-syntax-jsx": "^6.18.0",
-            "convert-source-map": "^1.5.0",
-            "escape-string-regexp": "^1.0.5",
-            "find-root": "^1.1.0",
-            "source-map": "^0.5.7"
-          }
-        },
-        "isobject": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
-          "dev": true
-        },
-        "process": {
-          "version": "0.11.10",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-          "dev": true
         },
         "qs": {
           "version": "6.9.0",
@@ -4653,40 +4182,6 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
-        },
-        "telejson": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/telejson/-/telejson-3.0.3.tgz",
-          "integrity": "sha512-gUOh6wox1zJjbGMg+e26NquZcp/F18EbIaqVvjiGqikRqVB4fYEAM8Nyin8smgwX30XhaRBOg+kCj4vInmvwAg==",
-          "dev": true,
-          "requires": {
-            "@types/is-function": "^1.0.0",
-            "global": "^4.4.0",
-            "is-function": "^1.0.1",
-            "is-regex": "^1.0.4",
-            "is-symbol": "^1.0.2",
-            "isobject": "^4.0.0",
-            "lodash": "^4.17.15",
-            "memoizerific": "^1.11.3"
-          },
-          "dependencies": {
-            "global": {
-              "version": "4.4.0",
-              "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
-              "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-              "dev": true,
-              "requires": {
-                "min-document": "^2.19.0",
-                "process": "^0.11.10"
-              }
-            },
-            "lodash": {
-              "version": "4.17.15",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-              "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-              "dev": true
-            }
-          }
         }
       }
     },
@@ -4950,9 +4445,9 @@
       }
     },
     "@types/webpack-env": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.14.0.tgz",
-      "integrity": "sha512-Fv+0gYJzE/czLoRKq+gnXWr4yBpPM3tO3C8pDLFwqVKlMICQUq5OsxwwFZYDaVr7+L6mgNDp16iOcJHEz3J5RQ==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.14.1.tgz",
+      "integrity": "sha512-0Ki9jAAhKDSuLDXOIMADg54Hu60SuBTEsWaJGGy5cV+SSUQ63J2a+RrYYGrErzz39fXzTibhKrAQJAb8M7PNcA==",
       "dev": true
     },
     "@types/yargs": {
@@ -5445,12 +4940,12 @@
       }
     },
     "ansi-to-html": {
-      "version": "0.6.11",
-      "resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.6.11.tgz",
-      "integrity": "sha512-88XZtrcwrfkyn6fGstHnkaF1kl7hGtNCYh4vSmItgEV+6JnQHryDBf7udF4f2RhTRQmYvJvPcTtqgaqrxzc9oA==",
+      "version": "0.6.12",
+      "resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.6.12.tgz",
+      "integrity": "sha512-qBkIqLW979675mP76yB7yVkzeAWtATegdnDQ0RA3CZzknx0yUlNxMSML4xFdBfTs2GWYFQ1FELfbGbVSPzJ+LA==",
       "dev": true,
       "requires": {
-        "entities": "^1.1.1"
+        "entities": "^1.1.2"
       }
     },
     "any-base": {
@@ -5658,25 +5153,65 @@
       "dev": true
     },
     "array.prototype.flat": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz",
-      "integrity": "sha512-rVqIs330nLJvfC7JqYvEWwqVr5QjYF1ib02i3YJtR/fICO6527Tjpc/e4Mvmxh3GIePPreRXMdaGyC99YphWEw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.2.tgz",
+      "integrity": "sha512-VXjh7lAL4KXKF2hY4FnEW9eRW6IhdvFW1sN/JwLbmECbCgACCnBHNyP3lFiYuttr0jxRN9Bsc5+G27dMseSWqQ==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.10.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.15.0",
         "function-bind": "^1.1.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
+          "integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.0",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.0",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.6.0",
+            "object-keys": "^1.1.1",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "array.prototype.flatmap": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.1.tgz",
-      "integrity": "sha512-i18e2APdsiezkcqDyZor78Pbfjfds3S94dG6dgIV2ZASJaUf1N0dz2tGdrmwrmlZuNUgxH+wz6Z0zYVH2c5xzQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.2.tgz",
+      "integrity": "sha512-ZZtPLE74KNE+0XcPv/vQmcivxN+8FhwOLvt2udHauO0aDEpsXDQrmd5HuJGpgPVyaV8HvkDPWnJ2iaem0oCKtA==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.10.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.15.0",
         "function-bind": "^1.1.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
+          "integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.0",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.0",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.6.0",
+            "object-keys": "^1.1.1",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "arrify": {
@@ -7691,12 +7226,12 @@
       "dev": true
     },
     "core-js-compat": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.2.1.tgz",
-      "integrity": "sha512-MwPZle5CF9dEaMYdDeWm73ao/IflDH+FjeJCWEADcEgFSE9TLimFKwJsfmkwzI8eC0Aj0mgvMDjeQjrElkz4/A==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.3.2.tgz",
+      "integrity": "sha512-gfiK4QnNXhnnHVOIZst2XHdFfdMTPxtR0EGs0TdILMlGIft+087oH6/Sw2xTTIjpWXC9vEwsJA8VG3XTGcmO5g==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.6.6",
+        "browserslist": "^4.7.0",
         "semver": "^6.3.0"
       },
       "dependencies": {
@@ -7718,15 +7253,15 @@
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.277",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.277.tgz",
-          "integrity": "sha512-Czmsrgng89DOgJlIknnw9bn5431QdtnUwGp5YYiPwU1DbZQUxCLF+rc1ZC09VNAdalOPcvH6AE8BaA0H5HjI/w==",
+          "version": "1.3.282",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.282.tgz",
+          "integrity": "sha512-irSaDeCGgfMu1OA30bhqIBr+dx+pDJjRbwCpob7YWqVZbzXblybNzPGklVnWqv4EXxbkEAzQYqiNCqNTgu00lQ==",
           "dev": true
         },
         "node-releases": {
-          "version": "1.1.34",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.34.tgz",
-          "integrity": "sha512-fNn12JTEfniTuCqo0r9jXgl44+KxRH/huV7zM/KAGOKxDKrHr6EbT7SSs4B+DNxyBE2mks28AD+Jw6PkfY5uwA==",
+          "version": "1.1.35",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.35.tgz",
+          "integrity": "sha512-JGcM/wndCN/2elJlU0IGdVEJQQnJwsLbgPCFd2pY7V0mxf17bZ0Gb/lgOtL29ZQhvEX5shnVhxQyZz3ex94N8w==",
           "dev": true,
           "requires": {
             "semver": "^6.3.0"
@@ -7741,9 +7276,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.2.1.tgz",
-      "integrity": "sha512-+qpvnYrsi/JDeQTArB7NnNc2VoMYLE1YSkziCDHgjexC2KH7OFiGhLUd3urxfyWmNjSwSW7NYXPWHMhuIJx9Ow==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.3.2.tgz",
+      "integrity": "sha512-sw695hB0UxFXrSkUthEby5tMdjOYN3hVC8IGQePF1m3JYb9e/KjT0TOFWzaSzlKwGNglKCgLYUjiJ7uZvactiw==",
       "dev": true
     },
     "core-util-is": {
@@ -11426,12 +10961,12 @@
           "dev": true
         },
         "uglify-js": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-          "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.1.tgz",
+          "integrity": "sha512-+dSJLJpXBb6oMHP+Yvw8hUgElz4gLTh82XuX68QiJVTXaE5ibl6buzhNkQdYhBlIhozWOC9ge16wyRmjG4TwVQ==",
           "dev": true,
           "requires": {
-            "commander": "~2.20.0",
+            "commander": "2.20.0",
             "source-map": "~0.6.1"
           }
         }
@@ -13260,9 +12795,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.6.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
-          "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
+          "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
           "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.2"
@@ -16424,9 +15959,9 @@
           }
         },
         "electron-to-chromium": {
-          "version": "1.3.277",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.277.tgz",
-          "integrity": "sha512-Czmsrgng89DOgJlIknnw9bn5431QdtnUwGp5YYiPwU1DbZQUxCLF+rc1ZC09VNAdalOPcvH6AE8BaA0H5HjI/w==",
+          "version": "1.3.282",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.282.tgz",
+          "integrity": "sha512-irSaDeCGgfMu1OA30bhqIBr+dx+pDJjRbwCpob7YWqVZbzXblybNzPGklVnWqv4EXxbkEAzQYqiNCqNTgu00lQ==",
           "dev": true
         },
         "inquirer": {
@@ -16457,9 +15992,9 @@
           "dev": true
         },
         "node-releases": {
-          "version": "1.1.34",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.34.tgz",
-          "integrity": "sha512-fNn12JTEfniTuCqo0r9jXgl44+KxRH/huV7zM/KAGOKxDKrHr6EbT7SSs4B+DNxyBE2mks28AD+Jw6PkfY5uwA==",
+          "version": "1.1.35",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.35.tgz",
+          "integrity": "sha512-JGcM/wndCN/2elJlU0IGdVEJQQnJwsLbgPCFd2pY7V0mxf17bZ0Gb/lgOtL29ZQhvEX5shnVhxQyZz3ex94N8w==",
           "dev": true,
           "requires": {
             "semver": "^6.3.0"
@@ -16690,9 +16225,9 @@
       }
     },
     "react-sizeme": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/react-sizeme/-/react-sizeme-2.6.7.tgz",
-      "integrity": "sha512-xCjPoBP5jmeW58TxIkcviMZqabZis7tTvDFWf0/Wa5XCgVWQTIe74NQBes2N1Kmp64GRLkpm60BaP0kk+v8aCQ==",
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/react-sizeme/-/react-sizeme-2.6.8.tgz",
+      "integrity": "sha512-eJKHV226d/S3st2He7bLIlY7FAmi2ItvZmUCmLLNjIvYjtiv58BksuFhTBQmvAxWaXZGb3Ao/44wfAS1voRdjA==",
       "dev": true,
       "requires": {
         "element-resize-detector": "^1.1.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4232,10 +4232,22 @@
       "integrity": "sha512-bWG5wapaWgbss9E238T0R6bfo5Fh3OkeoSt245CM7JJwVwpw6MEBCbIxLq5z8KzsE3uJhzcIuQkyiZmzV3M/Dw==",
       "dev": true
     },
+    "@types/error-stack-parser": {
+      "version": "1.3.18",
+      "resolved": "https://registry.npmjs.org/@types/error-stack-parser/-/error-stack-parser-1.3.18.tgz",
+      "integrity": "sha1-4ByfjIXKg7YQMgxiJYsMkCat4Pc=",
+      "dev": true
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
+      "dev": true
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
     "@types/events": {
@@ -4329,6 +4341,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.144",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.144.tgz",
+      "integrity": "sha512-ogI4g9W5qIQQUhXAclq6zhqgqNUr7UlFaqDHbch7WLSLeeM/7d3CRaw7GLajxvyFvhJqw4Rpcz5bhoaYtIx6Tg==",
       "dev": true
     },
     "@types/minimatch": {
@@ -4777,6 +4795,15 @@
         "acorn-walk": "^6.0.1"
       }
     },
+    "acorn-hammerhead": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/acorn-hammerhead/-/acorn-hammerhead-0.3.0.tgz",
+      "integrity": "sha512-Izrr9mXONhWc7q8fqUe6ijQy+KjmyQlgdWARgaCVjds+nPpoSS298FY8uSVN/to8nKVTtkJpafNUlACWxwZS5w==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "^0.0.39"
+      }
+    },
     "acorn-jsx": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
@@ -4861,6 +4888,12 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
       "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
+      "dev": true
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
     "ansi-align": {
@@ -5109,6 +5142,12 @@
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
+    "array-find": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
+      "integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=",
+      "dev": true
+    },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -5226,6 +5265,21 @@
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true
     },
+    "asar": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/asar/-/asar-2.0.1.tgz",
+      "integrity": "sha512-Vo9yTuUtyFahkVMFaI6uMuX6N7k5DWa6a/8+7ov0/f8Lq9TVR0tUjzSzxQSxT1Y+RJIZgnP7BVb6Uhi+9cjxqA==",
+      "dev": true,
+      "requires": {
+        "chromium-pickle-js": "^0.2.0",
+        "commander": "^2.20.0",
+        "cuint": "^0.2.2",
+        "glob": "^7.1.3",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "tmp-promise": "^1.0.5"
+      }
+    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -5279,6 +5333,12 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -5310,6 +5370,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+      "dev": true
+    },
+    "async-exit-hook": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-1.1.2.tgz",
+      "integrity": "sha1-gJXXXkiMKazuBVH+hyUhadeJz7o=",
       "dev": true
     },
     "async-limiter": {
@@ -5440,6 +5506,96 @@
         }
       }
     },
+    "babel-core": {
+      "version": "6.26.3",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.1",
+        "debug": "^2.6.9",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.8",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.7"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+          "dev": true
+        }
+      }
+    },
+    "babel-generator": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+      "dev": true,
+      "requires": {
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "detect-indent": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+          "dev": true,
+          "requires": {
+            "repeating": "^2.0.0"
+          }
+        },
+        "jsesc": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+          "dev": true
+        }
+      }
+    },
+    "babel-helper-bindify-decorators": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
+      "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-builder-binary-assignment-operator-visitor": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+      "dev": true,
+      "requires": {
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
     "babel-helper-builder-react-jsx": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
@@ -5451,17 +5607,97 @@
         "esutils": "^2.0.2"
       }
     },
+    "babel-helper-call-delegate": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-define-map": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
+      }
+    },
     "babel-helper-evaluate-path": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.5.0.tgz",
       "integrity": "sha512-mUh0UhS607bGh5wUMAQfOpt2JX2ThXMtppHRdRU1kL7ZLRWIXxoV2UIV1r2cAeeNeU1M5SB5/RSUgUxrK8yOkA==",
       "dev": true
     },
+    "babel-helper-explode-assignable-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-explode-class": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
+      "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
+      "dev": true,
+      "requires": {
+        "babel-helper-bindify-decorators": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
     "babel-helper-flip-expressions": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.4.3.tgz",
       "integrity": "sha1-NpZzahKKwYvCUlS19AoizrPB0/0=",
       "dev": true
+    },
+    "babel-helper-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+      "dev": true,
+      "requires": {
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-get-function-arity": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-hoist-variables": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
     },
     "babel-helper-is-nodes-equiv": {
       "version": "0.0.1",
@@ -5481,17 +5717,75 @@
       "integrity": "sha1-0kSjvvmESHJgP/tG4izorN9VFWI=",
       "dev": true
     },
+    "babel-helper-optimise-call-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-regex": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "babel-helper-remap-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
     "babel-helper-remove-or-void": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.3.tgz",
       "integrity": "sha1-pPA7QAd6D/6I5F0HAQ3uJB/1rmA=",
       "dev": true
     },
+    "babel-helper-replace-supers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+      "dev": true,
+      "requires": {
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
     "babel-helper-to-multiple-sequence-expressions": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.5.0.tgz",
       "integrity": "sha512-m2CvfDW4+1qfDdsrtf4dwOslQC3yhbgyBFptncp4wvtdrDHqueW7slsYv4gArie056phvQFhT2nRcGS4bnm6mA==",
       "dev": true
+    },
+    "babel-helpers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
     },
     "babel-jest": {
       "version": "24.9.0",
@@ -5528,11 +5822,29 @@
         "pify": "^4.0.1"
       }
     },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
     "babel-plugin-add-react-displayname": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/babel-plugin-add-react-displayname/-/babel-plugin-add-react-displayname-0.0.5.tgz",
       "integrity": "sha1-M51M3be2X9YtHfnbn+BN4TQSK9U=",
       "dev": true
+    },
+    "babel-plugin-check-es2015-constants": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
     },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.0",
@@ -5687,6 +5999,42 @@
         "babel-helper-is-void-0": "^0.4.3"
       }
     },
+    "babel-plugin-syntax-async-functions": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+      "dev": true
+    },
+    "babel-plugin-syntax-async-generators": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
+      "integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
+      "dev": true
+    },
+    "babel-plugin-syntax-class-properties": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
+      "dev": true
+    },
+    "babel-plugin-syntax-decorators": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
+      "integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs=",
+      "dev": true
+    },
+    "babel-plugin-syntax-dynamic-import": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
+      "dev": true
+    },
+    "babel-plugin-syntax-exponentiation-operator": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+      "dev": true
+    },
     "babel-plugin-syntax-flow": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
@@ -5699,11 +6047,343 @@
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
       "dev": true
     },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+      "dev": true
+    },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "7.0.0-beta.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
       "integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==",
       "dev": true
+    },
+    "babel-plugin-transform-async-generator-functions": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
+      "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
+      "dev": true,
+      "requires": {
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-generators": "^6.5.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+      "dev": true,
+      "requires": {
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-class-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
+      "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-plugin-syntax-class-properties": "^6.8.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-decorators": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
+      "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
+      "dev": true,
+      "requires": {
+        "babel-helper-explode-class": "^6.24.1",
+        "babel-plugin-syntax-decorators": "^6.13.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-arrow-functions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoped-functions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoping": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "babel-plugin-transform-es2015-classes": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+      "dev": true,
+      "requires": {
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-computed-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-destructuring": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-duplicate-keys": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-for-of": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-amd": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-commonjs": {
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+      "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-systemjs": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-umd": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-object-super": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+      "dev": true,
+      "requires": {
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-parameters": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+      "dev": true,
+      "requires": {
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-shorthand-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-spread": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-sticky-regex": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-template-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-typeof-symbol": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-unicode-regex": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        },
+        "regexpu-core": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+          "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+          "dev": true,
+          "requires": {
+            "regenerate": "^1.2.1",
+            "regjsgen": "^0.2.0",
+            "regjsparser": "^0.1.4"
+          }
+        },
+        "regjsgen": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+          "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+          "dev": true
+        },
+        "regjsparser": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+          "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+          "dev": true,
+          "requires": {
+            "jsesc": "~0.5.0"
+          }
+        }
+      }
+    },
+    "babel-plugin-transform-exponentiation-operator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+      "dev": true,
+      "requires": {
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
     },
     "babel-plugin-transform-flow-strip-types": {
       "version": "6.22.0",
@@ -5714,6 +6394,12 @@
         "babel-plugin-syntax-flow": "^6.18.0",
         "babel-runtime": "^6.22.0"
       }
+    },
+    "babel-plugin-transform-for-of-as-array": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-for-of-as-array/-/babel-plugin-transform-for-of-as-array-1.1.1.tgz",
+      "integrity": "sha512-eE4hZJhOUKpX0q/X3adR8B4hLox+t8oe4ZqmhANUmv4cds07AbWt6O0rtFXK7PKFPPnW4nz/5mpbkPMkflyGeg==",
+      "dev": true
     },
     "babel-plugin-transform-inline-consecutive-adds": {
       "version": "0.4.3",
@@ -5738,6 +6424,16 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.4.tgz",
       "integrity": "sha1-rLs+VqNVXdI5KOS1gtKFFi3SsZg=",
       "dev": true
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+        "babel-runtime": "^6.26.0"
+      }
     },
     "babel-plugin-transform-property-literals": {
       "version": "6.9.4",
@@ -5788,6 +6484,28 @@
         "babel-runtime": "^6.22.0"
       }
     },
+    "babel-plugin-transform-regenerator": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "^0.10.0"
+      },
+      "dependencies": {
+        "regenerator-transform": {
+          "version": "0.10.1",
+          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+          "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.18.0",
+            "babel-types": "^6.19.0",
+            "private": "^0.1.6"
+          }
+        }
+      }
+    },
     "babel-plugin-transform-regexp-constructors": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.3.tgz",
@@ -5815,11 +6533,30 @@
         "babel-helper-evaluate-path": "^0.5.0"
       }
     },
+    "babel-plugin-transform-runtime": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
+      "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
     "babel-plugin-transform-simplify-comparison-operators": {
       "version": "6.9.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.4.tgz",
       "integrity": "sha1-9ir+CWyrDh9ootdT/fKDiIRxzrk=",
       "dev": true
+    },
+    "babel-plugin-transform-strict-mode": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
     },
     "babel-plugin-transform-undefined-to-void": {
       "version": "6.9.4",
@@ -5849,6 +6586,62 @@
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
           "dev": true
+        }
+      }
+    },
+    "babel-preset-env": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
+      "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-to-generator": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+        "babel-plugin-transform-es2015-classes": "^6.23.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+        "babel-plugin-transform-es2015-for-of": "^6.23.0",
+        "babel-plugin-transform-es2015-function-name": "^6.22.0",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+        "babel-plugin-transform-es2015-object-super": "^6.22.0",
+        "babel-plugin-transform-es2015-parameters": "^6.23.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+        "babel-plugin-transform-regenerator": "^6.22.0",
+        "browserslist": "^3.2.6",
+        "invariant": "^2.2.2",
+        "semver": "^5.3.0"
+      },
+      "dependencies": {
+        "babel-plugin-syntax-trailing-function-commas": {
+          "version": "6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+          "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+          "dev": true
+        },
+        "browserslist": {
+          "version": "3.2.8",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+          "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30000844",
+            "electron-to-chromium": "^1.3.47"
+          }
         }
       }
     },
@@ -5951,6 +6744,71 @@
         "babel-preset-flow": "^6.23.0"
       }
     },
+    "babel-preset-stage-2": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
+      "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-dynamic-import": "^6.18.0",
+        "babel-plugin-transform-class-properties": "^6.24.1",
+        "babel-plugin-transform-decorators": "^6.24.1",
+        "babel-preset-stage-3": "^6.24.1"
+      }
+    },
+    "babel-preset-stage-3": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
+      "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-generator-functions": "^6.24.1",
+        "babel-plugin-transform-async-to-generator": "^6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "^6.24.1",
+        "babel-plugin-transform-object-rest-spread": "^6.22.0"
+      },
+      "dependencies": {
+        "babel-plugin-syntax-trailing-function-commas": {
+          "version": "6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+          "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+          "dev": true
+        }
+      }
+    },
+    "babel-register": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "dev": true,
+      "requires": {
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.10",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.4.18",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+          "dev": true,
+          "requires": {
+            "source-map": "^0.5.6"
+          }
+        }
+      }
+    },
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
@@ -5975,6 +6833,44 @@
         }
       }
     },
+    "babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "9.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "dev": true
+        }
+      }
+    },
     "babel-types": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
@@ -5994,6 +6890,12 @@
           "dev": true
         }
       }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true
     },
     "bail": {
       "version": "1.0.4",
@@ -6089,6 +6991,12 @@
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true
     },
+    "bin-v8-flags-filter": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bin-v8-flags-filter/-/bin-v8-flags-filter-1.2.0.tgz",
+      "integrity": "sha512-g8aeYkY7GhyyKRvQMBsJQZjhm2iCX3dKYvfrMpwVR8IxmUGrkpCBFoKbB9Rh0o3sTLCjU/1tFpZ4C7j3f+D+3g==",
+      "dev": true
+    },
     "binary-extensions": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
@@ -6165,6 +7073,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+      "dev": true
+    },
+    "bowser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.6.0.tgz",
+      "integrity": "sha1-N/w4e2Fstq7zcNq01r1AK3TFxU0=",
       "dev": true
     },
     "boxen": {
@@ -6261,6 +7175,15 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
+    },
+    "brotli": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.2.tgz",
+      "integrity": "sha1-UlqcrU/LqWR119OI9q7LE+7VL0Y=",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.1.2"
+      }
     },
     "browser-process-hrtime": {
       "version": "0.1.3",
@@ -6510,6 +7433,28 @@
         "caller-callsite": "^2.0.0"
       }
     },
+    "callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
+      "dev": true
+    },
+    "callsite-record": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/callsite-record/-/callsite-record-4.1.3.tgz",
+      "integrity": "sha512-otAcPmu8TiHZ38cIL3NjQa1nGoSQRRe8WDDUgj5ZUwJWn1wzOYBwVSJbpVyzZ0sesQeKlYsPu9DG70fhh6AK9g==",
+      "dev": true,
+      "requires": {
+        "@types/error-stack-parser": "^1.3.18",
+        "@types/lodash": "^4.14.72",
+        "callsite": "^1.0.0",
+        "chalk": "^2.4.0",
+        "error-stack-parser": "^1.3.3",
+        "highlight-es": "^1.0.0",
+        "lodash": "4.6.1 || ^4.16.1",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
     "callsites": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
@@ -6590,6 +7535,20 @@
       "integrity": "sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==",
       "dev": true
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -6657,6 +7616,12 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
     "chokidar": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
@@ -6691,6 +7656,41 @@
       "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
       "dev": true
     },
+    "chrome-emulated-devices-list": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/chrome-emulated-devices-list/-/chrome-emulated-devices-list-0.1.1.tgz",
+      "integrity": "sha512-wQu6YKNTNGaUXovpkvXLnfeumVK47r2TKpOuCTwOKv/5SmRzfHual+E+oDIwS3KFWAcJPAhoNRAOLvXwzC6/pw==",
+      "dev": true
+    },
+    "chrome-remote-interface": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.25.7.tgz",
+      "integrity": "sha512-6zI6LbR2IiGmduFZededaerEr9hHXabxT/L+fRrdq65a0CfyLMzpq0BKuZiqN0Upqcacsb6q2POj7fmobwBsEA==",
+      "dev": true,
+      "requires": {
+        "commander": "2.11.x",
+        "ws": "3.3.x"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
+        },
+        "ws": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0",
+            "ultron": "~1.1.0"
+          }
+        }
+      }
+    },
     "chrome-trace-event": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
@@ -6699,6 +7699,12 @@
       "requires": {
         "tslib": "^1.9.0"
       }
+    },
+    "chromium-pickle-js": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
+      "integrity": "sha1-BKEGZywYsIWrd02YPfo+oTjyIgU=",
+      "dev": true
     },
     "ci-info": {
       "version": "2.0.0",
@@ -6931,6 +7937,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "coffeescript": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.4.1.tgz",
+      "integrity": "sha512-34GV1aHrsMpTaO3KfMJL40ZNuvKDR/g98THHnE9bQj8HjMaZvSrLik99WWqyMhRtbe8V5hpx5iLgdcSvM/S2wg==",
       "dev": true
     },
     "collapse-white-space": {
@@ -7226,12 +8238,12 @@
       "dev": true
     },
     "core-js-compat": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.3.2.tgz",
-      "integrity": "sha512-gfiK4QnNXhnnHVOIZst2XHdFfdMTPxtR0EGs0TdILMlGIft+087oH6/Sw2xTTIjpWXC9vEwsJA8VG3XTGcmO5g==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.2.1.tgz",
+      "integrity": "sha512-MwPZle5CF9dEaMYdDeWm73ao/IflDH+FjeJCWEADcEgFSE9TLimFKwJsfmkwzI8eC0Aj0mgvMDjeQjrElkz4/A==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.7.0",
+        "browserslist": "^4.6.6",
         "semver": "^6.3.0"
       },
       "dependencies": {
@@ -7253,15 +8265,15 @@
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.282",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.282.tgz",
-          "integrity": "sha512-irSaDeCGgfMu1OA30bhqIBr+dx+pDJjRbwCpob7YWqVZbzXblybNzPGklVnWqv4EXxbkEAzQYqiNCqNTgu00lQ==",
+          "version": "1.3.277",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.277.tgz",
+          "integrity": "sha512-Czmsrgng89DOgJlIknnw9bn5431QdtnUwGp5YYiPwU1DbZQUxCLF+rc1ZC09VNAdalOPcvH6AE8BaA0H5HjI/w==",
           "dev": true
         },
         "node-releases": {
-          "version": "1.1.35",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.35.tgz",
-          "integrity": "sha512-JGcM/wndCN/2elJlU0IGdVEJQQnJwsLbgPCFd2pY7V0mxf17bZ0Gb/lgOtL29ZQhvEX5shnVhxQyZz3ex94N8w==",
+          "version": "1.1.34",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.34.tgz",
+          "integrity": "sha512-fNn12JTEfniTuCqo0r9jXgl44+KxRH/huV7zM/KAGOKxDKrHr6EbT7SSs4B+DNxyBE2mks28AD+Jw6PkfY5uwA==",
           "dev": true,
           "requires": {
             "semver": "^6.3.0"
@@ -7276,9 +8288,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.3.2.tgz",
-      "integrity": "sha512-sw695hB0UxFXrSkUthEby5tMdjOYN3hVC8IGQePF1m3JYb9e/KjT0TOFWzaSzlKwGNglKCgLYUjiJ7uZvactiw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.2.1.tgz",
+      "integrity": "sha512-+qpvnYrsi/JDeQTArB7NnNc2VoMYLE1YSkziCDHgjexC2KH7OFiGhLUd3urxfyWmNjSwSW7NYXPWHMhuIJx9Ow==",
       "dev": true
     },
     "core-util-is": {
@@ -7448,6 +8460,35 @@
         "randomfill": "^1.0.3"
       }
     },
+    "crypto-md5": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-md5/-/crypto-md5-1.0.0.tgz",
+      "integrity": "sha1-zMjadQx1PH7curxUKWdHKjhOhrs=",
+      "dev": true
+    },
+    "css": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.3.tgz",
+      "integrity": "sha512-0W171WccAjQGGTKLhw4m2nnl0zPHUlTO/I8td4XzJgIB8Hg3ZZx71qT4G4eX8OVsSiaAKiUMy73E3nsbPlg2DQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "source-map": "^0.1.38",
+        "source-map-resolve": "^0.5.1",
+        "urix": "^0.1.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "dev": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
+      }
+    },
     "css-blank-pseudo": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz",
@@ -7608,6 +8649,12 @@
       "integrity": "sha512-lAJUJP3M6HxFXbqtGRc0iZrdyeN+WzOWeY0q/VnFzI+kqVrYIzC7bWlKqCW7oCIdzoPkvfp82EVvrTlQ8zsWQg==",
       "dev": true
     },
+    "cuint": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
+      "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=",
+      "dev": true
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -7700,6 +8747,21 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "dedent": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.4.0.tgz",
+      "integrity": "sha1-h979BAvUwVldljKC7FfzwqhSVkI=",
+      "dev": true
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -7759,6 +8821,55 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
+        }
+      }
+    },
+    "del": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+      "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
+      "dev": true,
+      "requires": {
+        "globby": "^6.1.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "p-map": "^1.1.1",
+        "pify": "^3.0.0",
+        "rimraf": "^2.2.8"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+              "dev": true
+            }
+          }
+        },
+        "p-map": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+          "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+          "dev": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
         }
       }
     },
@@ -8081,6 +9192,12 @@
         "minimalistic-crypto-utils": "^1.0.0"
       }
     },
+    "emittery": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.4.1.tgz",
+      "integrity": "sha512-r4eRSeStEGf6M5SKdrQhhLK5bOwOBxQhIE3YSTnZE3GpKiLfnnhE+tPtrJE79+eDJgm39BM6LSoI8SCx4HbwlQ==",
+      "dev": true
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -8151,6 +9268,33 @@
         "once": "^1.4.0"
       }
     },
+    "endpoint-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/endpoint-utils/-/endpoint-utils-1.0.2.tgz",
+      "integrity": "sha1-CAjDNppyfNeWejn/NOvJJriBRqg=",
+      "dev": true,
+      "requires": {
+        "ip": "^1.1.3",
+        "pinkie-promise": "^1.0.0"
+      },
+      "dependencies": {
+        "pinkie": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
+          "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q=",
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+          "integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
+          "dev": true,
+          "requires": {
+            "pinkie": "^1.0.0"
+          }
+        }
+      }
+    },
     "enhanced-resolve": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
@@ -8184,6 +9328,15 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "error-stack-parser": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.6.tgz",
+      "integrity": "sha1-4Oc7k+QXE40c18C3RrGkoUhUwpI=",
+      "dev": true,
+      "requires": {
+        "stackframe": "^0.3.1"
       }
     },
     "es-abstract": {
@@ -8700,6 +9853,15 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
       "dev": true
+    },
+    "esotope-hammerhead": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/esotope-hammerhead/-/esotope-hammerhead-0.4.0.tgz",
+      "integrity": "sha512-TAmc7OhAiWeovbzE9GGenU2vwuB9tzKHlW0hTH4rZsLmCNEKo8wIZ9qbEnw8nyXeNTjCmBYOYXUyaN+eZht7Tg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "^0.0.39"
+      }
     },
     "espree": {
       "version": "5.0.1",
@@ -10196,6 +11358,12 @@
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
     "get-stdin": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
@@ -10384,6 +11552,15 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
+    },
+    "graphlib": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.7.tgz",
+      "integrity": "sha512-TyI9jIy2J4j0qgPmOOrHTCtpPqJGN/aurBwc6ZT+bRii+di1I+Wv3obRhVrmBEXet+qkMaEX67dXrwsd3QQM6w==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.5"
+      }
     },
     "graphql": {
       "version": "14.5.8",
@@ -10856,6 +12033,25 @@
         "upper-case": "^1.1.3"
       }
     },
+    "highlight-es": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/highlight-es/-/highlight-es-1.0.3.tgz",
+      "integrity": "sha512-s/SIX6yp/5S1p8aC/NRDC1fwEb+myGIfp8/TzZz0rtAv8fzsdX7vGl3Q1TrXCsczFq8DI3CBFBCySPClfBSdbg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.0",
+        "is-es2016-keyword": "^1.0.0",
+        "js-tokens": "^3.0.0"
+      },
+      "dependencies": {
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
+        }
+      }
+    },
     "highlight.js": {
       "version": "9.12.0",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
@@ -10880,6 +12076,16 @@
       "dev": true,
       "requires": {
         "react-is": "^16.7.0"
+      }
+    },
+    "home-or-tmp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
     },
     "hosted-git-info": {
@@ -11477,6 +12683,18 @@
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true
     },
+    "is-docker": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-1.1.0.tgz",
+      "integrity": "sha1-8EN01O7lMQ6ajhE78UlUEeRhdqE=",
+      "dev": true
+    },
+    "is-es2016-keyword": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-es2016-keyword/-/is-es2016-keyword-1.0.0.tgz",
+      "integrity": "sha1-9uVOEQxeT40mXmnS7Q6vjPX0dxg=",
+      "dev": true
+    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -11488,6 +12706,15 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
@@ -11551,6 +12778,12 @@
         }
       }
     },
+    "is-jquery-obj": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-jquery-obj/-/is-jquery-obj-0.1.1.tgz",
+      "integrity": "sha512-18toSebUVF7y717dgw/Dzn6djOCqrkiDp3MhB8P6TdKyCVkbD1ZwE7Uz8Hwx6hUPTvKjbyYH9ncXT4ts4qLaSA==",
+      "dev": true
+    },
     "is-lower-case": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
@@ -11593,6 +12826,30 @@
       "dev": true,
       "requires": {
         "symbol-observable": "^1.1.0"
+      }
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "^1.0.0"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-plain-obj": {
@@ -11672,6 +12929,12 @@
       "requires": {
         "upper-case": "^1.1.0"
       }
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
     },
     "is-valid-path": {
       "version": "0.1.1",
@@ -12857,6 +14120,15 @@
         "type-check": "~0.3.2"
       }
     },
+    "linux-platform-info": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/linux-platform-info/-/linux-platform-info-0.0.3.tgz",
+      "integrity": "sha1-La4yQ4Xmbj11W+yD+Gx77qYc64M=",
+      "dev": true,
+      "requires": {
+        "os-family": "^1.0.0"
+      }
+    },
     "listr": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
@@ -13297,6 +14569,26 @@
         }
       }
     },
+    "log-update-async-hook": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/log-update-async-hook/-/log-update-async-hook-2.0.2.tgz",
+      "integrity": "sha512-HQwkKFTZeUOrDi1Duf2CSUa/pSpcaCHKLdx3D/Z16DsipzByOBffcg5y0JZA1q0n80dYgLXe2hFM9JGNgBsTDw==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^2.0.0",
+        "async-exit-hook": "^1.1.2",
+        "onetime": "^2.0.1",
+        "wrap-ansi": "^2.1.0"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
+          "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=",
+          "dev": true
+        }
+      }
+    },
     "longest-streak": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.3.tgz",
@@ -13418,6 +14710,12 @@
       "integrity": "sha1-beJlMXSt+12e3DPGnT6Sobdvrwg=",
       "dev": true
     },
+    "map-reverse": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-reverse/-/map-reverse-1.0.1.tgz",
+      "integrity": "sha1-J06fUAphEVMYO1uNhJCpwcI+4xA=",
+      "dev": true
+    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -13447,6 +14745,15 @@
       "requires": {
         "prop-types": "^15.6.2",
         "unquote": "^1.1.0"
+      }
+    },
+    "match-url-wildcard": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/match-url-wildcard/-/match-url-wildcard-0.0.4.tgz",
+      "integrity": "sha512-R1XhQaamUZPWLOPtp4ig5j+3jctN+skhgRmEQTUamMzmNtRG69QEirQs0NZKLtHMR7tzWpmtnS4Eqv65DcgXUA==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "material-colors": {
@@ -13730,6 +15037,18 @@
         "minimist": "0.0.8"
       }
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+      "dev": true
+    },
+    "moment-duration-format-commonjs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/moment-duration-format-commonjs/-/moment-duration-format-commonjs-1.0.0.tgz",
+      "integrity": "sha512-MVFR4hIh4jfuwSCPBEE5CCwn3refvTsxK/Yv/DpKJ6YcNnCimlVJ6DQeTJG1KVQPw1o8m3tkbHE9gVjivyv9iA==",
+      "dev": true
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -13750,6 +15069,12 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "mustache": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
+      "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
+      "dev": true
+    },
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
@@ -13762,6 +15087,12 @@
       "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
       "dev": true,
       "optional": true
+    },
+    "nanoid": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-1.3.4.tgz",
+      "integrity": "sha512-4ug4BsuHxiVHoRUe1ud6rUFT3WUMmjXt1W0quL0CviZQANdan7D8kqN5/maw53hmAApY/jfzMRkC57BNNs60ZQ==",
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -13899,6 +15230,12 @@
       "requires": {
         "semver": "^5.3.0"
       }
+    },
+    "node-version": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/node-version/-/node-version-1.2.0.tgz",
+      "integrity": "sha512-ma6oU4Sk0qOoKEAymVoTvk8EdXEobdS7m/mAGhDJ8Rouugho48crHBORAmy5BoOcv8wraPM6xumapQp5hl4iIQ==",
+      "dev": true
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -14225,6 +15562,18 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+      "dev": true
+    },
+    "os-family": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/os-family/-/os-family-1.1.0.tgz",
+      "integrity": "sha512-E3Orl5pvDJXnVmpaAA2TeNNpNhTMl4o5HghuWhOivBjEiTnJSrMYSa5uZMek1lBEvu8kKEsa2YgVcGFVDqX/9w==",
+      "dev": true
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-locale": {
@@ -14567,6 +15916,12 @@
         }
       }
     },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
     "pbkdf2": {
       "version": "3.0.17",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
@@ -14609,6 +15964,21 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
     },
     "pirates": {
       "version": "4.0.1",
@@ -15587,6 +16957,15 @@
         "function-bind": "^1.1.1"
       }
     },
+    "promisify-event": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/promisify-event/-/promisify-event-1.0.0.tgz",
+      "integrity": "sha1-vXUj6ga3AWLzcJeQFrU6aGxg6Q8=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "^2.0.0"
+      }
+    },
     "prompts": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.2.1.tgz",
@@ -15742,6 +17121,12 @@
           "dev": true
         }
       }
+    },
+    "qrcode-terminal": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.10.0.tgz",
+      "integrity": "sha1-p2pI4mEKGPl/o6K9UytoKs/4bFM=",
+      "dev": true
     },
     "qs": {
       "version": "6.5.2",
@@ -16278,6 +17663,15 @@
       "dev": true,
       "requires": {
         "lodash": "^4.0.1"
+      }
+    },
+    "read-file-relative": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/read-file-relative/-/read-file-relative-1.2.0.tgz",
+      "integrity": "sha1-mPfZbqoh0rTHov69Y9L8jPNen5s=",
+      "dev": true,
+      "requires": {
+        "callsite": "^1.0.0"
       }
     },
     "read-pkg": {
@@ -16945,10 +18339,25 @@
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
+    },
     "replace-ext": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
       "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+      "dev": true
+    },
+    "replicator": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/replicator/-/replicator-1.0.3.tgz",
+      "integrity": "sha512-WsKsraaM0x0QHy5CtzdgFXUxyowoBhyNkmPqmZShW6h+rOWnyT6Od3zRdTX9r616rAA6kDC9MKQGnSM/CJKfVQ==",
       "dev": true
     },
     "request": {
@@ -17271,6 +18680,15 @@
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
+      }
+    },
+    "sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "dev": true,
+      "requires": {
+        "truncate-utf8-bytes": "^1.0.0"
       }
     },
     "sax": {
@@ -17878,6 +19296,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
       "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
+      "dev": true
+    },
+    "stackframe": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz",
+      "integrity": "sha1-M6qE8Rd6VUjIk1Uzy/6zQgl19aQ=",
       "dev": true
     },
     "state-toggle": {
@@ -18897,6 +20321,538 @@
         }
       }
     },
+    "testcafe": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-1.5.0.tgz",
+      "integrity": "sha512-qtSUH8csayEW/zVLFNmhglBmQIM38rV0dtWzz5khC1BXyIk1xW+Os5vcrepkS8hIXblpJRG0ugi/2FMzBHhH/A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "^10.12.19",
+        "async-exit-hook": "^1.1.2",
+        "babel-core": "^6.22.1",
+        "babel-plugin-transform-class-properties": "^6.24.1",
+        "babel-plugin-transform-for-of-as-array": "^1.1.1",
+        "babel-plugin-transform-runtime": "^6.22.0",
+        "babel-preset-env": "^1.1.8",
+        "babel-preset-flow": "^6.23.0",
+        "babel-preset-stage-2": "^6.22.0",
+        "babel-runtime": "^6.22.0",
+        "bin-v8-flags-filter": "^1.1.2",
+        "callsite": "^1.0.0",
+        "callsite-record": "^4.0.0",
+        "chai": "^4.1.2",
+        "chalk": "^1.1.0",
+        "chrome-emulated-devices-list": "^0.1.0",
+        "chrome-remote-interface": "^0.25.3",
+        "coffeescript": "^2.3.1",
+        "commander": "^2.8.1",
+        "debug": "^2.2.0",
+        "dedent": "^0.4.0",
+        "del": "^3.0.0",
+        "elegant-spinner": "^1.0.1",
+        "emittery": "^0.4.1",
+        "endpoint-utils": "^1.0.2",
+        "error-stack-parser": "^1.3.6",
+        "globby": "^9.2.0",
+        "graceful-fs": "^4.1.11",
+        "graphlib": "^2.1.5",
+        "import-lazy": "^3.1.0",
+        "indent-string": "^1.2.2",
+        "is-ci": "^1.0.10",
+        "is-docker": "^1.1.0",
+        "is-glob": "^2.0.1",
+        "is-stream": "^1.1.0",
+        "json5": "^2.1.0",
+        "lodash": "^4.17.13",
+        "log-update-async-hook": "^2.0.2",
+        "make-dir": "^1.3.0",
+        "map-reverse": "^1.0.1",
+        "moment": "^2.10.3",
+        "moment-duration-format-commonjs": "^1.0.0",
+        "mustache": "^2.1.2",
+        "nanoid": "^1.0.1",
+        "node-version": "^1.0.0",
+        "os-family": "^1.0.0",
+        "parse5": "^1.5.0",
+        "pify": "^2.3.0",
+        "pinkie": "^2.0.4",
+        "pngjs": "^3.3.1",
+        "promisify-event": "^1.0.0",
+        "qrcode-terminal": "^0.10.0",
+        "read-file-relative": "^1.2.0",
+        "replicator": "^1.0.3",
+        "resolve-cwd": "^1.0.0",
+        "resolve-from": "^4.0.0",
+        "sanitize-filename": "^1.6.0",
+        "source-map-support": "^0.5.5",
+        "strip-bom": "^2.0.0",
+        "testcafe-browser-tools": "1.6.8",
+        "testcafe-hammerhead": "14.9.2",
+        "testcafe-legacy-api": "3.1.11",
+        "testcafe-reporter-json": "^2.1.0",
+        "testcafe-reporter-list": "^2.1.0",
+        "testcafe-reporter-minimal": "^2.1.0",
+        "testcafe-reporter-spec": "^2.1.1",
+        "testcafe-reporter-xunit": "^2.1.0",
+        "time-limit-promise": "^1.0.2",
+        "tmp": "0.0.28",
+        "tree-kill": "^1.1.0",
+        "typescript": "^3.3.3",
+        "useragent": "^2.1.7"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.14.21",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.21.tgz",
+          "integrity": "sha512-nuFlRdBiqbF+PJIEVxm2jLFcQWN7q7iWEJGsBV4n7v1dbI9qXB8im2pMMKMCUZe092sQb5SQft2DHfuQGK5hqQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "ci-info": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+          "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+          "dev": true
+        },
+        "dir-glob": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+          "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+          "dev": true,
+          "requires": {
+            "path-type": "^3.0.0"
+          }
+        },
+        "get-stdin": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+          "dev": true
+        },
+        "globby": {
+          "version": "9.2.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
+          "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
+          "dev": true,
+          "requires": {
+            "@types/glob": "^7.1.1",
+            "array-union": "^1.0.2",
+            "dir-glob": "^2.2.2",
+            "fast-glob": "^2.2.6",
+            "glob": "^7.1.3",
+            "ignore": "^4.0.3",
+            "pify": "^4.0.1",
+            "slash": "^2.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+              "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+              "dev": true
+            }
+          }
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        },
+        "import-lazy": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-3.1.0.tgz",
+          "integrity": "sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==",
+          "dev": true
+        },
+        "indent-string": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+          "integrity": "sha1-25m8xYPrarux5I3LsZmamGBBy2s=",
+          "dev": true,
+          "requires": {
+            "get-stdin": "^4.0.1",
+            "minimist": "^1.1.0",
+            "repeating": "^1.1.0"
+          }
+        },
+        "is-ci": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+          "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+          "dev": true,
+          "requires": {
+            "ci-info": "^1.5.0"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "make-dir": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+              "dev": true
+            }
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "parse5": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
+          "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
+          "dev": true
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "repeating": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+          "dev": true,
+          "requires": {
+            "is-finite": "^1.0.0"
+          }
+        },
+        "resolve-cwd": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-1.0.0.tgz",
+          "integrity": "sha1-Tq7qQe0EDRcCRX32SkKysH0kb58=",
+          "dev": true,
+          "requires": {
+            "resolve-from": "^2.0.0"
+          },
+          "dependencies": {
+            "resolve-from": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+              "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+              "dev": true
+            }
+          }
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        },
+        "tmp": {
+          "version": "0.0.28",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
+          "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "~1.0.1"
+          }
+        }
+      }
+    },
+    "testcafe-browser-tools": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/testcafe-browser-tools/-/testcafe-browser-tools-1.6.8.tgz",
+      "integrity": "sha512-xFgwmcAOutSJR6goqO8uUFGF5IF2xRC/Ssh4pB5QZ+bTjYsN5amnjgM+813bDBLelC+HmXKqylviz7Dzxbtbcw==",
+      "dev": true,
+      "requires": {
+        "array-find": "^1.0.0",
+        "babel-runtime": "^5.6.15",
+        "graceful-fs": "^4.1.11",
+        "linux-platform-info": "^0.0.3",
+        "mkdirp": "^0.5.1",
+        "mustache": "^2.1.2",
+        "os-family": "^1.0.0",
+        "pify": "^2.3.0",
+        "pinkie": "^2.0.1",
+        "read-file-relative": "^1.2.0",
+        "which-promise": "^1.0.0"
+      },
+      "dependencies": {
+        "babel-runtime": {
+          "version": "5.8.38",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
+          "integrity": "sha1-HAsC62MxL18If/IEUIJ7QlydTBk=",
+          "dev": true,
+          "requires": {
+            "core-js": "^1.0.0"
+          }
+        },
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
+    "testcafe-hammerhead": {
+      "version": "14.9.2",
+      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-14.9.2.tgz",
+      "integrity": "sha512-0rO9NTTueDXPqeWASThKEHX5AGF0FDhiPVRdkkWnKUOAtfPJz/qovZnIEpoC7q0DdmgbYYvK3if9Si8SdFNk0A==",
+      "dev": true,
+      "requires": {
+        "acorn-hammerhead": "^0.3.0",
+        "asar": "^2.0.1",
+        "bowser": "1.6.0",
+        "brotli": "^1.3.1",
+        "crypto-md5": "^1.0.0",
+        "css": "2.2.3",
+        "esotope-hammerhead": "^0.4.0",
+        "iconv-lite": "0.4.11",
+        "lodash": "^4.17.13",
+        "lru-cache": "2.6.3",
+        "match-url-wildcard": "0.0.4",
+        "merge-stream": "^1.0.1",
+        "mime": "~1.4.1",
+        "mustache": "^2.1.1",
+        "nanoid": "^0.2.2",
+        "os-family": "^1.0.0",
+        "parse5": "2.2.3",
+        "pinkie": "1.0.0",
+        "read-file-relative": "^1.2.0",
+        "semver": "5.5.0",
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.6.0",
+        "webauth": "^1.1.0"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.11",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz",
+          "integrity": "sha1-LstC/SlHRJIiCaLnxATayHk9it4=",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.3.tgz",
+          "integrity": "sha1-UczQtPwMhDWH16VwnOTTt2Kb7cU=",
+          "dev": true
+        },
+        "merge-stream": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+          "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.0.1"
+          }
+        },
+        "mime": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+          "dev": true
+        },
+        "nanoid": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-0.2.2.tgz",
+          "integrity": "sha512-GHoRrvNEKiwdkwQ/enKL8AhQkkrBC/2KxMZkDvQzp8OtkpX8ZAmoYJWFVl7l8F2+HcEJUfdg21Ab2wXXfrvACQ==",
+          "dev": true
+        },
+        "parse5": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz",
+          "integrity": "sha1-DE/EHBAAxea5PUiwP4CDg3g06fY=",
+          "dev": true
+        },
+        "pinkie": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
+          "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q=",
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "dev": true
+        },
+        "tough-cookie": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+          "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+          "dev": true,
+          "requires": {
+            "punycode": "^1.4.1"
+          }
+        }
+      }
+    },
+    "testcafe-legacy-api": {
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/testcafe-legacy-api/-/testcafe-legacy-api-3.1.11.tgz",
+      "integrity": "sha512-JWv8Exc9FAEBbKw+IP97Ebd+0FzA3nzgRv9iQCNh/+JlZyUox7NWiojs9BAXqgxIltl54rdo7TxPkNslxb+Ltw==",
+      "dev": true,
+      "requires": {
+        "async": "0.2.6",
+        "babel-runtime": "^5.8.34",
+        "dedent": "^0.6.0",
+        "highlight-es": "^1.0.0",
+        "is-jquery-obj": "^0.1.0",
+        "lodash": "^4.14.0",
+        "moment": "^2.14.1",
+        "mustache": "^2.2.1",
+        "os-family": "^1.0.0",
+        "parse5": "^2.1.5",
+        "pify": "^2.3.0",
+        "pinkie": "^2.0.1",
+        "strip-bom": "^2.0.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.6",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.6.tgz",
+          "integrity": "sha1-rT83PZJJrjJIgVZVgryQ4VKrvWg=",
+          "dev": true
+        },
+        "babel-runtime": {
+          "version": "5.8.38",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
+          "integrity": "sha1-HAsC62MxL18If/IEUIJ7QlydTBk=",
+          "dev": true,
+          "requires": {
+            "core-js": "^1.0.0"
+          }
+        },
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
+        },
+        "dedent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.6.0.tgz",
+          "integrity": "sha1-Dm2o8M5Sg471zsXI+TlrDBtko8s=",
+          "dev": true
+        },
+        "parse5": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz",
+          "integrity": "sha1-DE/EHBAAxea5PUiwP4CDg3g06fY=",
+          "dev": true
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        }
+      }
+    },
+    "testcafe-reporter-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-json/-/testcafe-reporter-json-2.2.0.tgz",
+      "integrity": "sha512-wfpNaZgGP2WoqdmnIXOyxcpwSzdH1HvzXSN397lJkXOrQrwhuGUThPDvyzPnZqxZSzXdDUvIPJm55tCMWbfymQ==",
+      "dev": true
+    },
+    "testcafe-reporter-list": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-list/-/testcafe-reporter-list-2.1.0.tgz",
+      "integrity": "sha1-n6ifcbl9Pf5ktDAtXiJ97mmuxrk=",
+      "dev": true
+    },
+    "testcafe-reporter-minimal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-minimal/-/testcafe-reporter-minimal-2.1.0.tgz",
+      "integrity": "sha1-Z28DVHY0FDxurzq1KGgnOkvr9CE=",
+      "dev": true
+    },
+    "testcafe-reporter-spec": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-spec/-/testcafe-reporter-spec-2.1.1.tgz",
+      "integrity": "sha1-gVb87Q9RMkhlWa1WC8gGdkaSdew=",
+      "dev": true
+    },
+    "testcafe-reporter-xunit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-xunit/-/testcafe-reporter-xunit-2.1.0.tgz",
+      "integrity": "sha1-5tZsVyzhWvJmcGrw/WELKoQd1EM=",
+      "dev": true
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -18930,6 +20886,12 @@
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
       }
+    },
+    "time-limit-promise": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/time-limit-promise/-/time-limit-promise-1.0.4.tgz",
+      "integrity": "sha512-FLHDDsIDducw7MBcRWlFtW2Tm50DoKOSFf0Nzx17qwXj8REXCte0eUkHrJl9QU3Bl9arG3XNYX0PcHpZ9xyuLw==",
+      "dev": true
     },
     "timers-browserify": {
       "version": "2.0.11",
@@ -18986,6 +20948,27 @@
       "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"
+      }
+    },
+    "tmp-promise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-1.1.0.tgz",
+      "integrity": "sha512-8+Ah9aB1IRXCnIOxXZ0uFozV1nMU5xiu7hhFVUSxZ3bYu+psD4TzagCzVbexUCgNNGJnsmNDQlS4nG3mTyoNkw==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.0",
+        "tmp": "0.1.0"
+      },
+      "dependencies": {
+        "tmp": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+          "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+          "dev": true,
+          "requires": {
+            "rimraf": "^2.6.3"
+          }
+        }
       }
     },
     "tmpl": {
@@ -19114,6 +21097,15 @@
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.4.tgz",
       "integrity": "sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q==",
       "dev": true
+    },
+    "truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+      "dev": true,
+      "requires": {
+        "utf8-byte-length": "^1.0.1"
+      }
     },
     "ts-invariant": {
       "version": "0.4.4",
@@ -19274,6 +21266,12 @@
         "prelude-ls": "~1.1.2"
       }
     },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
     "type-fest": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
@@ -19337,6 +21335,12 @@
           "dev": true
         }
       }
+    },
+    "ultron": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+      "dev": true
     },
     "unfetch": {
       "version": "4.1.0",
@@ -19680,6 +21684,22 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "useragent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz",
+      "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.x",
+        "tmp": "0.0.x"
+      }
+    },
+    "utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=",
+      "dev": true
+    },
     "utif": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/utif/-/utif-2.0.1.tgz",
@@ -19871,6 +21891,12 @@
         "neo-async": "^2.5.0"
       }
     },
+    "webauth": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/webauth/-/webauth-1.1.0.tgz",
+      "integrity": "sha1-ZHBPa4AmmGYFvDymKZUubib90QA=",
+      "dev": true
+    },
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -20058,6 +22084,40 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "which-promise": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-promise/-/which-promise-1.0.0.tgz",
+      "integrity": "sha1-ILch3wWzW3Bhdv+hCwkJq6RgMDU=",
+      "dev": true,
+      "requires": {
+        "pify": "^2.2.0",
+        "pinkie-promise": "^1.0.0",
+        "which": "^1.1.2"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "pinkie": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
+          "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q=",
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
+          "integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
+          "dev": true,
+          "requires": {
+            "pinkie": "^1.0.0"
+          }
+        }
+      }
     },
     "wide-align": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "generate:specs:provisioning": "npx @manifoldco/swagger-to-ts src/spec/provisioning/v1.yaml -w 'export namespace Provisioning' -o src/types/provisioning.ts",
     "generate:specs:connector": "npx @manifoldco/swagger-to-ts src/spec/connector/v1.yaml -w 'export namespace Connector' -o src/types/connector.ts",
     "testcafe": "npx testcafe chrome e2e/",
+    "testcafe:dev": "DEPLOY_URL=http://localhost:6006 npm run testcafe",
     "happo": "npm run build &&  npm run generate:gql && manifold run -t manifold -p manifold-ui-ci -- happo run",
     "happo-ci-circleci": "npm run build && npm run generate:gql && happo-ci-circleci",
     "heroku-postbuild": "npm run build:docs",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@stencil/postcss": "^1.0.1",
     "@storybook/addon-knobs": "^5.2.3",
     "@storybook/addons": "^5.2.3",
-    "@storybook/html": "^5.2.3",
+    "@storybook/html": "^5.2.4",
     "@types/fetch-mock": "^7.3.1",
     "@types/jest": "^24.0.18",
     "@types/puppeteer": "1.20.1",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@manifoldco/eslint-plugin-stencil": "^0.4.1",
     "@manifoldco/icons": "0.0.3",
     "@reach/observe-rect": "^1.0.3",
-    "@stencil/core": "^1.6.1",
+    "@stencil/core": "^1.7.2",
     "@stencil/postcss": "^1.0.1",
     "@storybook/addon-knobs": "^5.2.3",
     "@storybook/addons": "^5.2.3",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "generate:specs:marketplace": "npx @manifoldco/swagger-to-ts src/spec/marketplace/v1.yaml -w 'export namespace Marketplace' -o src/types/marketplace.ts",
     "generate:specs:provisioning": "npx @manifoldco/swagger-to-ts src/spec/provisioning/v1.yaml -w 'export namespace Provisioning' -o src/types/provisioning.ts",
     "generate:specs:connector": "npx @manifoldco/swagger-to-ts src/spec/connector/v1.yaml -w 'export namespace Connector' -o src/types/connector.ts",
+    "testcafe": "npx testcafe chrome e2e/",
     "happo": "npm run build &&  npm run generate:gql && manifold run -t manifold -p manifold-ui-ci -- happo run",
     "happo-ci-circleci": "npm run build && npm run generate:gql && happo-ci-circleci",
     "heroku-postbuild": "npm run build:docs",
@@ -119,6 +120,7 @@
     "stylelint-config-prettier": "^6.0.0",
     "stylelint-config-rational-order": "^0.1.2",
     "stylelint-config-standard": "^19.0.0",
+    "testcafe": "^1.5.0",
     "ts-loader": "^6.2.0",
     "wait-on": "^3.3.0",
     "webpack": "^4.41.0"


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

Because we want automated, full-stack, end-to-end testing!

This introduced TestCafe along with a test against our StoryBook site that does some filtering on the marketplace component.

This is a work in progress. The `testcafe` task will currently only work if you have StoryBook running locally at `localhost:6006`. The next step would be to try and integrate this into CI, so that it would run against our deployed storybook instance immediately after we deploy it.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
