### PR TITLE
Fixes the issue with test failing due to setTimeout

### DIFF
--- a/src/components/manifold-credentials/manifold-credentials.spec.ts
+++ b/src/components/manifold-credentials/manifold-credentials.spec.ts
@@ -8,6 +8,8 @@ import { CredentialEdge } from '../../types/graphql';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+global.setTimeout = jest.fn();
+
 const graphqlEndpoint = 'http://test.com/graphql';
 const credentials: Partial<CredentialEdge[]> = [
   { cursor: '', node: { key: 'KEY_1', value: 'SECRET_1' } },


### PR DESCRIPTION
If we don't mock `setTimeout` in test loading components that uses it, then it may randomly fail as `setTimeout` resolves on a dead component. Very similar to the "`setState` on unmounted component" issue in React.