### PR TITLE
Add optional ownerID to manifold-data-provision-button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added a `sidebar` slot to `<manifold-marketplace>` (#612)
 - Exposed `ensureAuthToken` function for making authenticated GraphQL calls directly from platforms
   (#576)
+- Added `ownerId` prop to `<manifold-data-provision-button>`
 
 ### Removed
 

--- a/docs/docs/data/manifold-data-provision-button.md
+++ b/docs/docs/data/manifold-data-provision-button.md
@@ -106,3 +106,13 @@ plain ol’ CSS.
 [shadow-dom]: https://developers.google.com/web/fundamentals/web-components/shadowdom
 [slot]: https://stenciljs.com/docs/templating-jsx/
 [plan-selector]: /components/plan-selector
+
+## Owner ID
+
+You can pass a platform specific owner ID to be attached to the created resource like this:
+
+```html
+<manifold-data-provision-button owner-id="user-1234">
+  Provision Resource
+</manifold-data-provision-button>
+```

--- a/docs/docs/data/manifold-data-provision-button.md
+++ b/docs/docs/data/manifold-data-provision-button.md
@@ -107,12 +107,13 @@ plain ol’ CSS.
 [slot]: https://stenciljs.com/docs/templating-jsx/
 [plan-selector]: /components/plan-selector
 
-## Owner ID
+## Context (team, org, etc.)
 
-You can pass a platform specific owner ID to be attached to the created resource like this:
+By default, Manifold assumes the user creating the resource will own it. But 
+when creating a resource owned by another context (e.g. a team, or 
+organization, or whatever your platform calls it), you’ll need to specify an 
+owner-id different from their own:
 
 ```html
-<manifold-data-provision-button owner-id="user-1234">
-  Provision Resource
-</manifold-data-provision-button>
+<manifold-data-provision-button owner-id="team-123">
 ```

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -174,6 +174,10 @@ export namespace Components {
     */
     'graphqlFetch'?: GraphqlFetch;
     /**
+    * Owner ID
+    */
+    'ownerId'?: string;
+    /**
     * Plan to provision (slug)
     */
     'planId'?: string;
@@ -1174,6 +1178,10 @@ declare namespace LocalJSX {
     'onManifold-provisionButton-error'?: (event: CustomEvent<any>) => void;
     'onManifold-provisionButton-invalid'?: (event: CustomEvent<any>) => void;
     'onManifold-provisionButton-success'?: (event: CustomEvent<any>) => void;
+    /**
+    * Owner ID
+    */
+    'ownerId'?: string;
     /**
     * Plan to provision (slug)
     */

--- a/src/components/manifold-data-provision-button/create-with-owner.graphql
+++ b/src/components/manifold-data-provision-button/create-with-owner.graphql
@@ -1,4 +1,4 @@
-mutation CreateResource($planId: ID!, $productId: ID!, $regionId: ID!, $resourceLabel: String!) {
+mutation CreateResource($planId: ID!, $productId: ID!, $regionId: ID!, $resourceLabel: String!, $ownerId: ID!) {
   createResource(
     input: {
       displayName: $resourceLabel
@@ -6,6 +6,7 @@ mutation CreateResource($planId: ID!, $productId: ID!, $regionId: ID!, $resource
       planId: $planId
       productId: $productId
       regionId: $regionId
+      ownerId: $ownerId
     }
   ) {
     data {

--- a/src/components/manifold-data-provision-button/create-with-owner.graphql
+++ b/src/components/manifold-data-provision-button/create-with-owner.graphql
@@ -1,4 +1,4 @@
-mutation CreateResource($planId: ID!, $productId: ID!, $regionId: ID!, $resourceLabel: String!, $ownerId: ID!) {
+mutation CreateResourceWithOwner($planId: ID!, $productId: ID!, $regionId: ID!, $resourceLabel: String!, $ownerId: ID!) {
   createResource(
     input: {
       displayName: $resourceLabel

--- a/src/components/manifold-data-provision-button/create.graphql
+++ b/src/components/manifold-data-provision-button/create.graphql
@@ -6,9 +6,7 @@ mutation CreateResource($planId: ID!, $productId: ID!, $regionId: ID!, $resource
       planId: $planId
       productId: $productId
       regionId: $regionId
-      owner: {
-        id: $ownerId
-      }
+      ownerId: $ownerId
     }
   ) {
     data {

--- a/src/components/manifold-data-provision-button/create.graphql
+++ b/src/components/manifold-data-provision-button/create.graphql
@@ -6,6 +6,9 @@ mutation CreateResource($planId: ID!, $productId: ID!, $regionId: ID!, $resource
       planId: $planId
       productId: $productId
       regionId: $regionId
+      owner: {
+        id: $ownerId
+      }
     }
   ) {
     data {

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
@@ -66,6 +66,8 @@ export class ManifoldDataProvisionButton {
   @Prop() graphqlFetch?: GraphqlFetch = connection.graphqlFetch;
   /** Product ID */
   @Prop({ mutable: true }) productId?: string = '';
+  /** Owner ID */
+  @Prop() ownerId?: string;
   /** Product to provision (slug) */
   @Prop() productLabel?: string;
   /** Plan to provision (slug) */
@@ -145,6 +147,7 @@ export class ManifoldDataProvisionButton {
         productId: this.productId,
         regionId: this.regionId,
         resourceLabel: this.resourceLabel,
+        ownerId: this.ownerId,
       },
     });
     this.provisioning = false;

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
@@ -6,6 +6,7 @@ import { GraphqlFetch } from '../../utils/graphqlFetch';
 import logger from '../../utils/logger';
 import loadMark from '../../utils/loadMark';
 import createResource from './create.graphql';
+import createResourceWithOwner from './create-with-owner.graphql';
 import { CreateResourceMutation } from '../../types/graphql';
 
 interface ClickMessage {
@@ -141,7 +142,7 @@ export class ManifoldDataProvisionButton {
     // disable button & attempt provision
     this.provisioning = true;
     const { data, errors } = await this.graphqlFetch<CreateResourceMutation>({
-      query: createResource,
+      query: this.ownerId ? createResourceWithOwner : createResource,
       variables: {
         planId: this.planId,
         productId: this.productId,

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1416,6 +1416,26 @@ export type DeleteResourceMutation = (
   ) }
 );
 
+export type CreateResourceWithOwnerMutationVariables = {
+  planId: Scalars['ID'],
+  productId: Scalars['ID'],
+  regionId: Scalars['ID'],
+  resourceLabel: Scalars['String'],
+  ownerId: Scalars['ID']
+};
+
+
+export type CreateResourceWithOwnerMutation = (
+  { __typename?: 'Mutation' }
+  & { createResource: (
+    { __typename?: 'CreateResourcePayload' }
+    & { data: (
+      { __typename?: 'Resource' }
+      & Pick<Resource, 'id' | 'label'>
+    ) }
+  ) }
+);
+
 export type CreateResourceMutationVariables = {
   planId: Scalars['ID'],
   productId: Scalars['ID'],

--- a/stories/resource.stories.js
+++ b/stories/resource.stories.js
@@ -80,6 +80,7 @@ storiesOf('Resource', module)
     const labels = getProductLabels(env);
     const newResource = text('resource-label', 'my-resource');
     const productLabel = select('product-label', labels, labels[0]);
+    const ownerId = text('owner-id', '');
     return `
       <style>
         menu {
@@ -93,6 +94,7 @@ storiesOf('Resource', module)
         <manifold-data-provision-button
           product-label="${productLabel}"
           resource-label="${newResource}"
+          owner-id="${ownerId}"
         >
           Provision ${newResource}
         </manifold-data-provision-button>


### PR DESCRIPTION
## Reason for change

Closes https://github.com/manifoldco/engineering/issues/9651
Adds `ownerId` prop to `manifold-data-provision-button` and includes ID on createResource gql call

## Testing

1. Refer to https://app.gitbook.com/@manifold/s/engineering/testing-guides/exploratory-testing-with-webcomponents-using-storybook to find the ownerID attached to your token
1. In the Resource -> create story I have added a new ownerID field to the knobs panel. Try creating resources with:
    - No ownerID
    - A valid ownerID
    - An invalid owner ID
1. The first two should return good data, the final one should error

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
