### PR TITLE
feat: Add component names to GraphQL

### DIFF
--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -1,4 +1,4 @@
-import { h, Component, Prop, State, Watch, Event, EventEmitter } from '@stencil/core';
+import { h, Component, Element, Prop, State, Watch, Event, EventEmitter } from '@stencil/core';
 
 import { AuthToken } from '../../types/auth';
 import logger from '../../utils/logger';
@@ -10,6 +10,7 @@ export type AuthType = 'oauth' | 'manual';
 
 @Component({ tag: 'manifold-auth-token' })
 export class ManifoldAuthToken {
+  @Element() el: HTMLElement;
   /** _(hidden)_ */
   @Prop() setAuthToken?: (s: string) => void = connection.setAuthToken;
   /** _(hidden)_ */
@@ -59,7 +60,7 @@ export class ManifoldAuthToken {
     const payload = e.detail as AuthToken;
 
     if (payload.error) {
-      report(payload.error);
+      report(payload.error, this.el);
       return;
     }
 

--- a/src/components/manifold-copy-credentials/manifold-copy-credentials.tsx
+++ b/src/components/manifold-copy-credentials/manifold-copy-credentials.tsx
@@ -69,6 +69,7 @@ export class ManifoldCopyCredentials {
     const { data, errors } = await this.graphqlFetch<ResourceWithCredentialsQuery>({
       query,
       variables: { resourceLabel: this.resourceLabel },
+      element: this.el,
     });
 
     // if errors, report them but keep going

--- a/src/components/manifold-credentials/manifold-credentials.tsx
+++ b/src/components/manifold-credentials/manifold-credentials.tsx
@@ -38,6 +38,7 @@ export class ManifoldCredentials {
     const { data, errors } = await this.graphqlFetch<ResourceCredentialsQuery>({
       query: resourceCredentialsQuery,
       variables: { resourceLabel: this.resourceLabel },
+      element: this.el,
     });
 
     if (errors) {

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
@@ -75,6 +75,7 @@ export class ManifoldDataDeprovisionButton {
       variables: {
         resourceId: this.resourceId,
       },
+      element: this.el,
     });
 
     if (data && data.deleteResource) {
@@ -109,6 +110,7 @@ export class ManifoldDataDeprovisionButton {
       variables: {
         resourceLabel,
       },
+      element: this.el,
     });
 
     if (data && data.resource) {

--- a/src/components/manifold-data-has-resource/manifold-data-has-resource.tsx
+++ b/src/components/manifold-data-has-resource/manifold-data-has-resource.tsx
@@ -77,6 +77,7 @@ export class ManifoldDataHasResource {
     const { data } = await this.graphqlFetch({
       query: label ? singleResource : allResources,
       variables: { resourceLabel: label },
+      element: this.el,
     });
 
     let hasAnyResources = false;

--- a/src/components/manifold-data-product-logo/manifold-data-product-logo.tsx
+++ b/src/components/manifold-data-product-logo/manifold-data-product-logo.tsx
@@ -1,4 +1,4 @@
-import { h, Component, Prop, State, Watch } from '@stencil/core';
+import { h, Component, Element, Prop, State, Watch } from '@stencil/core';
 import { gql } from '@manifoldco/gql-zero';
 
 import { GraphqlFetch } from '../../utils/graphqlFetch';
@@ -18,6 +18,7 @@ const query = gql`
 
 @Component({ tag: 'manifold-data-product-logo' })
 export class ManifoldDataProductLogo {
+  @Element() el: HTMLElement;
   /** _(optional)_ `alt` attribute */
   @Prop() alt?: string;
   /** _(hidden)_ */
@@ -44,7 +45,7 @@ export class ManifoldDataProductLogo {
 
     this.product = undefined;
     const variables = { productLabel };
-    const { data } = await this.graphqlFetch({ query, variables });
+    const { data } = await this.graphqlFetch({ query, variables, element: this.el });
 
     this.product = (data && data.product) || undefined;
   };

--- a/src/components/manifold-data-product-name/manifold-data-product-name.tsx
+++ b/src/components/manifold-data-product-name/manifold-data-product-name.tsx
@@ -50,6 +50,7 @@ export class ManifoldDataProductName {
         }
       `,
       variables: { productLabel },
+      element: this.el,
     });
 
     if (data && data.product) {
@@ -79,6 +80,7 @@ export class ManifoldDataProductName {
         }
       `,
       variables: { resourceLabel },
+      element: this.el,
     });
 
     if (data && data.resource && data.resource.plan && data.resource.plan.product) {

--- a/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
+++ b/src/components/manifold-data-provision-button/manifold-data-provision-button.tsx
@@ -150,6 +150,7 @@ export class ManifoldDataProvisionButton {
         resourceLabel: this.resourceLabel,
         ownerId: this.ownerId,
       },
+      element: this.el,
     });
     this.provisioning = false;
 
@@ -183,6 +184,7 @@ export class ManifoldDataProvisionButton {
       variables: {
         productLabel,
       },
+      element: this.el,
     });
 
     if (data && data.product) {
@@ -200,6 +202,7 @@ export class ManifoldDataProvisionButton {
       variables: {
         planId,
       },
+      element: this.el,
     });
 
     if (data && data.plan && data.plan.regions) {

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
@@ -126,6 +126,7 @@ export class ManifoldDataRenameButton {
         resourceId: this.resourceId,
         newLabel: this.newLabel,
       },
+      element: this.el,
     });
 
     // error event
@@ -155,6 +156,7 @@ export class ManifoldDataRenameButton {
     const { data, errors } = await this.graphqlFetch({
       query: queryResourceId,
       variables: { resourceLabel },
+      element: this.el,
     });
 
     if (errors) {

--- a/src/components/manifold-data-resize-button/manifold-data-resize-button.tsx
+++ b/src/components/manifold-data-resize-button/manifold-data-resize-button.tsx
@@ -1,4 +1,4 @@
-import { h, Component, Prop, Event, EventEmitter, Watch } from '@stencil/core';
+import { h, Component, Prop, Element, Event, EventEmitter, Watch } from '@stencil/core';
 import { gql } from '@manifoldco/gql-zero';
 
 import connection from '../../state/connection';
@@ -38,6 +38,7 @@ const resourceIdQuery = gql`
 
 @Component({ tag: 'manifold-data-resize-button' })
 export class ManifoldDataResizeButton {
+  @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() graphqlFetch?: GraphqlFetch = connection.graphqlFetch;
   @Prop() planId?: string;
@@ -67,6 +68,7 @@ export class ManifoldDataResizeButton {
       variables: {
         resourceLabel,
       },
+      element: this.el,
     });
 
     if (data && data.resource) {
@@ -93,6 +95,7 @@ export class ManifoldDataResizeButton {
         resourceId: this.resourceId,
         planId: this.planId,
       },
+      element: this.el,
     });
 
     if (data && data.updateResourcePlan) {

--- a/src/components/manifold-data-resource-list/manifold-data-resource-list.tsx
+++ b/src/components/manifold-data-resource-list/manifold-data-resource-list.tsx
@@ -58,6 +58,7 @@ export class ManifoldDataResourceList {
       variables: this.ownerId ? { owner: this.ownerId } : {},
       getConnection: (q: Query) => q.resources,
       graphqlFetch: this.graphqlFetch,
+      element: this.el,
     });
   };
 

--- a/src/components/manifold-data-resource-logo/manifold-data-resource-logo.tsx
+++ b/src/components/manifold-data-resource-logo/manifold-data-resource-logo.tsx
@@ -1,4 +1,4 @@
-import { h, Component, Prop, State, Watch } from '@stencil/core';
+import { h, Component, Element, Prop, State, Watch } from '@stencil/core';
 
 import connection from '../../state/connection';
 import { GraphqlFetch } from '../../utils/graphqlFetch';
@@ -14,6 +14,7 @@ interface ProductState {
 
 @Component({ tag: 'manifold-data-resource-logo' })
 export class ManifoldDataResourceLogo {
+  @Element() el: HTMLElement;
   /** _(optional)_ `alt` attribute */
   @Prop() alt?: string;
   /** _(hidden)_ */
@@ -41,6 +42,7 @@ export class ManifoldDataResourceLogo {
     const { data } = await this.graphqlFetch<ResourceLogoQuery>({
       query: resourceQuery,
       variables: { resourceLabel },
+      element: this.el,
     });
 
     if (data) {

--- a/src/components/manifold-data-sso-button/manifold-data-sso-button.tsx
+++ b/src/components/manifold-data-sso-button/manifold-data-sso-button.tsx
@@ -1,4 +1,4 @@
-import { h, Component, Prop, Event, EventEmitter } from '@stencil/core';
+import { h, Component, Element, Prop, Event, EventEmitter } from '@stencil/core';
 
 import connection from '../../state/connection';
 import logger from '../../utils/logger';
@@ -33,6 +33,7 @@ interface ErrorMessage {
 
 @Component({ tag: 'manifold-data-sso-button' })
 export class ManifoldDataSsoButton {
+  @Element() el: HTMLElement;
   /** _(hidden)_ */
   @Prop() graphqlFetch?: GraphqlFetch = connection.graphqlFetch;
   /** The label of the resource to rename */
@@ -67,6 +68,7 @@ export class ManifoldDataSsoButton {
     >({
       query: this.resourceId ? ssoByID : ssoByLabel,
       variables,
+      element: this.el,
     });
 
     if (data && data.resource) {

--- a/src/components/manifold-plan/manifold-plan.tsx
+++ b/src/components/manifold-plan/manifold-plan.tsx
@@ -59,6 +59,7 @@ export class ManifoldPlan {
       variables: {
         planId,
       },
+      element: this.el,
     });
 
     if (data && data.plan) {

--- a/src/components/manifold-product/manifold-product.tsx
+++ b/src/components/manifold-product/manifold-product.tsx
@@ -59,7 +59,7 @@ export class ManifoldProduct {
     }
 
     const variables = { productLabel };
-    const { data } = await this.graphqlFetch({ query, variables });
+    const { data } = await this.graphqlFetch({ query, variables, element: this.el });
 
     this.product = (data && data.product) || undefined;
     this.loaded.emit(data && data.product);

--- a/src/components/manifold-resource-card/manifold-resource-card.tsx
+++ b/src/components/manifold-resource-card/manifold-resource-card.tsx
@@ -51,7 +51,11 @@ export class ManifoldResourceCard {
       return;
     }
 
-    const { data, errors } = await this.graphqlFetch({ query, variables: { resourceLabel } });
+    const { data, errors } = await this.graphqlFetch({
+      query,
+      variables: { resourceLabel },
+      element: this.el,
+    });
 
     if (data && data.resource) {
       this.resource = data.resource;

--- a/src/components/manifold-resource-container/manifold-resource-container.tsx
+++ b/src/components/manifold-resource-container/manifold-resource-container.tsx
@@ -163,7 +163,11 @@ export class ManifoldResourceContainer {
       return;
     }
 
-    const { data, errors } = await this.graphqlFetch({ query, variables: { resourceLabel } });
+    const { data, errors } = await this.graphqlFetch({
+      query,
+      variables: { resourceLabel },
+      element: this.el,
+    });
 
     if (data && data.resource) {
       this.gqlData = data.resource;

--- a/src/components/manifold-resource-container/manifold-resource-container.tsx
+++ b/src/components/manifold-resource-container/manifold-resource-container.tsx
@@ -1,4 +1,4 @@
-import { h, Component, Prop, State, Watch, Event, EventEmitter } from '@stencil/core';
+import { h, Element, Component, Prop, State, Watch, Event, EventEmitter } from '@stencil/core';
 import { gql } from '@manifoldco/gql-zero';
 
 import connection from '../../state/connection';
@@ -124,6 +124,7 @@ const query = gql`
 
 @Component({ tag: 'manifold-resource-container' })
 export class ManifoldResourceContainer {
+  @Element() el: HTMLElement;
   /** _(hidden)_ */
   @Prop() graphqlFetch?: GraphqlFetch = connection.graphqlFetch;
   /** Which resource does this belong to? */

--- a/src/components/manifold-resource-list/manifold-resource-list.tsx
+++ b/src/components/manifold-resource-list/manifold-resource-list.tsx
@@ -62,6 +62,7 @@ export class ManifoldResourceList {
       variables: this.ownerId ? { owner: this.ownerId } : {},
       getConnection: (q: Query) => q.resources,
       graphqlFetch: this.graphqlFetch,
+      element: this.el,
     });
   };
 

--- a/src/components/manifold-service-card/manifold-service-card.tsx
+++ b/src/components/manifold-service-card/manifold-service-card.tsx
@@ -83,7 +83,11 @@ export class ManifoldServiceCard {
       return;
     }
 
-    const { data, errors } = await this.graphqlFetch({ query, variables: { productLabel } });
+    const { data, errors } = await this.graphqlFetch({
+      query,
+      variables: { productLabel },
+      element: this.el,
+    });
     if (data && data.product) {
       this.product = data.product;
     }

--- a/src/utils/fetchAllPages.spec.ts
+++ b/src/utils/fetchAllPages.spec.ts
@@ -252,6 +252,7 @@ describe('Fetching all pages of a GraphQL connection', () => {
         nextPage: { first: 3, after: '' },
         getConnection: (q: Query) => q.categories,
         graphqlFetch: createGraphqlFetch({}),
+        element: document.createElement('custom-element'),
       }).catch(e => {
         expect(e).toBeInstanceOf(MissingPageInfo);
       });
@@ -278,6 +279,7 @@ describe('Fetching all pages of a GraphQL connection', () => {
       nextPage: { first: 3, after: '' },
       getConnection: (q: Query) => q.categories,
       graphqlFetch: createGraphqlFetch({}),
+      element: document.createElement('custom-element'),
     });
 
     expect(fetchMock.calls).toHaveLength(2);

--- a/src/utils/fetchAllPages.ts
+++ b/src/utils/fetchAllPages.ts
@@ -18,7 +18,7 @@ interface Args<Edge, T> {
   variables?: { [key: string]: string | number | undefined };
   getConnection: (q: T) => Connection<Edge> | null | undefined;
   graphqlFetch?: GraphqlFetch;
-  element?: HTMLElement;
+  element: HTMLElement;
 }
 
 export class MissingPageInfo extends Error {

--- a/src/utils/graphqlFetch.spec.ts
+++ b/src/utils/graphqlFetch.spec.ts
@@ -26,7 +26,7 @@ describe('graphqlFetch', () => {
         status: 200,
         body: { data: {} },
       });
-      await fetcher({ query: '' });
+      await fetcher({ query: '', element: document.createElement('custom-element') });
       expect(fetchMock.called('https://api.manifold.co/graphql')).toBe(true);
     });
 
@@ -47,7 +47,10 @@ describe('graphqlFetch', () => {
         body,
       });
 
-      const result = await fetcher({ query: '' });
+      const result = await fetcher({
+        query: '',
+        element: document.createElement('custom-element'),
+      });
 
       expect(fetchMock.called(graphqlEndpoint)).toBe(true);
       expect(result).toEqual(body);
@@ -66,6 +69,7 @@ describe('graphqlFetch', () => {
       expect.assertions(2);
       return fetcher({
         query: 'myQuery',
+        element: document.createElement('custom-element'),
       }).catch(result => {
         expect(fetchMock.called(graphqlEndpoint)).toBe(true);
         expect(result).toEqual(err);
@@ -100,8 +104,8 @@ describe('graphqlFetch', () => {
         body: { data: null, errors },
       });
 
-      await fetcher({ query: '' });
-      expect(errorReporter).toHaveBeenCalledWith(errors, undefined);
+      await fetcher({ query: '', element: document.createElement('custom-element') });
+      expect(errorReporter).toHaveBeenCalledWith(errors, {});
     });
 
     it('reports GraphQL errors', async () => {
@@ -119,9 +123,9 @@ describe('graphqlFetch', () => {
 
       fetchMock.mock(graphqlEndpoint, { status: 422, body });
 
-      await fetcher({ query: '' });
+      await fetcher({ query: '', element: document.createElement('custom-element') });
       // graphql format
-      expect(errorReporter).toHaveBeenCalledWith(body.errors, undefined);
+      expect(errorReporter).toHaveBeenCalledWith(body.errors, {});
     });
 
     it('reports unknown errors', async () => {
@@ -133,9 +137,9 @@ describe('graphqlFetch', () => {
 
       fetchMock.mock(graphqlEndpoint, { status: 500, body: {} });
 
-      await fetcher({ query: '' });
+      await fetcher({ query: '', element: document.createElement('custom-element') });
       // graphql format
-      expect(errorReporter).toHaveBeenCalledWith([{ message: 'Internal Server Error' }], undefined);
+      expect(errorReporter).toHaveBeenCalledWith([{ message: 'Internal Server Error' }], {});
     });
 
     it('reports auth errors', async () => {
@@ -159,8 +163,8 @@ describe('graphqlFetch', () => {
       const response = { status: 200, body };
       fetchMock.mock(graphqlEndpoint, response);
 
-      return fetcher({ query: '' }).catch(() => {
-        expect(errorReporter).toHaveBeenCalledWith(body.errors, undefined);
+      return fetcher({ query: '', element: document.createElement('custom-element') }).catch(() => {
+        expect(errorReporter).toHaveBeenCalledWith(body.errors, {});
       });
     });
   });
@@ -180,10 +184,12 @@ describe('graphqlFetch', () => {
         });
 
         expect.assertions(2);
-        return fetcher({ query: '' }).catch(result => {
-          expect(fetchMock.called(graphqlEndpoint)).toBe(true);
-          expect(result).toEqual(new Error('Auth token expired'));
-        });
+        return fetcher({ query: '', element: document.createElement('custom-element') }).catch(
+          result => {
+            expect(fetchMock.called(graphqlEndpoint)).toBe(true);
+            expect(result).toEqual(new Error('Auth token expired'));
+          }
+        );
       });
     });
 
@@ -203,9 +209,11 @@ describe('graphqlFetch', () => {
         });
 
         expect.assertions(1);
-        return fetcher({ query: '' }).catch(() => {
-          expect(setAuthToken).toHaveBeenCalledWith('');
-        });
+        return fetcher({ query: '', element: document.createElement('custom-element') }).catch(
+          () => {
+            expect(setAuthToken).toHaveBeenCalledWith('');
+          }
+        );
       });
 
       it('Will retry if the token is refreshed', async () => {
@@ -227,7 +235,7 @@ describe('graphqlFetch', () => {
           })
           .mock(graphqlEndpoint, { status: 200, body }, { overwriteRoutes: false });
 
-        const fetch = fetcher({ query: '' });
+        const fetch = fetcher({ query: '', element: document.createElement('custom-element') });
 
         /* Queue the dispatch back a tick to allow listeners to be set up */
         await new Promise(resolve => {
@@ -266,7 +274,10 @@ describe('graphqlFetch', () => {
         body,
       });
 
-      const result = await fetcher({ query: '' });
+      const result = await fetcher({
+        query: '',
+        element: document.createElement('custom-element'),
+      });
 
       expect(fetchMock.called(graphqlEndpoint)).toBe(true);
       expect(result).toEqual(body);
@@ -295,6 +306,7 @@ describe('graphqlFetch', () => {
       expect.assertions(2);
       return fetcher({
         query: '',
+        element: document.createElement('custom-element'),
       }).catch(e => {
         expect(fetchMock.called(graphqlEndpoint)).toBe(true);
         expect(e.message).toEqual('Auth token expired');
@@ -314,7 +326,10 @@ describe('graphqlFetch', () => {
 
       fetchMock.mock(graphqlEndpoint, { status: 422, body });
 
-      const result = await fetcher({ query: '' });
+      const result = await fetcher({
+        query: '',
+        element: document.createElement('custom-element'),
+      });
       expect(fetchMock.called(graphqlEndpoint)).toBe(true);
       expect(result).toEqual(body);
     });
@@ -331,7 +346,10 @@ describe('graphqlFetch', () => {
         body: {},
       });
 
-      const result = await fetcher({ query: '' });
+      const result = await fetcher({
+        query: '',
+        element: document.createElement('custom-element'),
+      });
       expect(fetchMock.called(graphqlEndpoint)).toBe(true);
       expect(result).toEqual({
         data: null,
@@ -341,39 +359,7 @@ describe('graphqlFetch', () => {
   });
 
   describe('metrics', () => {
-    it('emits a metrics event from document when no EventEmitter supplied', async () => {
-      const fetcher = createGraphqlFetch({
-        wait: () => 0,
-        endpoint: () => graphqlEndpoint,
-        getAuthToken: () => '1234',
-      });
-
-      fetchMock.mock(graphqlEndpoint, {
-        data: null,
-        errors: [{ message: 'no results', locations: [] }],
-      });
-
-      const mockEvent = jest.fn();
-      document.addEventListener('manifold-graphql-fetch-duration', mockEvent);
-      await fetcher({ query: '' });
-
-      // test duration
-      expect(mockEvent.mock.calls[0][0].detail.duration).toBeGreaterThanOrEqual(0);
-      // test everything BUT duration
-      expect(mockEvent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          detail: expect.objectContaining({
-            componentName: undefined,
-            errors: [{ locations: [], message: 'no results' }],
-            npmVersion: '<@NPM_PACKAGE_VERSION@>', // expect Rollbar-replaceable string
-            request: { query: '' },
-            type: 'manifold-graphql-fetch-duration',
-          }),
-        })
-      );
-    });
-
-    it('emits a metrics event from an element when supplied', async () => {
+    it('emits a metrics event ', async () => {
       const element = document.createElement('my-element');
       const mockEvent = jest.fn();
       element.addEventListener('manifold-graphql-fetch-duration', mockEvent);
@@ -418,7 +404,7 @@ describe('graphqlFetch', () => {
         status: 200,
         body: { data: null, errors: null },
       });
-      await fetcher({ query: '' });
+      await fetcher({ query: '', element: document.createElement('custom-element') });
       const body = fetchMock.calls()[0][1] as RequestInit;
       expect(body.headers).toEqual(expect.objectContaining({ Connection: 'keep-alive' }));
     });

--- a/src/utils/graphqlFetch.spec.ts
+++ b/src/utils/graphqlFetch.spec.ts
@@ -105,7 +105,7 @@ describe('graphqlFetch', () => {
       });
 
       await fetcher({ query: '', element: document.createElement('custom-element') });
-      expect(errorReporter).toHaveBeenCalledWith(errors, {});
+      expect(errorReporter.mock.calls[0][0]).toEqual(errors);
     });
 
     it('reports GraphQL errors', async () => {
@@ -125,7 +125,7 @@ describe('graphqlFetch', () => {
 
       await fetcher({ query: '', element: document.createElement('custom-element') });
       // graphql format
-      expect(errorReporter).toHaveBeenCalledWith(body.errors, {});
+      expect(errorReporter.mock.calls[0][0]).toEqual(body.errors);
     });
 
     it('reports unknown errors', async () => {
@@ -139,7 +139,7 @@ describe('graphqlFetch', () => {
 
       await fetcher({ query: '', element: document.createElement('custom-element') });
       // graphql format
-      expect(errorReporter).toHaveBeenCalledWith([{ message: 'Internal Server Error' }], {});
+      expect(errorReporter.mock.calls[0][0]).toEqual([{ message: 'Internal Server Error' }]);
     });
 
     it('reports auth errors', async () => {
@@ -164,7 +164,7 @@ describe('graphqlFetch', () => {
       fetchMock.mock(graphqlEndpoint, response);
 
       return fetcher({ query: '', element: document.createElement('custom-element') }).catch(() => {
-        expect(errorReporter).toHaveBeenCalledWith(body.errors, {});
+        expect(errorReporter.mock.calls[0][0]).toEqual(body.errors);
       });
     });
   });

--- a/src/utils/graphqlFetch.ts
+++ b/src/utils/graphqlFetch.ts
@@ -15,12 +15,12 @@ type GraphqlArgs =
   | {
       mutation: string;
       variables?: { [key: string]: string | number | undefined };
-      element?: HTMLElement;
+      element: HTMLElement;
     }
   | {
       query: string;
       variables?: { [key: string]: string | number | undefined };
-      element?: HTMLElement;
+      element: HTMLElement;
     }; // require query or mutation, but not both
 
 export interface GraphqlError {
@@ -33,7 +33,7 @@ export interface GraphqlError {
 }
 
 interface GraphqlFetchEventDetail {
-  componentName?: string;
+  componentName: string;
   duration: number;
   errors?: GraphqlError[];
   npmVersion: string;
@@ -102,7 +102,7 @@ export function createGraphqlFetch({
 
     const fetchDuration = performance.now() - rttStart;
     const detail: GraphqlFetchEventDetail = {
-      componentName: (element && element.tagName) || undefined,
+      componentName: element.tagName,
       duration: fetchDuration,
       errors: body.errors,
       npmVersion: '<@NPM_PACKAGE_VERSION@>',

--- a/src/utils/graphqlFetch.ts
+++ b/src/utils/graphqlFetch.ts
@@ -11,17 +11,17 @@ interface CreateGraphqlFetch {
   onReady?: () => Promise<unknown>;
 }
 
-type GraphqlArgs =
+type GraphqlRequest =
   | {
       mutation: string;
       variables?: { [key: string]: string | number | undefined };
-      element: HTMLElement;
     }
   | {
       query: string;
       variables?: { [key: string]: string | number | undefined };
-      element: HTMLElement;
     }; // require query or mutation, but not both
+
+type GraphqlArgs = GraphqlRequest & { element: HTMLElement };
 
 export interface GraphqlError {
   message: string;
@@ -37,7 +37,7 @@ interface GraphqlFetchEventDetail {
   duration: number;
   errors?: GraphqlError[];
   npmVersion: string;
-  request: GraphqlArgs;
+  request: GraphqlRequest;
   type: 'manifold-graphql-fetch-duration';
 }
 


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

Followup to #668 that discussed approach. This is just a chore to update all the names to broadcast their names to GraphQL, and enforce that via TypeScript.

## Testing

All components should now send their name to GraphQL via the `x-manifold-component` header.

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
