### PR TITLE
docs: Format CHANGELOG

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -10,3 +10,6 @@ update_configs:
       - match:
         dependency_name: 'puppeteer' # Version-managed by Stencil
         version_requirement: '*'
+    commit_message:
+      prefix: 'chore'
+      include_scope: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,6 @@
 
 <!-- are all the steps completed? -->
 
-- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
 - [ ] **Prop changes**: [docs][docs] were updated
 - [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
 - [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,7 @@
 
 <!-- are all the steps completed? -->
 
+- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
 - [ ] **Prop changes**: [docs][docs] were updated
 - [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
 - [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,38 @@
-# Changelog
+#### 2019-10-30
 
-All notable changes to this project will be documented in this file.
+##### Continuous Integration
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
-adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+- Fix Happo check ([#667](https://github.com/manifoldco/ui/pull/667))
+  ([856a22c9](https://github.com/manifoldco/ui/commit/856a22c9e55d7f0cef1e0ec88c9288ebba259c08))
+- Move PR checks from CircleCI to GitHub Actions ([#661](https://github.com/manifoldco/ui/pull/661))
+  ([23f47deb](https://github.com/manifoldco/ui/commit/23f47deb244f113e415b6340f85cae9983597ea2))
 
-## [v0.6.1]
+#### 0.6.1 (2019-10-25)
 
-### Changed
+##### Bug Fixes
 
 - Removed Node version restriction on package (#659)
+
+##### Chores
+
 - Updated Stencil to v1.7.4 (#652)
 
-## [v0.6.0]
+#### 0.6.0 (2019-10-22)
 
-### Added
+##### Breaking Changes:
+
+- `<manifold-data-provision-button>` now requires `plan-id` rather than `plan-label` as a prop
+- `<manifold-plan>` now requires `plan-id` rather than `plan-label` as a prop
+
+##### New Features
 
 - Added a `sidebar` slot to `<manifold-marketplace>` (#612)
 - Exposed `ensureAuthToken` function for making authenticated GraphQL calls directly from platforms
   (#576)
 - Added `ownerId` prop to `<manifold-data-provision-button>`, `<manifold-data-resource-list>`, and
   `<manifold-resource-list>`
-- Added test for `<manifold-plan-selector regions="">` (#644)
 
-### Removed
-
-- Removed `manifold-resource-details` component. (#597)
-
-### Changed
+##### Performance Improvements
 
 - Converted `manifold-resource-container` to use the GraphQL.
 - Converted `manifold-resource-plan` to use the GraphQL data fetched from the
@@ -36,104 +41,109 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `manifold-resource-container`. (#584)
 - Converted `manifold-resource-deprovision` to use the GraphQL data fetched from the
   `manifold-resource-container`. (#595)
+- Converted `<manifold-data-rename-button>` to use GraphQL (#596)
 - Converted `<manifold-data-provision-button>` to use GraphQL data (#600)
 - Converted `manifold-resource-rename` to use the GraphQL data fetched from the
   `manifold-resource-container`. (#602)
-- Converted `<manifold-data-rename-button>` to use GraphQL (#596)
 - Converted `manifold-resource-sso` to use the GraphQL data fetched from the
   `manifold-resource-container`. (#603)
 - Converted `<manifold-data-deprovision-button>` to use GraphQL (#604)
 - Converted `<manifold-plan-cost>` to GraphQL (#605)
-- Updated Stencil to v1.7.2 (#631)
-- Owner ID no longer fetched to create/delete resources (#608)
-- Converted `<manifold-data-resize-button>` to use GraphQL
-- Updated `<manifold-product>` ahead of a GraphQL deprecation (#619)
-- Converted `<manifold-data-resource-logo>` to use GraphQL (#635)
+- Converted `<manifold-data-resize-button>` to use GraphQL (#609)
 - Converted `<manifold-resource-status>` to use GraphQL (#611)
 - Converted `<manifold-resource-list>` to use GraphQL (#627)
+- Converted `<manifold-data-resource-logo>` to use GraphQL (#635)
 - Converted `<manifold-data-sso-button>` to use GraphQL (#640)
 
-### Breaking Changes:
+##### Chores
 
-- `<manifold-data-provision-button>` now requires `plan-id` rather than `plan-label` as a prop
-- `<manifold-plan>` now requires `plan-id` rather than `plan-label` as a prop
+- Removed `manifold-resource-details` component. (#597)
+- Owner ID no longer fetched to create/delete resources (#608)
+- Updated `<manifold-product>` ahead of a GraphQL deprecation (#619)
+- Updated Stencil to v1.7.2 (#631)
+- Added test for `<manifold-plan-selector regions="">` (#644)
 
-## [v0.5.17]
+#### 0.5.17 (2019-10-02)
 
-### Changed
+##### Performance Improvements
 
 - Converted `manifold-resource-product` to use the GraphQL data fetched from the
   `manifold-resource-container`. (#566)
 
-## [v0.5.16]
+#### 0.5.16 (2019-09-30)
 
-### Added
+##### Chores
 
-- `manifold-product-load` event (#560)
+- Added `manifold-product-load` event (#560)
 
-### Changed
+##### New Features
 
 - Deprecated friendly resource names in favor of kebab-case resource labels (#559)
 - Removed `resource-id` prop from `manifild-resource-card` (#537)
 - Converted `manifold-resource-card` to GraphQL (#537)
 
-## [v0.5.15]
+#### 0.5.15 (2019-09-29)
+
+##### New Features
 
 - Added `manifold-resource-load` event to `manifold-resource-container` (#556)
 
-## [v0.5.14]
+#### 0.5.14 (2019-09-29)
 
-### Added
+##### New Features
 
 - Added `disabled` attribute to `manifold-resource-rename` (#553)
 
-### Fixed
+##### Bug Fixes
 
 - Fixed local testing addresses.
 - Fixed console warning about `loading="lazy"` (#552)
 - Prevent actions on `<manifold-credentials>` while awaiting a resourceLabel (#554)
 
-### Changed
+##### Chores
 
 - Changed number of skeleton products that load (#551)
 
-## [v0.5.13]
+#### 0.5.13 (2019-09-29)
 
-### Fixed
+##### Bug Fixes
 
 - Credentials appear one-per-line (#546)
 - Fixed credential error message top margin (#545)
 - Fixed success event after a resource rename to include potentially modified label (#547)
 
-## [v0.5.12]
+#### 0.5.12 (2019-09-26)
 
-### Breaking changes
+##### Breaking changes
 
 - `resource-id` renamed to `resource-label` in `<manifold-resource-card>`
 - `product-id` renamed to `product-label` in `<manifold-service-card>`
 
-### Added
+##### New Features
 
 - Added `label` to `<manifold-data-has-resource>` (#542)
 
-### Changed
+##### Chores
 
 - Removed `product-id` from `manifold-service-card` (#533)
+
+##### Performance Improvements
+
 - Converted `manifold-service-card` to GraphQL (#533)
 
-### Fixed
+##### Bug Fixes
 
 - Fixed loading flicker of resource components while provisioning/deprovisioning. (#539)
 
-## [v0.5.11]
+#### 0.5.11 (2019-09-19)
 
-### Added
+##### New Features
 
 - Ability to authenticate and refresh manually, bypassing OAuth. (#495)
 - Added a time to first meaningful render event to be consumed by `<manifold-performance>` component
   (#501)
 
-### Changed
+##### Chores
 
 - Changed `manifold-marketplace` to use GraphQL. (#489)
 - Improved Storybook stories (#500)
@@ -141,41 +151,41 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `<manifold-data-provision-button>` will now work even if given an undefined resource label. The
   API will auto-generate the label if omitted. (#503)
 
-### Fixed
+##### Bug Fixes
 
 - Fixed `<manifold-button>` borders (#500)
 - `<manifold-credentials>` now uses GraphQL (#490)
 - `<manifold-marketplace>` fetches products in one request (#522)
 
-## [v0.5.10]
+#### 0.5.10 (2019-09-09)
 
-### Added
+##### New Features
 
 - Enabled custom loading indicators. (#471)
 - Added `<manifold-copy-credentials>` for quickly-copying secrets to a user’s clipboard. (#452)
 
-### Fixed
+##### Bug Fixes
 
 - Multiple queries in GraphQL now supported in TypeScript. (#476)
 
-### Changed
+##### Chores
 
 - Clarified documentation for multiple components. (#481)
 
-## [v0.5.9]
+## 0.5.9 (2019-09-05)
 
-### Added
+##### New Features
 
 - Added an events queue to `<manifold-performance>` to capture any performance events emitted before
   DataDog is ready. (#451)
 - Added more event data & testing for `<manifold-data-provision-button>`. (#447)
 
-### Fixed
+##### Bug Fixes
 
 - Fixed a typo in manifold-data-deprovision-button documentation. (#457)
 - Upgraded `@manifoldco/shadowcat` to feature the latest security patches. (#477)
 
-### Changed
+##### Chores
 
 - Changed the docs fetch mocking to now wait for the real request duration. This duration is
   obtained at build time from the manifold APIs. (#450)
@@ -184,77 +194,81 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Changed `manifold-data-product-name` to use GraphQL. (#463)
 - Changed `manifold-data-resource-list` to use GraphQL. (#474)
 
-## [v0.5.8]
+#### 0.5.8 (2019-08-26)
 
-### Fixed
+##### Bug Fixes
 
 - Fixed resource card CTA slot from flashing while loading. (#438)
 - Hide credentials button no longer flashes when credentials component loads. (#434)
 - When an expired auth token causes an API call to respond with a 401, the token will now refresh
   and the API call will retry. (#440)
 
-### Changed
+##### Chores
 
 - Enforce standard height on product cards for more consistency. (#435)
 - Replace auth token polling with an event based system. (#436)
 
-## [v0.5.7]
+#### 0.5.7 (2019-08-23)
 
-### Added
+##### New Features
 
+- `<manifold-performance>` component for partners to add opt-in metrics collection to their
+  implementation (#427
 - We now release and publish our components to our CDN @
   `https://js.cdn.manifold.co/@manifoldco/ui`. (#408, #418)
 
-### Fixed
+##### Bug Fixes
 
 - Fixed events firing twice for `<manifold-resource-rename>`, `<manifold-resource-sso>`, and
   `<manifold-resource-deprovision>`. (#401)
 - Performance optimizations for network calls in `manifold-marketplace`. (#424)
 - Prevent provision button from being clicked multiple times. (#410)
 - Fixed a bug in Firefox with `<manifold-auth-token>`. (#429)
-
-### Changed
-
 - Removed padding above `<manifold-product-page>` (#399)
-- Adjusted positioning for CTA slot in `manifold-service-card-view`. (#404)
+- Adjusted positioning for CTA slot in `manifold-service-card-view`. (#404) )
 
-### Added
+#### 0.5.6 (2019-08-21)
 
-- `<manifold-performance>` component for partners to add opt-in metrics collection to their
-  implementation (#427)
+##### New Features
 
-## [v0.5.5]
+- Emit metrics events from restFetch and graphqlFetch (#396)
 
-### Fixed
+##### Bug Fixes
+
+- Fixed flash of “No services found” on marketplace grid (#390)
+
+#### 0.5.5 (2019-08-16)
+
+##### Bug Fixes
 
 - Stability improvements for GraphQL queries (#376)
 - Improved loading state for `<manifold-resource-list>` (#382)
 - Fixed public endpoints trying to authenticate (#383)
 - Fixed “no services“ flash on `<manifold-marketplace>` (#390)
 
-## [v0.5.4]
+#### 0.5.4 (2019-08-15)
 
-### Fixed
+##### Bug Fixes
 
 - Fixed the service card loading the free badge after rendering, which caused a jumpy UI. (#355)
 - Added the ability to specify a slot on the `manifold-credentials` with a default manifold button
   if not set. (#362)
 
-### Changed
+##### Chores
 
 - Updated Stencil to v1.2.5 (#375)
 - Changed the event name for the `manifold-auth-token` component from the stencil auto-generated
   name to `manifold-token-receive` and documented that event. (#360)
 - View component `<manifold-service-card-view>` no longer fetches data, is it should (#355)
 
-### Fixed
+##### Bug Fixes
 
 - Fixed issue where success event of `manifold-data-rename-resource` was emitted before renamed
   resource was ready. (#380)
 
-## [v0.5.3]
+#### 0.5.3 (2019-08-12)
 
-### Fixed
+##### Bug Fixes
 
 - Fixed the deprovision button failing because the code expected a JSON return value.
 - Fixed the resource list not showing the status of provisioning or deprovisioning resources.
@@ -264,20 +278,26 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   look misaligned.
 - Fixed the appearance of “free“ badges on product cards in `<manifold-marketplace>`
 
-### Added
+##### New Features
 
 - Added a `refetch-until-valid` property on the `resource-container` component to allow users to
   reload this component until the found resource exists and is of state `available`.
 - Added the terms of service to the product page component.
 - Added `<manifold-plan-selector free-plans>` filter flag
 
-## [v0.5.2]
+#### 0.5.2 (2019-08-02)
 
-### Added
+##### Breaking changes
+
+- Deprecated `resource-label` attibute on `manifold-data-product-logo`. Use
+  `manifold-data-resource-logo` component instead.
+- Deprecated `region-name` prop in favour of `region-id` for `manifold-data-provision-button`.
+
+##### New Features
 
 - Added `oauth-url` prop to `manifold-auth-token` component.
 
-### Fixed
+##### Bug Fixes
 
 - Fixed name for `manifold-service-view` to be `manifold-service-card-view` to match documentation.
 - Added missing support for theme variable `--manifold-tag-free-text-color`.
@@ -285,13 +305,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   region changes.
 - Fixed scroll highlight for `<manifold-marketplace>` sidebar
 
-### Deprecated
-
-- Deprecated `resource-label` attibute on `manifold-data-product-logo`. Use
-  `manifold-data-resource-logo` component instead.
-- Deprecated `region-name` prop in favour of `region-id` for `manifold-data-provision-button`.
-
-### Changed
+##### Chores
 
 - Added graphqlFetch to `manifold-connection`.
 - Converted `manifold-data-product-logo` to use GraphQL.
@@ -300,72 +314,69 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   component.
 - Improved `plan-selector` performance by reducing API calls for non-custom plans.
 
-## [v0.5.1]
+#### 0.5.1 (2019-08-01)
 
-### Breaking changes
+##### Breaking changes
 
 - `resource-label` removed from `<manifold-data-product-logo>` in favor of new
   `<manifold-data-resource-logo>` component
 
-## [v0.5.0]
+#### 0.5.0 (2019-07-25)
 
-### Added
+##### New Features
 
 - Added a SSO data button and the resource wrapper for ssoing into a resource's product dashboard.
 - Added a new CTA slot in the product card for displaying unique cta content.
 
-### Fixed
+##### Bug Fixes
 
 - Fixed the provision button requiring the label to be set, preventing or automatic label generation
   from working.
 
-### Changed
+##### Chores
 
 - Changed the `manifold-auth-token` component to now use the shadowcat oauth system rather than only
   use the given token. This enables platforms to now use real authentication.
 
-## [0.4.3]
+#### 0.4.3 (2019-07-16)
 
-### Fixed
+##### Bug Fixes
 
 - Fixed the rename and deprovision button not behaving properly when used in their resource warpers
 
-## [0.4.2]
+#### 0.4.2 (2019-07-16)
 
-### Changed
+##### Chores
 
 - Changed the deprovision and rename button to not include a shadow dom root, they can now be styled
   from external stylesheets.
 
-## [0.4.1]
+#### 0.4.1 (2019-07-15)
 
-### Changed
+##### Chores
 
 - Made all the internal attributes optional on the components to make sure TypeScript does not
   complain.
 
-## [0.4.0]
+#### 0.4.0 (2019-07-15)
 
-### Deprecated
+##### Breaking changes
 
 - Deprecated the `resource-name` attribute in all the resource components for `resource-label` as to
   be more consistent with the other components and our other codebases.
-
-### Changed
-
-- Changed how the `manifold-service-card` works to have it fetch the product unless given. This
-  allows it to be used standalone or in the `marketplace`.
-
-### Breaking changes
-
 - `resource-name` renamed to `resource-label` in the following components:
   `<manifold-resource-list>`, `<manifold-resource-plan>`, `<manifold-resource-product>`,
   `<manifold-data-product-logo>`, `<manifold-data-product-name>`,
   `<manifold-data-provision-button>`, `<manifold-data-resource-list>`
 
-## [0.3.1]
+##### Chores
 
-### Added
+- Changed how the `manifold-service-card` works to have it fetch the product unless given. This
+  allows it to be used standalone or in the `marketplace`.
+
+#### 0.3.1 (2019-07-12)
+
+##### New Features
 
 - New `manifold-resource-product` and `manifold-resource-plan` component to load a resource's
   product and plan card.
@@ -375,20 +386,35 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   to be in a `resource-container`.
 - New `manifold-mock-resource` component that allows to mock a `resource-container` with a fake
   resource.
+- Added new size to `manifold-resource-status`
 
-### Changed
+##### Chores
 
 - Changed the input from the `manifold-data-provision-button` to remove the input make it a pure
   button.
-- Changed the `manifold-resource-status` component to now display in two different sizes.
 - Changed the `manifold-resource-credentials` component to use the standalone `manifold-credentials`
   component.
 
-[0.3.0]: https://github.com/manifoldco/ui/compare/v0.2.1...v0.3.0
-[0.2.2]: https://github.com/manifoldco/ui/compare/v0.2.1...v0.2.2
-[0.2.1]: https://github.com/manifoldco/ui/compare/v0.2.0...v0.2.1
-[0.2.0]: https://github.com/manifoldco/ui/compare/v0.1.1...v0.2.0
-[0.1.1]: https://github.com/manifoldco/ui/compare/v0.1.0...v0.1.1
-[0.1.0]: https://github.com/manifoldco/ui/compare/v0.0.2...v0.1.0
-[0.1.0]: https://github.com/manifoldco/ui/compare/v0.0.2...v0.1.0
-[0.0.3]: https://github.com/manifoldco/ui/releases/tag/v0.0.3
+#### 0.3.0 (2019-07-09)
+
+- https://github.com/manifoldco/ui/compare/v0.2.2...v0.3.0
+
+#### 0.2.2 (2019-07-08)
+
+- https://github.com/manifoldco/ui/compare/v0.2.1...v0.2.2
+
+#### 0.2.1 (2019-07-05)
+
+- https://github.com/manifoldco/ui/compare/v0.2.0...v0.2.1
+
+#### 0.2.0 (2019-07-04)
+
+- https://github.com/manifoldco/ui/compare/v0.1.1...v0.2.0
+
+#### 0.1.1 (2019-06-19)
+
+- https://github.com/manifoldco/ui/compare/v0.1.0...v0.1.1
+
+#### 0.1.0 (2019-06-13)
+
+- https://github.com/manifoldco/ui/compare/v0.0.3...v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,419 +2,377 @@
 
 ##### Continuous Integration
 
-- Fix Happo check ([#667](https://github.com/manifoldco/ui/pull/667))
-  ([856a22c9](https://github.com/manifoldco/ui/commit/856a22c9e55d7f0cef1e0ec88c9288ebba259c08))
-- Move PR checks from CircleCI to GitHub Actions ([#661](https://github.com/manifoldco/ui/pull/661))
-  ([23f47deb](https://github.com/manifoldco/ui/commit/23f47deb244f113e415b6340f85cae9983597ea2))
+*  Fix Happo check ([#667](https://github.com/manifoldco/ui/pull/667)) ([856a22c9](https://github.com/manifoldco/ui/commit/856a22c9e55d7f0cef1e0ec88c9288ebba259c08))
+*  Move PR checks from CircleCI to GitHub Actions ([#661](https://github.com/manifoldco/ui/pull/661)) ([23f47deb](https://github.com/manifoldco/ui/commit/23f47deb244f113e415b6340f85cae9983597ea2))
 
 #### 0.6.1 (2019-10-25)
 
 ##### Bug Fixes
 
-- Removed Node version restriction on package (#659)
+* Removed Node version restriction on package (#659)
 
 ##### Chores
 
-- Updated Stencil to v1.7.4 (#652)
+* Updated Stencil to v1.7.4 (#652)
 
 #### 0.6.0 (2019-10-22)
 
 ##### Breaking Changes:
 
-- `<manifold-data-provision-button>` now requires `plan-id` rather than `plan-label` as a prop
-- `<manifold-plan>` now requires `plan-id` rather than `plan-label` as a prop
+* `<manifold-data-provision-button>` now requires `plan-id` rather than `plan-label` as a prop
+* `<manifold-plan>` now requires `plan-id` rather than `plan-label` as a prop
 
 ##### New Features
 
-- Added a `sidebar` slot to `<manifold-marketplace>` (#612)
-- Exposed `ensureAuthToken` function for making authenticated GraphQL calls directly from platforms
-  (#576)
-- Added `ownerId` prop to `<manifold-data-provision-button>`, `<manifold-data-resource-list>`, and
-  `<manifold-resource-list>`
+* Added a `sidebar` slot to `<manifold-marketplace>` (#612)
+* Exposed `ensureAuthToken` function for making authenticated GraphQL calls directly from platforms (#576)
+* Added `ownerId` prop to `<manifold-data-provision-button>`, `<manifold-data-resource-list>`, and `<manifold-resource-list>`
 
 ##### Performance Improvements
 
-- Converted `manifold-resource-container` to use the GraphQL.
-- Converted `manifold-resource-plan` to use the GraphQL data fetched from the
-  `manifold-resource-container`. (#578)
-- Converted `manifold-resource-credentials` to use the GraphQL data fetched from the
-  `manifold-resource-container`. (#584)
-- Converted `manifold-resource-deprovision` to use the GraphQL data fetched from the
-  `manifold-resource-container`. (#595)
-- Converted `<manifold-data-rename-button>` to use GraphQL (#596)
-- Converted `<manifold-data-provision-button>` to use GraphQL data (#600)
-- Converted `manifold-resource-rename` to use the GraphQL data fetched from the
-  `manifold-resource-container`. (#602)
-- Converted `manifold-resource-sso` to use the GraphQL data fetched from the
-  `manifold-resource-container`. (#603)
-- Converted `<manifold-data-deprovision-button>` to use GraphQL (#604)
-- Converted `<manifold-plan-cost>` to GraphQL (#605)
-- Converted `<manifold-data-resize-button>` to use GraphQL (#609)
-- Converted `<manifold-resource-status>` to use GraphQL (#611)
-- Converted `<manifold-resource-list>` to use GraphQL (#627)
-- Converted `<manifold-data-resource-logo>` to use GraphQL (#635)
-- Converted `<manifold-data-sso-button>` to use GraphQL (#640)
+* Converted `manifold-resource-container` to use the GraphQL.
+* Converted `manifold-resource-plan` to use the GraphQL data fetched from the `manifold-resource-container`. (#578)
+* Converted `manifold-resource-credentials` to use the GraphQL data fetched from the `manifold-resource-container`. (#584)
+* Converted `manifold-resource-deprovision` to use the GraphQL data fetched from the `manifold-resource-container`. (#595)
+* Converted `<manifold-data-rename-button>` to use GraphQL (#596)
+* Converted `<manifold-data-provision-button>` to use GraphQL data (#600)
+* Converted `manifold-resource-rename` to use the GraphQL data fetched from the `manifold-resource-container`. (#602)
+* Converted `manifold-resource-sso` to use the GraphQL data fetched from the `manifold-resource-container`. (#603)
+* Converted `<manifold-data-deprovision-button>` to use GraphQL (#604)
+* Converted `<manifold-plan-cost>` to GraphQL (#605)
+* Converted `<manifold-data-resize-button>` to use GraphQL (#609)
+* Converted `<manifold-resource-status>` to use GraphQL (#611)
+* Converted `<manifold-resource-list>` to use GraphQL (#627)
+* Converted `<manifold-data-resource-logo>` to use GraphQL (#635)
+* Converted `<manifold-data-sso-button>` to use GraphQL (#640)
 
 ##### Chores
 
-- Removed `manifold-resource-details` component. (#597)
-- Owner ID no longer fetched to create/delete resources (#608)
-- Updated `<manifold-product>` ahead of a GraphQL deprecation (#619)
-- Updated Stencil to v1.7.2 (#631)
-- Added test for `<manifold-plan-selector regions="">` (#644)
+* Removed `manifold-resource-details` component. (#597)
+* Owner ID no longer fetched to create/delete resources (#608)
+* Updated `<manifold-product>` ahead of a GraphQL deprecation (#619)
+* Updated Stencil to v1.7.2 (#631)
+* Added test for `<manifold-plan-selector regions="">` (#644)
 
 #### 0.5.17 (2019-10-02)
 
 ##### Performance Improvements
 
-- Converted `manifold-resource-product` to use the GraphQL data fetched from the
-  `manifold-resource-container`. (#566)
+* Converted `manifold-resource-product` to use the GraphQL data fetched from the `manifold-resource-container`. (#566)
 
 #### 0.5.16 (2019-09-30)
 
 ##### Chores
 
-- Added `manifold-product-load` event (#560)
+* Added `manifold-product-load` event (#560)
 
 ##### New Features
 
-- Deprecated friendly resource names in favor of kebab-case resource labels (#559)
-- Removed `resource-id` prop from `manifild-resource-card` (#537)
-- Converted `manifold-resource-card` to GraphQL (#537)
+* Deprecated friendly resource names in favor of kebab-case resource labels (#559)
+* Removed `resource-id` prop from `manifild-resource-card` (#537)
+* Converted `manifold-resource-card` to GraphQL (#537)
 
 #### 0.5.15 (2019-09-29)
 
 ##### New Features
 
-- Added `manifold-resource-load` event to `manifold-resource-container` (#556)
+* Added `manifold-resource-load` event to `manifold-resource-container` (#556)
 
 #### 0.5.14 (2019-09-29)
 
 ##### New Features
 
-- Added `disabled` attribute to `manifold-resource-rename` (#553)
+* Added `disabled` attribute to `manifold-resource-rename` (#553)
 
 ##### Bug Fixes
 
-- Fixed local testing addresses.
-- Fixed console warning about `loading="lazy"` (#552)
-- Prevent actions on `<manifold-credentials>` while awaiting a resourceLabel (#554)
+* Fixed local testing addresses.
+* Fixed console warning about `loading="lazy"` (#552)
+* Prevent actions on `<manifold-credentials>` while awaiting a resourceLabel (#554)
 
 ##### Chores
 
-- Changed number of skeleton products that load (#551)
+* Changed number of skeleton products that load (#551)
 
 #### 0.5.13 (2019-09-29)
 
 ##### Bug Fixes
 
-- Credentials appear one-per-line (#546)
-- Fixed credential error message top margin (#545)
-- Fixed success event after a resource rename to include potentially modified label (#547)
+* Credentials appear one-per-line (#546)
+* Fixed credential error message top margin (#545)
+* Fixed success event after a resource rename to include potentially modified label (#547)
 
 #### 0.5.12 (2019-09-26)
 
 ##### Breaking changes
 
-- `resource-id` renamed to `resource-label` in `<manifold-resource-card>`
-- `product-id` renamed to `product-label` in `<manifold-service-card>`
+* `resource-id` renamed to `resource-label` in `<manifold-resource-card>`
+* `product-id` renamed to `product-label` in `<manifold-service-card>`
 
 ##### New Features
 
-- Added `label` to `<manifold-data-has-resource>` (#542)
+* Added `label` to `<manifold-data-has-resource>` (#542)
 
 ##### Chores
 
-- Removed `product-id` from `manifold-service-card` (#533)
+* Removed `product-id` from `manifold-service-card` (#533)
 
 ##### Performance Improvements
 
-- Converted `manifold-service-card` to GraphQL (#533)
+* Converted `manifold-service-card` to GraphQL (#533)
 
 ##### Bug Fixes
 
-- Fixed loading flicker of resource components while provisioning/deprovisioning. (#539)
+* Fixed loading flicker of resource components while provisioning/deprovisioning. (#539)
 
 #### 0.5.11 (2019-09-19)
 
 ##### New Features
 
-- Ability to authenticate and refresh manually, bypassing OAuth. (#495)
-- Added a time to first meaningful render event to be consumed by `<manifold-performance>` component
-  (#501)
+* Ability to authenticate and refresh manually, bypassing OAuth. (#495)
+* Added a time to first meaningful render event to be consumed by `<manifold-performance>` component (#501)
 
 ##### Chores
 
-- Changed `manifold-marketplace` to use GraphQL. (#489)
-- Improved Storybook stories (#500)
-- `@manifoldco/shadowcat` is now part of UI. (#498)
-- `<manifold-data-provision-button>` will now work even if given an undefined resource label. The
-  API will auto-generate the label if omitted. (#503)
+* Changed `manifold-marketplace` to use GraphQL. (#489)
+* Improved Storybook stories (#500)
+* `@manifoldco/shadowcat` is now part of UI. (#498)
+* `<manifold-data-provision-button>` will now work even if given an undefined resource label. The API will auto-generate the label if omitted. (#503)
 
 ##### Bug Fixes
 
-- Fixed `<manifold-button>` borders (#500)
-- `<manifold-credentials>` now uses GraphQL (#490)
-- `<manifold-marketplace>` fetches products in one request (#522)
+* Fixed `<manifold-button>` borders (#500)
+* `<manifold-credentials>` now uses GraphQL (#490)
+* `<manifold-marketplace>` fetches products in one request (#522)
 
 #### 0.5.10 (2019-09-09)
 
 ##### New Features
 
-- Enabled custom loading indicators. (#471)
-- Added `<manifold-copy-credentials>` for quickly-copying secrets to a user’s clipboard. (#452)
+* Enabled custom loading indicators. (#471)
+* Added `<manifold-copy-credentials>` for quickly-copying secrets to a user’s clipboard. (#452)
 
 ##### Bug Fixes
 
-- Multiple queries in GraphQL now supported in TypeScript. (#476)
+* Multiple queries in GraphQL now supported in TypeScript. (#476)
 
 ##### Chores
 
-- Clarified documentation for multiple components. (#481)
+* Clarified documentation for multiple components. (#481)
 
 ## 0.5.9 (2019-09-05)
 
 ##### New Features
 
-- Added an events queue to `<manifold-performance>` to capture any performance events emitted before
-  DataDog is ready. (#451)
-- Added more event data & testing for `<manifold-data-provision-button>`. (#447)
+* Added an events queue to `<manifold-performance>` to capture any performance events emitted before DataDog is ready. (#451)
+* Added more event data & testing for `<manifold-data-provision-button>`. (#447)
 
 ##### Bug Fixes
 
-- Fixed a typo in manifold-data-deprovision-button documentation. (#457)
-- Upgraded `@manifoldco/shadowcat` to feature the latest security patches. (#477)
+* Fixed a typo in manifold-data-deprovision-button documentation. (#457)
+* Upgraded `@manifoldco/shadowcat` to feature the latest security patches. (#477)
 
 ##### Chores
 
-- Changed the docs fetch mocking to now wait for the real request duration. This duration is
-  obtained at build time from the manifold APIs. (#450)
-- Changed the `manifold-product` component to now use the GraphQL API rather than the REST API.
-  (#456)
-- Changed `manifold-data-product-name` to use GraphQL. (#463)
-- Changed `manifold-data-resource-list` to use GraphQL. (#474)
+* Changed the docs fetch mocking to now wait for the real request duration. This duration is obtained at build time from the manifold APIs. (#450)
+* Changed the `manifold-product` component to now use the GraphQL API rather than the REST API. (#456)
+* Changed `manifold-data-product-name` to use GraphQL. (#463)
+* Changed `manifold-data-resource-list` to use GraphQL. (#474)
 
 #### 0.5.8 (2019-08-26)
 
 ##### Bug Fixes
 
-- Fixed resource card CTA slot from flashing while loading. (#438)
-- Hide credentials button no longer flashes when credentials component loads. (#434)
-- When an expired auth token causes an API call to respond with a 401, the token will now refresh
-  and the API call will retry. (#440)
+* Fixed resource card CTA slot from flashing while loading. (#438)
+* Hide credentials button no longer flashes when credentials component loads. (#434)
+* When an expired auth token causes an API call to respond with a 401, the token will now refresh and the API call will retry. (#440)
 
 ##### Chores
 
-- Enforce standard height on product cards for more consistency. (#435)
-- Replace auth token polling with an event based system. (#436)
+* Enforce standard height on product cards for more consistency. (#435)
+* Replace auth token polling with an event based system. (#436)
 
 #### 0.5.7 (2019-08-23)
 
 ##### New Features
 
-- `<manifold-performance>` component for partners to add opt-in metrics collection to their
-  implementation (#427
-- We now release and publish our components to our CDN @
-  `https://js.cdn.manifold.co/@manifoldco/ui`. (#408, #418)
+* `<manifold-performance>` component for partners to add opt-in metrics collection to their implementation (#427)
+* We now release and publish our components to our CDN @ `https://js.cdn.manifold.co/@manifoldco/ui`. (#408, #418)
 
 ##### Bug Fixes
 
-- Fixed events firing twice for `<manifold-resource-rename>`, `<manifold-resource-sso>`, and
-  `<manifold-resource-deprovision>`. (#401)
-- Performance optimizations for network calls in `manifold-marketplace`. (#424)
-- Prevent provision button from being clicked multiple times. (#410)
-- Fixed a bug in Firefox with `<manifold-auth-token>`. (#429)
-- Removed padding above `<manifold-product-page>` (#399)
-- Adjusted positioning for CTA slot in `manifold-service-card-view`. (#404) )
+* Fixed events firing twice for `<manifold-resource-rename>`, `<manifold-resource-sso>`, and `<manifold-resource-deprovision>`. (#401)
+* Performance optimizations for network calls in `manifold-marketplace`. (#424)
+* Prevent provision button from being clicked multiple times. (#410)
+* Fixed a bug in Firefox with `<manifold-auth-token>`. (#429)
+* Removed padding above `<manifold-product-page>` (#399)
+* Adjusted positioning for CTA slot in `manifold-service-card-view`. (#404) )
 
 #### 0.5.6 (2019-08-21)
 
 ##### New Features
 
-- Emit metrics events from restFetch and graphqlFetch (#396)
+* Emit metrics events from restFetch and graphqlFetch (#396)
 
 ##### Bug Fixes
 
-- Fixed flash of “No services found” on marketplace grid (#390)
+* Fixed flash of “No services found” on marketplace grid (#390)
 
 #### 0.5.5 (2019-08-16)
 
 ##### Bug Fixes
 
-- Stability improvements for GraphQL queries (#376)
-- Improved loading state for `<manifold-resource-list>` (#382)
-- Fixed public endpoints trying to authenticate (#383)
-- Fixed “no services“ flash on `<manifold-marketplace>` (#390)
+* Stability improvements for GraphQL queries (#376)
+* Improved loading state for `<manifold-resource-list>` (#382)
+* Fixed public endpoints trying to authenticate (#383)
+* Fixed “no services“ flash on `<manifold-marketplace>` (#390)
 
 #### 0.5.4 (2019-08-15)
 
 ##### Bug Fixes
 
-- Fixed the service card loading the free badge after rendering, which caused a jumpy UI. (#355)
-- Added the ability to specify a slot on the `manifold-credentials` with a default manifold button
-  if not set. (#362)
+* Fixed the service card loading the free badge after rendering, which caused a jumpy UI. (#355)
+* Added the ability to specify a slot on the `manifold-credentials` with a default manifold button if not set. (#362)
 
 ##### Chores
 
-- Updated Stencil to v1.2.5 (#375)
-- Changed the event name for the `manifold-auth-token` component from the stencil auto-generated
-  name to `manifold-token-receive` and documented that event. (#360)
-- View component `<manifold-service-card-view>` no longer fetches data, is it should (#355)
+* Updated Stencil to v1.2.5 (#375)
+* Changed the event name for the `manifold-auth-token` component from the stencil auto-generated name to `manifold-token-receive` and documented that event. (#360)
+* View component `<manifold-service-card-view>` no longer fetches data, is it should (#355)
 
 ##### Bug Fixes
 
-- Fixed issue where success event of `manifold-data-rename-resource` was emitted before renamed
+* Fixed issue where success event of `manifold-data-rename-resource` was emitted before renamed
   resource was ready. (#380)
 
 #### 0.5.3 (2019-08-12)
 
 ##### Bug Fixes
 
-- Fixed the deprovision button failing because the code expected a JSON return value.
-- Fixed the resource list not showing the status of provisioning or deprovisioning resources.
-- Fixed the resource card loading indicator - for a lack of a better word - wobbling around like its
-  life depended on it.
-- Fixed the title of the `service-card` taking a dynamic amount of space and making the description
-  look misaligned.
-- Fixed the appearance of “free“ badges on product cards in `<manifold-marketplace>`
+* Fixed the deprovision button failing because the code expected a JSON return value.
+* Fixed the resource list not showing the status of provisioning or deprovisioning resources.
+* Fixed the resource card loading indicator - for a lack of a better word - wobbling around like its life depended on it.
+* Fixed the title of the `service-card` taking a dynamic amount of space and making the description look misaligned.
+* Fixed the appearance of “free“ badges on product cards in `<manifold-marketplace>`
 
 ##### New Features
 
-- Added a `refetch-until-valid` property on the `resource-container` component to allow users to
-  reload this component until the found resource exists and is of state `available`.
-- Added the terms of service to the product page component.
-- Added `<manifold-plan-selector free-plans>` filter flag
+* Added a `refetch-until-valid` property on the `resource-container` component to allow users to reload this component until the found resource exists and is of state `available`.
+* Added the terms of service to the product page component.
+* Added `<manifold-plan-selector free-plans>` filter flag
 
 #### 0.5.2 (2019-08-02)
 
 ##### Breaking changes
 
-- Deprecated `resource-label` attibute on `manifold-data-product-logo`. Use
-  `manifold-data-resource-logo` component instead.
-- Deprecated `region-name` prop in favour of `region-id` for `manifold-data-provision-button`.
+* Deprecated `resource-label` attibute on `manifold-data-product-logo`. Use `manifold-data-resource-logo` component instead.
+* Deprecated `region-name` prop in favour of `region-id` for `manifold-data-provision-button`.
 
 ##### New Features
 
-- Added `oauth-url` prop to `manifold-auth-token` component.
+* Added `oauth-url` prop to `manifold-auth-token` component.
 
 ##### Bug Fixes
 
-- Fixed name for `manifold-service-view` to be `manifold-service-card-view` to match documentation.
-- Added missing support for theme variable `--manifold-tag-free-text-color`.
-- Fixed region selector so that it properly emits a `manifold-planSelector-change` event when the
-  region changes.
-- Fixed scroll highlight for `<manifold-marketplace>` sidebar
+* Fixed name for `manifold-service-view` to be `manifold-service-card-view` to match documentation.
+* Added missing support for theme variable `--manifold-tag-free-text-color`.
+* Fixed region selector so that it properly emits a `manifold-planSelector-change` event when the region changes.
+* Fixed scroll highlight for `<manifold-marketplace>` sidebar
 
 ##### Chores
 
-- Added graphqlFetch to `manifold-connection`.
-- Converted `manifold-data-product-logo` to use GraphQL.
-- Changed the provision button so it fetches the owner ID automatically if not set.
-- Added `productName` to `manifold-marketplace-click` event in the `manifold-service-card`
-  component.
-- Improved `plan-selector` performance by reducing API calls for non-custom plans.
+* Added graphqlFetch to `manifold-connection`.
+* Converted `manifold-data-product-logo` to use GraphQL.
+* Changed the provision button so it fetches the owner ID automatically if not set.
+* Added `productName` to `manifold-marketplace-click` event in the `manifold-service-card` component.
+* Improved `plan-selector` performance by reducing API calls for non-custom plans.
 
 #### 0.5.1 (2019-08-01)
 
 ##### Breaking changes
 
-- `resource-label` removed from `<manifold-data-product-logo>` in favor of new
-  `<manifold-data-resource-logo>` component
+* `resource-label` removed from `<manifold-data-product-logo>` in favor of new `<manifold-data-resource-logo>` component
 
 #### 0.5.0 (2019-07-25)
 
 ##### New Features
 
-- Added a SSO data button and the resource wrapper for ssoing into a resource's product dashboard.
-- Added a new CTA slot in the product card for displaying unique cta content.
+* Added a SSO data button and the resource wrapper for ssoing into a resource's product dashboard.
+* Added a new CTA slot in the product card for displaying unique cta content.
 
 ##### Bug Fixes
 
-- Fixed the provision button requiring the label to be set, preventing or automatic label generation
-  from working.
+* Fixed the provision button requiring the label to be set, preventing or automatic label generation from working.
 
 ##### Chores
 
-- Changed the `manifold-auth-token` component to now use the shadowcat oauth system rather than only
-  use the given token. This enables platforms to now use real authentication.
+* Changed the `manifold-auth-token` component to now use the shadowcat oauth system rather than only use the given token. This enables platforms to now use real authentication.
 
 #### 0.4.3 (2019-07-16)
 
 ##### Bug Fixes
 
-- Fixed the rename and deprovision button not behaving properly when used in their resource warpers
+* Fixed the rename and deprovision button not behaving properly when used in their resource warpers
 
 #### 0.4.2 (2019-07-16)
 
 ##### Chores
 
-- Changed the deprovision and rename button to not include a shadow dom root, they can now be styled
-  from external stylesheets.
+* Changed the deprovision and rename button to not include a shadow dom root, they can now be styled from external stylesheets.
 
 #### 0.4.1 (2019-07-15)
 
 ##### Chores
 
-- Made all the internal attributes optional on the components to make sure TypeScript does not
-  complain.
+* Made all the internal attributes optional on the components to make sure TypeScript does not complain.
 
 #### 0.4.0 (2019-07-15)
 
 ##### Breaking changes
 
-- Deprecated the `resource-name` attribute in all the resource components for `resource-label` as to
-  be more consistent with the other components and our other codebases.
-- `resource-name` renamed to `resource-label` in the following components:
-  `<manifold-resource-list>`, `<manifold-resource-plan>`, `<manifold-resource-product>`,
-  `<manifold-data-product-logo>`, `<manifold-data-product-name>`,
-  `<manifold-data-provision-button>`, `<manifold-data-resource-list>`
+* Deprecated the `resource-name` attribute in all the resource components for `resource-label` as to be more consistent with the other components and our other codebases.
+* `resource-name` renamed to `resource-label` in the following components: `<manifold-resource-list>`, `<manifold-resource-plan>`, `<manifold-resource-product>`, `<manifold-data-product-logo>`, `<manifold-data-product-name>`, `<manifold-data-provision-button>`, `<manifold-data-resource-list>`
 
 ##### Chores
 
-- Changed how the `manifold-service-card` works to have it fetch the product unless given. This
-  allows it to be used standalone or in the `marketplace`.
+* Changed how the `manifold-service-card` works to have it fetch the product unless given. This allows it to be used standalone or in the `marketplace`.
 
 #### 0.3.1 (2019-07-12)
 
 ##### New Features
 
-- New `manifold-resource-product` and `manifold-resource-plan` component to load a resource's
-  product and plan card.
-- New `manifold-data-deprovision-button` component that allows to deprovision a resource.
-- New `manifold-data-rename-button` component that allows to rename a resource.
-- New `manifold-credentials` component that allows to see a resource's credentials without needing
-  to be in a `resource-container`.
-- New `manifold-mock-resource` component that allows to mock a `resource-container` with a fake
-  resource.
-- Added new size to `manifold-resource-status`
+* New `manifold-resource-product` and `manifold-resource-plan` component to load a resource's product and plan card.
+* New `manifold-data-deprovision-button` component that allows to deprovision a resource.
+* New `manifold-data-rename-button` component that allows to rename a resource.
+* New `manifold-credentials` component that allows to see a resource's credentials without needing to be in a `resource-container`.
+* New `manifold-mock-resource` component that allows to mock a `resource-container` with a fake resource.
+* Added new size to `manifold-resource-status`
 
 ##### Chores
 
-- Changed the input from the `manifold-data-provision-button` to remove the input make it a pure
-  button.
-- Changed the `manifold-resource-credentials` component to use the standalone `manifold-credentials`
-  component.
+* Changed the input from the `manifold-data-provision-button` to remove the input make it a pure button.
+* Changed the `manifold-resource-credentials` component to use the standalone `manifold-credentials` component.
 
 #### 0.3.0 (2019-07-09)
 
-- https://github.com/manifoldco/ui/compare/v0.2.2...v0.3.0
+* https://github.com/manifoldco/ui/compare/v0.2.2...v0.3.0
 
 #### 0.2.2 (2019-07-08)
 
-- https://github.com/manifoldco/ui/compare/v0.2.1...v0.2.2
+* https://github.com/manifoldco/ui/compare/v0.2.1...v0.2.2
 
 #### 0.2.1 (2019-07-05)
 
-- https://github.com/manifoldco/ui/compare/v0.2.0...v0.2.1
+* https://github.com/manifoldco/ui/compare/v0.2.0...v0.2.1
 
 #### 0.2.0 (2019-07-04)
 
-- https://github.com/manifoldco/ui/compare/v0.1.1...v0.2.0
+* https://github.com/manifoldco/ui/compare/v0.1.1...v0.2.0
 
 #### 0.1.1 (2019-06-19)
 
-- https://github.com/manifoldco/ui/compare/v0.1.0...v0.1.1
+* https://github.com/manifoldco/ui/compare/v0.1.0...v0.1.1
 
 #### 0.1.0 (2019-06-13)
 
-- https://github.com/manifoldco/ui/compare/v0.0.3...v0.1.0
+* https://github.com/manifoldco/ui/compare/v0.0.3...v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -366,7 +366,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Deprecated the `resource-name` attribute in all the resource components for `resource-label` as to
   be more consistent with the other components and our other codebases.
 
-## [0.3.1] - 2019-07-12
+## 0.3.1 - 2019-07-12
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,12 +29,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `<manifold-resource-list>`
 - Added test for `<manifold-plan-selector regions="">` (#644)
 
-### Removed
-
-- Removed `manifold-resource-details` component. (#597)
-- `<manifold-data-provision-button>` now requires `plan-id` rather than `plan-label` as a prop
-- `<manifold-plan>` now requires `plan-id` rather than `plan-label` as a prop
-
 ### Changed
 
 - Converted `manifold-resource-container` to use the GraphQL.
@@ -61,6 +55,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Converted `<manifold-resource-list>` to use GraphQL (#627)
 - Converted `<manifold-data-sso-button>` to use GraphQL (#640)
 
+### Removed
+
+- Removed `manifold-resource-details` component. (#597)
+- `<manifold-data-provision-button>` now requires `plan-id` rather than `plan-label` as a prop
+- `<manifold-plan>` now requires `plan-id` rather than `plan-label` as a prop
+
 ## [0.5.17] - 2019-10-02
 
 ### Changed
@@ -82,6 +82,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.5.15] - 2019-09-29
 
+### Added
+
 - Added `manifold-resource-load` event to `manifold-resource-container` (#556)
 
 ## [0.5.14] - 2019-09-29
@@ -90,15 +92,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Added `disabled` attribute to `manifold-resource-rename` (#553)
 
+### Changed
+
+- Changed number of skeleton products that load (#551)
+
 ### Fixed
 
 - Fixed local testing addresses.
 - Fixed console warning about `loading="lazy"` (#552)
 - Prevent actions on `<manifold-credentials>` while awaiting a resourceLabel (#554)
-
-### Changed
-
-- Changed number of skeleton products that load (#551)
 
 ## [0.5.13] - 2019-09-29
 
@@ -154,13 +156,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Enabled custom loading indicators. (#471)
 - Added `<manifold-copy-credentials>` for quickly-copying secrets to a user’s clipboard. (#452)
 
-### Fixed
-
-- Multiple queries in GraphQL now supported in TypeScript. (#476)
-
 ### Changed
 
 - Clarified documentation for multiple components. (#481)
+
+### Fixed
+
+- Multiple queries in GraphQL now supported in TypeScript. (#476)
 
 ## [0.5.9] - 2019-09-05
 
@@ -169,11 +171,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added an events queue to `<manifold-performance>` to capture any performance events emitted before
   DataDog is ready. (#451)
 - Added more event data & testing for `<manifold-data-provision-button>`. (#447)
-
-### Fixed
-
-- Fixed a typo in manifold-data-deprovision-button documentation. (#457)
-- Upgraded `@manifoldco/shadowcat` to feature the latest security patches. (#477)
 
 ### Changed
 
@@ -184,7 +181,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Changed `manifold-data-product-name` to use GraphQL. (#463)
 - Changed `manifold-data-resource-list` to use GraphQL. (#474)
 
+### Fixed
+
+- Fixed a typo in manifold-data-deprovision-button documentation. (#457)
+- Upgraded `@manifoldco/shadowcat` to feature the latest security patches. (#477)
+
 ## [0.5.8] - 2019-08-26
+
+### Changed
+
+- Enforce standard height on product cards for more consistency. (#435)
+- Replace auth token polling with an event based system. (#436)
 
 ### Fixed
 
@@ -193,17 +200,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - When an expired auth token causes an API call to respond with a 401, the token will now refresh
   and the API call will retry. (#440)
 
-### Changed
-
-- Enforce standard height on product cards for more consistency. (#435)
-- Replace auth token polling with an event based system. (#436)
-
 ## [0.5.7] - 2019-08-23
 
 ### Added
 
 - We now release and publish our components to our CDN @
   `https://js.cdn.manifold.co/@manifoldco/ui`. (#408, #418)
+- `<manifold-performance>` component for partners to add opt-in metrics collection to their
+  implementation (#427)
+
+### Changed
+
+- Removed padding above `<manifold-product-page>` (#399)
+- Adjusted positioning for CTA slot in `manifold-service-card-view`. (#404)
 
 ### Fixed
 
@@ -212,16 +221,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Performance optimizations for network calls in `manifold-marketplace`. (#424)
 - Prevent provision button from being clicked multiple times. (#410)
 - Fixed a bug in Firefox with `<manifold-auth-token>`. (#429)
-
-### Changed
-
-- Removed padding above `<manifold-product-page>` (#399)
-- Adjusted positioning for CTA slot in `manifold-service-card-view`. (#404)
-
-### Added
-
-- `<manifold-performance>` component for partners to add opt-in metrics collection to their
-  implementation (#427)
 
 ## [0.5.6] - 2019-08-21
 
@@ -244,12 +243,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.5.4] - 2019-08-15
 
-### Fixed
-
-- Fixed the service card loading the free badge after rendering, which caused a jumpy UI. (#355)
-- Added the ability to specify a slot on the `manifold-credentials` with a default manifold button
-  if not set. (#362)
-
 ### Changed
 
 - Updated Stencil to v1.2.5 (#375)
@@ -259,10 +252,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Fixed the service card loading the free badge after rendering, which caused a jumpy UI. (#355)
+- Added the ability to specify a slot on the `manifold-credentials` with a default manifold button
+  if not set. (#362)
 - Fixed issue where success event of `manifold-data-rename-resource` was emitted before renamed
   resource was ready. (#380)
 
 ## [0.5.3] - 2019-08-12
+
+### Added
+
+- Added a `refetch-until-valid` property on the `resource-container` component to allow users to
+  reload this component until the found resource exists and is of state `available`.
+- Added the terms of service to the product page component.
+- Added `<manifold-plan-selector free-plans>` filter flag
 
 ### Fixed
 
@@ -274,32 +277,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   look misaligned.
 - Fixed the appearance of “free“ badges on product cards in `<manifold-marketplace>`
 
-### Added
-
-- Added a `refetch-until-valid` property on the `resource-container` component to allow users to
-  reload this component until the found resource exists and is of state `available`.
-- Added the terms of service to the product page component.
-- Added `<manifold-plan-selector free-plans>` filter flag
-
 ## [0.5.2] - 2019-08-02
 
 ### Added
 
 - Added `oauth-url` prop to `manifold-auth-token` component.
-
-### Fixed
-
-- Fixed name for `manifold-service-view` to be `manifold-service-card-view` to match documentation.
-- Added missing support for theme variable `--manifold-tag-free-text-color`.
-- Fixed region selector so that it properly emits a `manifold-planSelector-change` event when the
-  region changes.
-- Fixed scroll highlight for `<manifold-marketplace>` sidebar
-
-### Deprecated
-
-- Deprecated `resource-label` attibute on `manifold-data-product-logo`. Use
-  `manifold-data-resource-logo` component instead.
-- Deprecated `region-name` prop in favour of `region-id` for `manifold-data-provision-button`.
 
 ### Changed
 
@@ -309,6 +291,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added `productName` to `manifold-marketplace-click` event in the `manifold-service-card`
   component.
 - Improved `plan-selector` performance by reducing API calls for non-custom plans.
+
+### Deprecated
+
+- Deprecated `resource-label` attibute on `manifold-data-product-logo`. Use
+  `manifold-data-resource-logo` component instead.
+- Deprecated `region-name` prop in favour of `region-id` for `manifold-data-provision-button`.
+
+### Fixed
+
+- Fixed name for `manifold-service-view` to be `manifold-service-card-view` to match documentation.
+- Added missing support for theme variable `--manifold-tag-free-text-color`.
+- Fixed region selector so that it properly emits a `manifold-planSelector-change` event when the
+  region changes.
+- Fixed scroll highlight for `<manifold-marketplace>` sidebar
 
 ## [0.5.1] - 2019-08-01
 
@@ -324,15 +320,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added a SSO data button and the resource wrapper for ssoing into a resource's product dashboard.
 - Added a new CTA slot in the product card for displaying unique cta content.
 
-### Fixed
-
-- Fixed the provision button requiring the label to be set, preventing or automatic label generation
-  from working.
-
 ### Changed
 
 - Changed the `manifold-auth-token` component to now use the shadowcat oauth system rather than only
   use the given token. This enables platforms to now use real authentication.
+
+### Fixed
+
+- Fixed the provision button requiring the label to be set, preventing or automatic label generation
+  from working.
 
 ## [0.4.3] - 2019-07-16
 
@@ -356,11 +352,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.4.0] - 2019-07-15
 
-### Deprecated
-
-- Deprecated the `resource-name` attribute in all the resource components for `resource-label` as to
-  be more consistent with the other components and our other codebases.
-
 ### Changed
 
 - Changed how the `manifold-service-card` works to have it fetch the product unless given. This
@@ -369,6 +360,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `<manifold-resource-list>`, `<manifold-resource-plan>`, `<manifold-resource-product>`,
   `<manifold-data-product-logo>`, `<manifold-data-product-name>`,
   `<manifold-data-provision-button>`, `<manifold-data-resource-list>`
+
+### Deprecated
+
+- Deprecated the `resource-name` attribute in all the resource components for `resource-label` as to
+  be more consistent with the other components and our other codebases.
 
 ## [0.3.1] - 2019-07-12
 
@@ -391,10 +387,28 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Changed the `manifold-resource-credentials` component to use the standalone `manifold-credentials`
   component.
 
-[0.3.0]: https://github.com/manifoldco/ui/compare/v0.2.2...v0.3.0
-[0.2.2]: https://github.com/manifoldco/ui/compare/v0.2.1...v0.2.2
-[0.2.1]: https://github.com/manifoldco/ui/compare/v0.2.0...v0.2.1
-[0.2.0]: https://github.com/manifoldco/ui/compare/v0.1.1...v0.2.0
-[0.1.1]: https://github.com/manifoldco/ui/compare/v0.1.0...v0.1.1
-[0.1.0]: https://github.com/manifoldco/ui/compare/v0.0.2...v0.1.0
-[0.0.3]: https://github.com/manifoldco/ui/releases/tag/v0.0.3
+[unreleased]: https://github.com/manifoldco/ui/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/manifoldco/ui/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/manifoldco/ui/compare/v0.5.17...v0.6.0
+[0.5.17]: https://github.com/manifoldco/ui/compare/v0.5.16...v0.5.17
+[0.5.16]: https://github.com/manifoldco/ui/compare/v0.5.15...v0.5.16
+[0.5.15]: https://github.com/manifoldco/ui/compare/v0.5.14...v0.5.15
+[0.5.14]: https://github.com/manifoldco/ui/compare/v0.5.13...v0.5.14
+[0.5.13]: https://github.com/manifoldco/ui/compare/v0.5.12...v0.5.13
+[0.5.12]: https://github.com/manifoldco/ui/compare/v0.5.11...v0.5.12
+[0.5.11]: https://github.com/manifoldco/ui/compare/v0.5.10...v0.5.11
+[0.5.10]: https://github.com/manifoldco/ui/compare/v0.5.9...v0.5.10
+[0.5.9]: https://github.com/manifoldco/ui/compare/v0.5.8...v0.5.9
+[0.5.8]: https://github.com/manifoldco/ui/compare/v0.5.7...v0.5.8
+[0.5.7]: https://github.com/manifoldco/ui/compare/v0.5.6...v0.5.7
+[0.5.6]: https://github.com/manifoldco/ui/compare/v0.5.5...v0.5.6
+[0.5.5]: https://github.com/manifoldco/ui/compare/v0.5.4...v0.5.5
+[0.5.4]: https://github.com/manifoldco/ui/compare/v0.5.3...v0.5.4
+[0.5.3]: https://github.com/manifoldco/ui/compare/v0.5.2...v0.5.3
+[0.5.2]: https://github.com/manifoldco/ui/compare/v0.5.1...v0.5.2
+[0.5.1]: https://github.com/manifoldco/ui/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/manifoldco/ui/compare/v0.4.3...v0.5.0
+[0.4.3]: https://github.com/manifoldco/ui/compare/v0.4.2...v0.4.3
+[0.4.2]: https://github.com/manifoldco/ui/compare/v0.4.1...v0.4.2
+[0.4.1]: https://github.com/manifoldco/ui/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/manifoldco/ui/compare/v0.3.1...v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,371 +1,391 @@
-#### 0.6.1 (2019-10-25)
+# Changelog
 
-##### Bug Fixes
+All notable changes to this project will be documented in this file.
 
-* Removed Node version restriction on package (#659)
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-##### Chores
+## [Unreleased]
 
-* Updated Stencil to v1.7.4 (#652)
+### Changed
 
-#### 0.6.0 (2019-10-22)
+- Move checks from CircleCI to GitHub Actions (#661)
 
-##### Breaking Changes:
+## [0.6.1]
 
-* `<manifold-data-provision-button>` now requires `plan-id` rather than `plan-label` as a prop
-* `<manifold-plan>` now requires `plan-id` rather than `plan-label` as a prop
+### Changed
 
-##### New Features
+- Removed Node version restriction on package (#659)
+- Updated Stencil to v1.7.4 (#652)
 
-* Added a `sidebar` slot to `<manifold-marketplace>` (#612)
-* Exposed `ensureAuthToken` function for making authenticated GraphQL calls directly from platforms (#576)
-* Added `ownerId` prop to `<manifold-data-provision-button>`, `<manifold-data-resource-list>`, and `<manifold-resource-list>`
+## [0.6.0]
 
-##### Performance Improvements
+### Added
 
-* Converted `manifold-resource-container` to use the GraphQL.
-* Converted `manifold-resource-plan` to use the GraphQL data fetched from the `manifold-resource-container`. (#578)
-* Converted `manifold-resource-credentials` to use the GraphQL data fetched from the `manifold-resource-container`. (#584)
-* Converted `manifold-resource-deprovision` to use the GraphQL data fetched from the `manifold-resource-container`. (#595)
-* Converted `<manifold-data-rename-button>` to use GraphQL (#596)
-* Converted `<manifold-data-provision-button>` to use GraphQL data (#600)
-* Converted `manifold-resource-rename` to use the GraphQL data fetched from the `manifold-resource-container`. (#602)
-* Converted `manifold-resource-sso` to use the GraphQL data fetched from the `manifold-resource-container`. (#603)
-* Converted `<manifold-data-deprovision-button>` to use GraphQL (#604)
-* Converted `<manifold-plan-cost>` to GraphQL (#605)
-* Converted `<manifold-data-resize-button>` to use GraphQL (#609)
-* Converted `<manifold-resource-status>` to use GraphQL (#611)
-* Converted `<manifold-resource-list>` to use GraphQL (#627)
-* Converted `<manifold-data-resource-logo>` to use GraphQL (#635)
-* Converted `<manifold-data-sso-button>` to use GraphQL (#640)
+- Added a `sidebar` slot to `<manifold-marketplace>` (#612)
+- Exposed `ensureAuthToken` function for making authenticated GraphQL calls directly from platforms
+  (#576)
+- Added `ownerId` prop to `<manifold-data-provision-button>`, `<manifold-data-resource-list>`, and
+  `<manifold-resource-list>`
+- Added test for `<manifold-plan-selector regions="">` (#644)
 
-##### Chores
+### Removed
 
-* Removed `manifold-resource-details` component. (#597)
-* Owner ID no longer fetched to create/delete resources (#608)
-* Updated `<manifold-product>` ahead of a GraphQL deprecation (#619)
-* Updated Stencil to v1.7.2 (#631)
-* Added test for `<manifold-plan-selector regions="">` (#644)
+- Removed `manifold-resource-details` component. (#597)
+- `<manifold-data-provision-button>` now requires `plan-id` rather than `plan-label` as a prop
+- `<manifold-plan>` now requires `plan-id` rather than `plan-label` as a prop
 
-#### 0.5.17 (2019-10-02)
+### Changed
 
-##### Performance Improvements
+- Converted `manifold-resource-container` to use the GraphQL.
+- Converted `manifold-resource-plan` to use the GraphQL data fetched from the
+  `manifold-resource-container`. (#578)
+- Converted `manifold-resource-credentials` to use the GraphQL data fetched from the
+  `manifold-resource-container`. (#584)
+- Converted `manifold-resource-deprovision` to use the GraphQL data fetched from the
+  `manifold-resource-container`. (#595)
+- Converted `<manifold-data-provision-button>` to use GraphQL data (#600)
+- Converted `manifold-resource-rename` to use the GraphQL data fetched from the
+  `manifold-resource-container`. (#602)
+- Converted `<manifold-data-rename-button>` to use GraphQL (#596)
+- Converted `manifold-resource-sso` to use the GraphQL data fetched from the
+  `manifold-resource-container`. (#603)
+- Converted `<manifold-data-deprovision-button>` to use GraphQL (#604)
+- Converted `<manifold-plan-cost>` to GraphQL (#605)
+- Updated Stencil to v1.7.2 (#631)
+- Owner ID no longer fetched to create/delete resources (#608)
+- Converted `<manifold-data-resize-button>` to use GraphQL
+- Updated `<manifold-product>` ahead of a GraphQL deprecation (#619)
+- Converted `<manifold-data-resource-logo>` to use GraphQL (#635)
+- Converted `<manifold-resource-status>` to use GraphQL (#611)
+- Converted `<manifold-resource-list>` to use GraphQL (#627)
+- Converted `<manifold-data-sso-button>` to use GraphQL (#640)
 
-* Converted `manifold-resource-product` to use the GraphQL data fetched from the `manifold-resource-container`. (#566)
+## [0.5.17]
 
-#### 0.5.16 (2019-09-30)
+### Changed
 
-##### Chores
+- Converted `manifold-resource-product` to use the GraphQL data fetched from the
+  `manifold-resource-container`. (#566)
 
-* Added `manifold-product-load` event (#560)
+## [0.5.16]
 
-##### New Features
+### Added
 
-* Deprecated friendly resource names in favor of kebab-case resource labels (#559)
-* Removed `resource-id` prop from `manifild-resource-card` (#537)
-* Converted `manifold-resource-card` to GraphQL (#537)
+- `manifold-product-load` event (#560)
 
-#### 0.5.15 (2019-09-29)
+### Changed
 
-##### New Features
+- Deprecated friendly resource names in favor of kebab-case resource labels (#559)
+- Removed `resource-id` prop from `manifild-resource-card` (#537)
+- Converted `manifold-resource-card` to GraphQL (#537)
 
-* Added `manifold-resource-load` event to `manifold-resource-container` (#556)
+## [0.5.15]
 
-#### 0.5.14 (2019-09-29)
+- Added `manifold-resource-load` event to `manifold-resource-container` (#556)
 
-##### New Features
+## [0.5.14]
 
-* Added `disabled` attribute to `manifold-resource-rename` (#553)
+### Added
 
-##### Bug Fixes
+- Added `disabled` attribute to `manifold-resource-rename` (#553)
 
-* Fixed local testing addresses.
-* Fixed console warning about `loading="lazy"` (#552)
-* Prevent actions on `<manifold-credentials>` while awaiting a resourceLabel (#554)
+### Fixed
 
-##### Chores
+- Fixed local testing addresses.
+- Fixed console warning about `loading="lazy"` (#552)
+- Prevent actions on `<manifold-credentials>` while awaiting a resourceLabel (#554)
 
-* Changed number of skeleton products that load (#551)
+### Changed
 
-#### 0.5.13 (2019-09-29)
+- Changed number of skeleton products that load (#551)
 
-##### Bug Fixes
+## [0.5.13]
 
-* Credentials appear one-per-line (#546)
-* Fixed credential error message top margin (#545)
-* Fixed success event after a resource rename to include potentially modified label (#547)
+### Fixed
 
-#### 0.5.12 (2019-09-26)
+- Credentials appear one-per-line (#546)
+- Fixed credential error message top margin (#545)
+- Fixed success event after a resource rename to include potentially modified label (#547)
 
-##### Breaking changes
+## [0.5.12]
 
-* `resource-id` renamed to `resource-label` in `<manifold-resource-card>`
-* `product-id` renamed to `product-label` in `<manifold-service-card>`
+### Added
 
-##### New Features
+- Added `label` to `<manifold-data-has-resource>` (#542)
 
-* Added `label` to `<manifold-data-has-resource>` (#542)
+### Changed
 
-##### Chores
+- `resource-id` renamed to `resource-label` in `<manifold-resource-card>`
+- `product-id` renamed to `product-label` in `<manifold-service-card>`
+- Removed `product-id` from `manifold-service-card` (#533)
+- Converted `manifold-service-card` to GraphQL (#533)
 
-* Removed `product-id` from `manifold-service-card` (#533)
+### Fixed
 
-##### Performance Improvements
+- Fixed loading flicker of resource components while provisioning/deprovisioning. (#539)
 
-* Converted `manifold-service-card` to GraphQL (#533)
+## [0.5.11]
 
-##### Bug Fixes
+### Added
 
-* Fixed loading flicker of resource components while provisioning/deprovisioning. (#539)
+- Ability to authenticate and refresh manually, bypassing OAuth. (#495)
+- Added a time to first meaningful render event to be consumed by `<manifold-performance>` component
+  (#501)
 
-#### 0.5.11 (2019-09-19)
+### Changed
 
-##### New Features
+- Changed `manifold-marketplace` to use GraphQL. (#489)
+- Improved Storybook stories (#500)
+- `@manifoldco/shadowcat` is now part of UI. (#498)
+- `<manifold-data-provision-button>` will now work even if given an undefined resource label. The
+  API will auto-generate the label if omitted. (#503)
 
-* Ability to authenticate and refresh manually, bypassing OAuth. (#495)
-* Added a time to first meaningful render event to be consumed by `<manifold-performance>` component (#501)
+### Fixed
 
-##### Chores
+- Fixed `<manifold-button>` borders (#500)
+- `<manifold-credentials>` now uses GraphQL (#490)
+- `<manifold-marketplace>` fetches products in one request (#522)
 
-* Changed `manifold-marketplace` to use GraphQL. (#489)
-* Improved Storybook stories (#500)
-* `@manifoldco/shadowcat` is now part of UI. (#498)
-* `<manifold-data-provision-button>` will now work even if given an undefined resource label. The API will auto-generate the label if omitted. (#503)
+## [0.5.10]
 
-##### Bug Fixes
+### Added
 
-* Fixed `<manifold-button>` borders (#500)
-* `<manifold-credentials>` now uses GraphQL (#490)
-* `<manifold-marketplace>` fetches products in one request (#522)
+- Enabled custom loading indicators. (#471)
+- Added `<manifold-copy-credentials>` for quickly-copying secrets to a user’s clipboard. (#452)
 
-#### 0.5.10 (2019-09-09)
+### Fixed
 
-##### New Features
+- Multiple queries in GraphQL now supported in TypeScript. (#476)
 
-* Enabled custom loading indicators. (#471)
-* Added `<manifold-copy-credentials>` for quickly-copying secrets to a user’s clipboard. (#452)
+### Changed
 
-##### Bug Fixes
+- Clarified documentation for multiple components. (#481)
 
-* Multiple queries in GraphQL now supported in TypeScript. (#476)
+## [0.5.9]
 
-##### Chores
+### Added
 
-* Clarified documentation for multiple components. (#481)
+- Added an events queue to `<manifold-performance>` to capture any performance events emitted before
+  DataDog is ready. (#451)
+- Added more event data & testing for `<manifold-data-provision-button>`. (#447)
 
-## 0.5.9 (2019-09-05)
+### Fixed
 
-##### New Features
+- Fixed a typo in manifold-data-deprovision-button documentation. (#457)
+- Upgraded `@manifoldco/shadowcat` to feature the latest security patches. (#477)
 
-* Added an events queue to `<manifold-performance>` to capture any performance events emitted before DataDog is ready. (#451)
-* Added more event data & testing for `<manifold-data-provision-button>`. (#447)
+### Changed
 
-##### Bug Fixes
+- Changed the docs fetch mocking to now wait for the real request duration. This duration is
+  obtained at build time from the manifold APIs. (#450)
+- Changed the `manifold-product` component to now use the GraphQL API rather than the REST API.
+  (#456)
+- Changed `manifold-data-product-name` to use GraphQL. (#463)
+- Changed `manifold-data-resource-list` to use GraphQL. (#474)
 
-* Fixed a typo in manifold-data-deprovision-button documentation. (#457)
-* Upgraded `@manifoldco/shadowcat` to feature the latest security patches. (#477)
+## [0.5.8]
 
-##### Chores
+### Fixed
 
-* Changed the docs fetch mocking to now wait for the real request duration. This duration is obtained at build time from the manifold APIs. (#450)
-* Changed the `manifold-product` component to now use the GraphQL API rather than the REST API. (#456)
-* Changed `manifold-data-product-name` to use GraphQL. (#463)
-* Changed `manifold-data-resource-list` to use GraphQL. (#474)
+- Fixed resource card CTA slot from flashing while loading. (#438)
+- Hide credentials button no longer flashes when credentials component loads. (#434)
+- When an expired auth token causes an API call to respond with a 401, the token will now refresh
+  and the API call will retry. (#440)
 
-#### 0.5.8 (2019-08-26)
+### Changed
 
-##### Bug Fixes
+- Enforce standard height on product cards for more consistency. (#435)
+- Replace auth token polling with an event based system. (#436)
 
-* Fixed resource card CTA slot from flashing while loading. (#438)
-* Hide credentials button no longer flashes when credentials component loads. (#434)
-* When an expired auth token causes an API call to respond with a 401, the token will now refresh and the API call will retry. (#440)
+## [0.5.7]
 
-##### Chores
+### Added
 
-* Enforce standard height on product cards for more consistency. (#435)
-* Replace auth token polling with an event based system. (#436)
+- We now release and publish our components to our CDN @
+  `https://js.cdn.manifold.co/@manifoldco/ui`. (#408, #418)
 
-#### 0.5.7 (2019-08-23)
+### Fixed
 
-##### New Features
+- Fixed events firing twice for `<manifold-resource-rename>`, `<manifold-resource-sso>`, and
+  `<manifold-resource-deprovision>`. (#401)
+- Performance optimizations for network calls in `manifold-marketplace`. (#424)
+- Prevent provision button from being clicked multiple times. (#410)
+- Fixed a bug in Firefox with `<manifold-auth-token>`. (#429)
 
-* `<manifold-performance>` component for partners to add opt-in metrics collection to their implementation (#427)
-* We now release and publish our components to our CDN @ `https://js.cdn.manifold.co/@manifoldco/ui`. (#408, #418)
+### Changed
 
-##### Bug Fixes
+- Removed padding above `<manifold-product-page>` (#399)
+- Adjusted positioning for CTA slot in `manifold-service-card-view`. (#404)
 
-* Fixed events firing twice for `<manifold-resource-rename>`, `<manifold-resource-sso>`, and `<manifold-resource-deprovision>`. (#401)
-* Performance optimizations for network calls in `manifold-marketplace`. (#424)
-* Prevent provision button from being clicked multiple times. (#410)
-* Fixed a bug in Firefox with `<manifold-auth-token>`. (#429)
-* Removed padding above `<manifold-product-page>` (#399)
-* Adjusted positioning for CTA slot in `manifold-service-card-view`. (#404) )
+### Added
 
-#### 0.5.6 (2019-08-21)
+- `<manifold-performance>` component for partners to add opt-in metrics collection to their
+  implementation (#427)
 
-##### New Features
+## [0.5.5]
 
-* Emit metrics events from restFetch and graphqlFetch (#396)
+### Fixed
 
-##### Bug Fixes
+- Stability improvements for GraphQL queries (#376)
+- Improved loading state for `<manifold-resource-list>` (#382)
+- Fixed public endpoints trying to authenticate (#383)
+- Fixed “no services“ flash on `<manifold-marketplace>` (#390)
 
-* Fixed flash of “No services found” on marketplace grid (#390)
+## [0.5.4]
 
-#### 0.5.5 (2019-08-16)
+### Fixed
 
-##### Bug Fixes
+- Fixed the service card loading the free badge after rendering, which caused a jumpy UI. (#355)
+- Added the ability to specify a slot on the `manifold-credentials` with a default manifold button
+  if not set. (#362)
 
-* Stability improvements for GraphQL queries (#376)
-* Improved loading state for `<manifold-resource-list>` (#382)
-* Fixed public endpoints trying to authenticate (#383)
-* Fixed “no services“ flash on `<manifold-marketplace>` (#390)
+### Changed
 
-#### 0.5.4 (2019-08-15)
+- Updated Stencil to v1.2.5 (#375)
+- Changed the event name for the `manifold-auth-token` component from the stencil auto-generated
+  name to `manifold-token-receive` and documented that event. (#360)
+- View component `<manifold-service-card-view>` no longer fetches data, is it should (#355)
 
-##### Bug Fixes
+### Fixed
 
-* Fixed the service card loading the free badge after rendering, which caused a jumpy UI. (#355)
-* Added the ability to specify a slot on the `manifold-credentials` with a default manifold button if not set. (#362)
-
-##### Chores
-
-* Updated Stencil to v1.2.5 (#375)
-* Changed the event name for the `manifold-auth-token` component from the stencil auto-generated name to `manifold-token-receive` and documented that event. (#360)
-* View component `<manifold-service-card-view>` no longer fetches data, is it should (#355)
-
-##### Bug Fixes
-
-* Fixed issue where success event of `manifold-data-rename-resource` was emitted before renamed
+- Fixed issue where success event of `manifold-data-rename-resource` was emitted before renamed
   resource was ready. (#380)
 
-#### 0.5.3 (2019-08-12)
+## [0.5.3]
 
-##### Bug Fixes
+### Fixed
 
-* Fixed the deprovision button failing because the code expected a JSON return value.
-* Fixed the resource list not showing the status of provisioning or deprovisioning resources.
-* Fixed the resource card loading indicator - for a lack of a better word - wobbling around like its life depended on it.
-* Fixed the title of the `service-card` taking a dynamic amount of space and making the description look misaligned.
-* Fixed the appearance of “free“ badges on product cards in `<manifold-marketplace>`
+- Fixed the deprovision button failing because the code expected a JSON return value.
+- Fixed the resource list not showing the status of provisioning or deprovisioning resources.
+- Fixed the resource card loading indicator - for a lack of a better word - wobbling around like its
+  life depended on it.
+- Fixed the title of the `service-card` taking a dynamic amount of space and making the description
+  look misaligned.
+- Fixed the appearance of “free“ badges on product cards in `<manifold-marketplace>`
 
-##### New Features
+### Added
 
-* Added a `refetch-until-valid` property on the `resource-container` component to allow users to reload this component until the found resource exists and is of state `available`.
-* Added the terms of service to the product page component.
-* Added `<manifold-plan-selector free-plans>` filter flag
+- Added a `refetch-until-valid` property on the `resource-container` component to allow users to
+  reload this component until the found resource exists and is of state `available`.
+- Added the terms of service to the product page component.
+- Added `<manifold-plan-selector free-plans>` filter flag
 
-#### 0.5.2 (2019-08-02)
+## [0.5.2]
 
-##### Breaking changes
+### Added
 
-* Deprecated `resource-label` attibute on `manifold-data-product-logo`. Use `manifold-data-resource-logo` component instead.
-* Deprecated `region-name` prop in favour of `region-id` for `manifold-data-provision-button`.
+- Added `oauth-url` prop to `manifold-auth-token` component.
 
-##### New Features
+### Fixed
 
-* Added `oauth-url` prop to `manifold-auth-token` component.
+- Fixed name for `manifold-service-view` to be `manifold-service-card-view` to match documentation.
+- Added missing support for theme variable `--manifold-tag-free-text-color`.
+- Fixed region selector so that it properly emits a `manifold-planSelector-change` event when the
+  region changes.
+- Fixed scroll highlight for `<manifold-marketplace>` sidebar
 
-##### Bug Fixes
+### Deprecated
 
-* Fixed name for `manifold-service-view` to be `manifold-service-card-view` to match documentation.
-* Added missing support for theme variable `--manifold-tag-free-text-color`.
-* Fixed region selector so that it properly emits a `manifold-planSelector-change` event when the region changes.
-* Fixed scroll highlight for `<manifold-marketplace>` sidebar
+- Deprecated `resource-label` attibute on `manifold-data-product-logo`. Use
+  `manifold-data-resource-logo` component instead.
+- Deprecated `region-name` prop in favour of `region-id` for `manifold-data-provision-button`.
 
-##### Chores
+### Changed
 
-* Added graphqlFetch to `manifold-connection`.
-* Converted `manifold-data-product-logo` to use GraphQL.
-* Changed the provision button so it fetches the owner ID automatically if not set.
-* Added `productName` to `manifold-marketplace-click` event in the `manifold-service-card` component.
-* Improved `plan-selector` performance by reducing API calls for non-custom plans.
+- Added graphqlFetch to `manifold-connection`.
+- Converted `manifold-data-product-logo` to use GraphQL.
+- Changed the provision button so it fetches the owner ID automatically if not set.
+- Added `productName` to `manifold-marketplace-click` event in the `manifold-service-card`
+  component.
+- Improved `plan-selector` performance by reducing API calls for non-custom plans.
 
-#### 0.5.1 (2019-08-01)
+## [0.5.1]
 
-##### Breaking changes
+### Removed
 
-* `resource-label` removed from `<manifold-data-product-logo>` in favor of new `<manifold-data-resource-logo>` component
+- `resource-label` removed from `<manifold-data-product-logo>` in favor of new
+  `<manifold-data-resource-logo>` component
 
-#### 0.5.0 (2019-07-25)
+## [0.5.0]
 
-##### New Features
+### Added
 
-* Added a SSO data button and the resource wrapper for ssoing into a resource's product dashboard.
-* Added a new CTA slot in the product card for displaying unique cta content.
+- Added a SSO data button and the resource wrapper for ssoing into a resource's product dashboard.
+- Added a new CTA slot in the product card for displaying unique cta content.
 
-##### Bug Fixes
+### Fixed
 
-* Fixed the provision button requiring the label to be set, preventing or automatic label generation from working.
+- Fixed the provision button requiring the label to be set, preventing or automatic label generation
+  from working.
 
-##### Chores
+### Changed
 
-* Changed the `manifold-auth-token` component to now use the shadowcat oauth system rather than only use the given token. This enables platforms to now use real authentication.
+- Changed the `manifold-auth-token` component to now use the shadowcat oauth system rather than only
+  use the given token. This enables platforms to now use real authentication.
 
-#### 0.4.3 (2019-07-16)
+## [0.4.3]
 
-##### Bug Fixes
+### Fixed
 
-* Fixed the rename and deprovision button not behaving properly when used in their resource warpers
+- Fixed the rename and deprovision button not behaving properly when used in their resource warpers
 
-#### 0.4.2 (2019-07-16)
+## [0.4.2]
 
-##### Chores
+### Changed
 
-* Changed the deprovision and rename button to not include a shadow dom root, they can now be styled from external stylesheets.
+- Changed the deprovision and rename button to not include a shadow dom root, they can now be styled
+  from external stylesheets.
 
-#### 0.4.1 (2019-07-15)
+## [0.4.1]
 
-##### Chores
+### Changed
 
-* Made all the internal attributes optional on the components to make sure TypeScript does not complain.
+- Made all the internal attributes optional on the components to make sure TypeScript does not
+  complain.
 
-#### 0.4.0 (2019-07-15)
+## [0.4.0]
 
-##### Breaking changes
+### Deprecated
 
-* Deprecated the `resource-name` attribute in all the resource components for `resource-label` as to be more consistent with the other components and our other codebases.
-* `resource-name` renamed to `resource-label` in the following components: `<manifold-resource-list>`, `<manifold-resource-plan>`, `<manifold-resource-product>`, `<manifold-data-product-logo>`, `<manifold-data-product-name>`, `<manifold-data-provision-button>`, `<manifold-data-resource-list>`
+- Deprecated the `resource-name` attribute in all the resource components for `resource-label` as to
+  be more consistent with the other components and our other codebases.
 
-##### Chores
+### Changed
 
-* Changed how the `manifold-service-card` works to have it fetch the product unless given. This allows it to be used standalone or in the `marketplace`.
+- Changed how the `manifold-service-card` works to have it fetch the product unless given. This
+  allows it to be used standalone or in the `marketplace`.
+- `resource-name` renamed to `resource-label` in the following components:
+  `<manifold-resource-list>`, `<manifold-resource-plan>`, `<manifold-resource-product>`,
+  `<manifold-data-product-logo>`, `<manifold-data-product-name>`,
+  `<manifold-data-provision-button>`, `<manifold-data-resource-list>`
 
-#### 0.3.1 (2019-07-12)
+## [0.3.1]
 
-##### New Features
+### Added
 
-* New `manifold-resource-product` and `manifold-resource-plan` component to load a resource's product and plan card.
-* New `manifold-data-deprovision-button` component that allows to deprovision a resource.
-* New `manifold-data-rename-button` component that allows to rename a resource.
-* New `manifold-credentials` component that allows to see a resource's credentials without needing to be in a `resource-container`.
-* New `manifold-mock-resource` component that allows to mock a `resource-container` with a fake resource.
-* Added new size to `manifold-resource-status`
+- New `manifold-resource-product` and `manifold-resource-plan` component to load a resource's
+  product and plan card.
+- New `manifold-data-deprovision-button` component that allows to deprovision a resource.
+- New `manifold-data-rename-button` component that allows to rename a resource.
+- New `manifold-credentials` component that allows to see a resource's credentials without needing
+  to be in a `resource-container`.
+- New `manifold-mock-resource` component that allows to mock a `resource-container` with a fake
+  resource.
 
-##### Chores
+### Changed
 
-* Changed the input from the `manifold-data-provision-button` to remove the input make it a pure button.
-* Changed the `manifold-resource-credentials` component to use the standalone `manifold-credentials` component.
+- Changed the input from the `manifold-data-provision-button` to remove the input make it a pure
+  button.
+- Changed the `manifold-resource-status` component to now display in two different sizes.
+- Changed the `manifold-resource-credentials` component to use the standalone `manifold-credentials`
+  component.
 
-#### 0.3.0 (2019-07-09)
-
-* https://github.com/manifoldco/ui/compare/v0.2.2...v0.3.0
-
-#### 0.2.2 (2019-07-08)
-
-* https://github.com/manifoldco/ui/compare/v0.2.1...v0.2.2
-
-#### 0.2.1 (2019-07-05)
-
-* https://github.com/manifoldco/ui/compare/v0.2.0...v0.2.1
-
-#### 0.2.0 (2019-07-04)
-
-* https://github.com/manifoldco/ui/compare/v0.1.1...v0.2.0
-
-#### 0.1.1 (2019-06-19)
-
-* https://github.com/manifoldco/ui/compare/v0.1.0...v0.1.1
-
-#### 0.1.0 (2019-06-13)
-
-* https://github.com/manifoldco/ui/compare/v0.0.3...v0.1.0
+[0.3.0]: https://github.com/manifoldco/ui/compare/v0.2.1...v0.3.0
+[0.2.2]: https://github.com/manifoldco/ui/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/manifoldco/ui/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/manifoldco/ui/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/manifoldco/ui/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/manifoldco/ui/compare/v0.0.2...v0.1.0
+[0.1.0]: https://github.com/manifoldco/ui/compare/v0.0.2...v0.1.0
+[0.0.3]: https://github.com/manifoldco/ui/releases/tag/v0.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,3 @@
-#### 2019-10-30
-
-##### Continuous Integration
-
-*  Fix Happo check ([#667](https://github.com/manifoldco/ui/pull/667)) ([856a22c9](https://github.com/manifoldco/ui/commit/856a22c9e55d7f0cef1e0ec88c9288ebba259c08))
-*  Move PR checks from CircleCI to GitHub Actions ([#661](https://github.com/manifoldco/ui/pull/661)) ([23f47deb](https://github.com/manifoldco/ui/commit/23f47deb244f113e415b6340f85cae9983597ea2))
-
 #### 0.6.1 (2019-10-25)
 
 ##### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Move checks from CircleCI to GitHub Actions (#661)
 
-## [0.6.1]
+## [0.6.1] - 2019-10-25
 
 ### Changed
 
 - Removed Node version restriction on package (#659)
 - Updated Stencil to v1.7.4 (#652)
 
-## [0.6.0]
+## [0.6.0] - 2019-10-22
 
 ### Added
 
@@ -61,14 +61,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Converted `<manifold-resource-list>` to use GraphQL (#627)
 - Converted `<manifold-data-sso-button>` to use GraphQL (#640)
 
-## [0.5.17]
+## [0.5.17] - 2019-10-02
 
 ### Changed
 
 - Converted `manifold-resource-product` to use the GraphQL data fetched from the
   `manifold-resource-container`. (#566)
 
-## [0.5.16]
+## [0.5.16] - 2019-09-30
 
 ### Added
 
@@ -80,11 +80,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Removed `resource-id` prop from `manifild-resource-card` (#537)
 - Converted `manifold-resource-card` to GraphQL (#537)
 
-## [0.5.15]
+## [0.5.15] - 2019-09-29
 
 - Added `manifold-resource-load` event to `manifold-resource-container` (#556)
 
-## [0.5.14]
+## [0.5.14] - 2019-09-29
 
 ### Added
 
@@ -100,7 +100,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Changed number of skeleton products that load (#551)
 
-## [0.5.13]
+## [0.5.13] - 2019-09-29
 
 ### Fixed
 
@@ -108,7 +108,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed credential error message top margin (#545)
 - Fixed success event after a resource rename to include potentially modified label (#547)
 
-## [0.5.12]
+## [0.5.12] - 2019-09-26
 
 ### Added
 
@@ -125,7 +125,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fixed loading flicker of resource components while provisioning/deprovisioning. (#539)
 
-## [0.5.11]
+## [0.5.11] - 2019-09-19
 
 ### Added
 
@@ -147,7 +147,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `<manifold-credentials>` now uses GraphQL (#490)
 - `<manifold-marketplace>` fetches products in one request (#522)
 
-## [0.5.10]
+## [0.5.10] - 2019-09-09
 
 ### Added
 
@@ -162,7 +162,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Clarified documentation for multiple components. (#481)
 
-## [0.5.9]
+## [0.5.9] - 2019-09-05
 
 ### Added
 
@@ -184,7 +184,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Changed `manifold-data-product-name` to use GraphQL. (#463)
 - Changed `manifold-data-resource-list` to use GraphQL. (#474)
 
-## [0.5.8]
+## [0.5.8] - 2019-08-26
 
 ### Fixed
 
@@ -198,7 +198,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Enforce standard height on product cards for more consistency. (#435)
 - Replace auth token polling with an event based system. (#436)
 
-## [0.5.7]
+## [0.5.7] - 2019-08-23
 
 ### Added
 
@@ -223,7 +223,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `<manifold-performance>` component for partners to add opt-in metrics collection to their
   implementation (#427)
 
-## [0.5.5]
+## [0.5.6] - 2019-08-21
+
+### Added
+
+- Emit metrics events from restFetch and graphqlFetch (#396)
+
+### Fixed
+
+- Fixed flash of “No services found” on marketplace grid (#390)
+
+## [0.5.5] - 2019-08-16
 
 ### Fixed
 
@@ -232,7 +242,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed public endpoints trying to authenticate (#383)
 - Fixed “no services“ flash on `<manifold-marketplace>` (#390)
 
-## [0.5.4]
+## [0.5.4] - 2019-08-15
 
 ### Fixed
 
@@ -252,7 +262,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed issue where success event of `manifold-data-rename-resource` was emitted before renamed
   resource was ready. (#380)
 
-## [0.5.3]
+## [0.5.3] - 2019-08-12
 
 ### Fixed
 
@@ -271,7 +281,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added the terms of service to the product page component.
 - Added `<manifold-plan-selector free-plans>` filter flag
 
-## [0.5.2]
+## [0.5.2] - 2019-08-02
 
 ### Added
 
@@ -300,14 +310,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   component.
 - Improved `plan-selector` performance by reducing API calls for non-custom plans.
 
-## [0.5.1]
+## [0.5.1] - 2019-08-01
 
 ### Removed
 
 - `resource-label` removed from `<manifold-data-product-logo>` in favor of new
   `<manifold-data-resource-logo>` component
 
-## [0.5.0]
+## [0.5.0] - 2019-07-25
 
 ### Added
 
@@ -324,27 +334,27 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Changed the `manifold-auth-token` component to now use the shadowcat oauth system rather than only
   use the given token. This enables platforms to now use real authentication.
 
-## [0.4.3]
+## [0.4.3] - 2019-07-16
 
 ### Fixed
 
 - Fixed the rename and deprovision button not behaving properly when used in their resource warpers
 
-## [0.4.2]
+## [0.4.2] - 2019-07-16
 
 ### Changed
 
 - Changed the deprovision and rename button to not include a shadow dom root, they can now be styled
   from external stylesheets.
 
-## [0.4.1]
+## [0.4.1] - 2019-07-15
 
 ### Changed
 
 - Made all the internal attributes optional on the components to make sure TypeScript does not
   complain.
 
-## [0.4.0]
+## [0.4.0] - 2019-07-15
 
 ### Deprecated
 
@@ -360,7 +370,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `<manifold-data-product-logo>`, `<manifold-data-product-name>`,
   `<manifold-data-provision-button>`, `<manifold-data-resource-list>`
 
-## [0.3.1]
+## [0.3.1] - 2019-07-12
 
 ### Added
 
@@ -381,11 +391,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Changed the `manifold-resource-credentials` component to use the standalone `manifold-credentials`
   component.
 
-[0.3.0]: https://github.com/manifoldco/ui/compare/v0.2.1...v0.3.0
+[0.3.0]: https://github.com/manifoldco/ui/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/manifoldco/ui/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/manifoldco/ui/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/manifoldco/ui/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/manifoldco/ui/compare/v0.1.0...v0.1.1
-[0.1.0]: https://github.com/manifoldco/ui/compare/v0.0.2...v0.1.0
 [0.1.0]: https://github.com/manifoldco/ui/compare/v0.0.2...v0.1.0
 [0.0.3]: https://github.com/manifoldco/ui/releases/tag/v0.0.3

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "copy-changelog": "node scripts/copy-changelog",
     "dev": "concurrently 'stencil build --watch' 'rm -rf dist && wait-on dist/loader/index.cjs.js && manifold run -p manifold-ui-local -- npm run storybook'",
     "docs": "npm run prepare:docs && cd docs && npm start",
-    "generate:changelog": "npx generate-changelog",
+    "generate:changelog": "npx keep-a-changelog",
     "generate:gql": "graphql-codegen --config codegen.yml",
     "generate:specs": "npm run generate:specs:catalog && npm run generate:specs:gateway && npm run generate:specs:marketplace && npm run generate:specs:provisioning && npm run generate:specs:connector",
     "generate:specs:catalog": "npx @manifoldco/swagger-to-ts src/spec/catalog/v1.yaml -w 'export namespace Catalog' -o src/types/catalog.ts",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "copy-changelog": "node scripts/copy-changelog",
     "dev": "concurrently 'stencil build --watch' 'rm -rf dist && wait-on dist/loader/index.cjs.js && manifold run -p manifold-ui-local -- npm run storybook'",
     "docs": "npm run prepare:docs && cd docs && npm start",
+    "generate:changelog": "npx generate-changelog",
     "generate:gql": "graphql-codegen --config codegen.yml",
     "generate:specs": "npm run generate:specs:catalog && npm run generate:specs:gateway && npm run generate:specs:marketplace && npm run generate:specs:provisioning && npm run generate:specs:connector",
     "generate:specs:catalog": "npx @manifoldco/swagger-to-ts src/spec/catalog/v1.yaml -w 'export namespace Catalog' -o src/types/catalog.ts",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "copy-changelog": "node scripts/copy-changelog",
     "dev": "concurrently 'stencil build --watch' 'rm -rf dist && wait-on dist/loader/index.cjs.js && manifold run -p manifold-ui-local -- npm run storybook'",
     "docs": "npm run prepare:docs && cd docs && npm start",
-    "generate:changelog": "npx keep-a-changelog",
+    "format:changelog": "npx keep-a-changelog && prettier CHANGELOG.md --write",
     "generate:gql": "graphql-codegen --config codegen.yml",
     "generate:specs": "npm run generate:specs:catalog && npm run generate:specs:gateway && npm run generate:specs:marketplace && npm run generate:specs:provisioning && npm run generate:specs:connector",
     "generate:specs:catalog": "npx @manifoldco/swagger-to-ts src/spec/catalog/v1.yaml -w 'export namespace Catalog' -o src/types/catalog.ts",


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

This PR has shifted a bit from feedback (which is good!). Originally this set out to autogenerate the CHANGELOG, but now this is just a formatter.

This adds a `npm run format:changelog` command that will format the CHANGELOG, and throw an error if we don’t match the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) style.

## Testing



## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
