### PR TITLE
Improved type safety on manifold-data-resource-logo

### DIFF
--- a/src/components/manifold-data-resource-logo/manifold-data-resource-logo.tsx
+++ b/src/components/manifold-data-resource-logo/manifold-data-resource-logo.tsx
@@ -43,12 +43,12 @@ export class ManifoldDataResourceLogo {
       variables: { resourceLabel },
     });
 
-    if (data && data.resource && data.resource.plan && data.resource.plan.product) {
+    if (data) {
       const newProduct = {
         displayName: data.resource.plan.product.displayName,
         logoUrl: data.resource.plan.product.logoUrl,
       };
-      this.product = newProduct as ProductState;
+      this.product = newProduct;
     }
   };
 


### PR DESCRIPTION

<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

In my previous PR @dangodev improved the grahpql query generation, I had used `as ProductState` as a work around before, came back to fix it.

## Testing

Ensure `manifold-data-resource-logo` still passes all checks and loads a image in the storybook resource details section.

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
