### PR TITLE
An action to run TestCafe on StoryBook deployment

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,4 +13,7 @@ jobs:
     name: Run e2e tests with test cafe
     runs-on: ubuntu-18.04
     steps:
-      - run: npm run testcafe
+      - name: Install dependencies
+        run: npm install
+      - name: Run TestCafe
+        run: npm run testcafe

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  deployment_status:
+    branches:
+      - sslotsky/test-cafe
+        
+jobs:
+  test:
+    env:
+      DEPLOY_URL: ${{ github.event.deployment_status.deployment_url }}
+    if: github.event.deployment_status.state == 'success' && github.event.deployment_status.creator.login == 'now'
+    name: Run e2e tests with test cafe
+    runs-on: ubuntu-18.04
+    steps:
+      - run: npm run testcafe


### PR DESCRIPTION
This is a first pass at a GitHub action for running TestCafe against the StoryBook previews that appear in pull requests. Currently, this action will only target sslotsky/test-cafe.

As soon as we achieve a successful run, we can merge sslotsky/test-cafe and update the action to run against pull request branches, or even the master branch.

<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
