### PR TITLE
Use typed query for manifold-plan-selector

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -8,9 +8,8 @@
 
 import { HTMLStencilElement, JSXBase } from '@stencil/core/internal';
 import {
-  Plan,
-  PlanEdge,
   PlanMeteredFeatureEdge,
+  PlansQuery,
   Product,
   ProductEdge,
   Resource,
@@ -43,8 +42,8 @@ import {
 export namespace Components {
   interface ManifoldActivePlan {
     'isExistingResource'?: boolean;
-    'plans'?: PlanEdge[];
-    'product'?: Product;
+    'plans'?: Plans;
+    'product'?: PlansQuery['product'];
     'regions'?: string[];
     'selectedResource'?: Resource;
   }
@@ -394,7 +393,7 @@ export namespace Components {
     * Compact mode (for plan selector sidebar)
     */
     'compact'?: boolean;
-    'plan'?: Plan;
+    'plan'?: PlansQuery['product']['paidPlans']['edges'][0]['node'];
     /**
     * _(hidden)_
     */
@@ -413,7 +412,7 @@ export namespace Components {
     'scrollLocked'?: boolean;
   }
   interface ManifoldPlanMenu {
-    'plans'?: PlanEdge[];
+    'plans'?: PlansQuery['product']['paidPlans']['edges'];
     'selectPlan': (planId: string) => void;
     'selectedPlanId'?: string;
   }
@@ -1035,8 +1034,8 @@ declare global {
 declare namespace LocalJSX {
   interface ManifoldActivePlan {
     'isExistingResource'?: boolean;
-    'plans'?: PlanEdge[];
-    'product'?: Product;
+    'plans'?: Plans;
+    'product'?: PlansQuery['product'];
     'regions'?: string[];
     'selectedResource'?: Resource;
   }
@@ -1413,7 +1412,7 @@ declare namespace LocalJSX {
     * Compact mode (for plan selector sidebar)
     */
     'compact'?: boolean;
-    'plan'?: Plan;
+    'plan'?: PlansQuery['product']['paidPlans']['edges'][0]['node'];
     /**
     * _(hidden)_
     */
@@ -1434,7 +1433,7 @@ declare namespace LocalJSX {
     'scrollLocked'?: boolean;
   }
   interface ManifoldPlanMenu {
-    'plans'?: PlanEdge[];
+    'plans'?: PlansQuery['product']['paidPlans']['edges'];
     'selectPlan'?: (planId: string) => void;
     'selectedPlanId'?: string;
   }

--- a/src/components/manifold-active-plan/manifold-active-plan.tsx
+++ b/src/components/manifold-active-plan/manifold-active-plan.tsx
@@ -1,7 +1,11 @@
 import { h, Component, State, Prop, Watch } from '@stencil/core';
 import logger from '../../utils/logger';
 import loadMark from '../../utils/loadMark';
-import { Product, PlanEdge, Resource } from '../../types/graphql';
+import { PlansQuery, ResourcePlansQuery } from '../../types/graphql';
+
+type Plans = PlansQuery['product']['paidPlans']['edges'];
+type Resource = ResourcePlansQuery['resource'];
+
 @Component({
   tag: 'manifold-active-plan',
   styleUrl: 'manifold-active-plan.css',
@@ -9,12 +13,12 @@ import { Product, PlanEdge, Resource } from '../../types/graphql';
 })
 export class ManifoldActivePlan {
   @Prop() isExistingResource?: boolean;
-  @Prop() plans?: PlanEdge[];
-  @Prop() product?: Product;
+  @Prop() plans?: Plans;
+  @Prop() product?: PlansQuery['product'];
   @Prop() regions?: string[];
   @Prop() selectedResource?: Resource;
   @State() selectedPlanId: string;
-  @Watch('plans') plansChange(newPlans: PlanEdge[]) {
+  @Watch('plans') plansChange(newPlans: Plans) {
     if (this.selectedResource && this.selectedResource.plan && this.selectedResource.plan.id) {
       this.selectPlan(this.selectedResource.plan.id);
     } else if (newPlans && newPlans.length > 0) {

--- a/src/components/manifold-plan-cost/manifold-plan-cost.tsx
+++ b/src/components/manifold-plan-cost/manifold-plan-cost.tsx
@@ -6,14 +6,14 @@ import { planCost, configurableFeatureDefaults } from '../../utils/plan';
 import { RestFetch } from '../../utils/restFetch';
 import logger from '../../utils/logger';
 import loadMark from '../../utils/loadMark';
-import { Plan } from '../../types/graphql';
+import { PlansQuery } from '../../types/graphql';
 
 @Component({ tag: 'manifold-plan-cost' })
 export class ManifoldPlanCost {
   @Element() el: HTMLElement;
   /** _(hidden)_ */
   @Prop() restFetch?: RestFetch = connection.restFetch;
-  @Prop() plan?: Plan;
+  @Prop() plan?: PlansQuery['product']['paidPlans']['edges'][0]['node'];
   /** Compact mode (for plan selector sidebar) */
   @Prop() compact?: boolean = false;
   /** User-selected plan features (needed only for customizable) */

--- a/src/components/manifold-plan-details/components/ConfigurableFeature.tsx
+++ b/src/components/manifold-plan-details/components/ConfigurableFeature.tsx
@@ -1,10 +1,10 @@
 import { h, FunctionalComponent } from '@stencil/core';
 
-import { PlanConfigurableFeatureEdge, PlanFeatureType } from '../../../types/graphql';
+import { ResourcePlansQuery, PlanFeatureType } from '../../../types/graphql';
 import { Option } from '../../../types/Select';
 
 interface ConfigurableFeatureProps {
-  configurableFeature?: PlanConfigurableFeatureEdge;
+  configurableFeature?: ResourcePlansQuery['resource']['plan']['product']['freePlans']['edges'][0]['node']['configurableFeatures']['edges'][0];
   onChange: (e: CustomEvent) => void;
   value?: string | number | boolean;
 }

--- a/src/components/manifold-plan-details/components/MeteredFeature.tsx
+++ b/src/components/manifold-plan-details/components/MeteredFeature.tsx
@@ -1,9 +1,11 @@
 import { h, FunctionalComponent } from '@stencil/core';
 
-import { PlanMeteredFeatureEdge, PlanMeteredFeatureNumericDetails } from '../../../types/graphql';
+import { PlanMeteredFeatureNumericDetails, ResourcePlansQuery } from '../../../types/graphql';
 import { $ } from '../../../utils/currency';
 import { pluralize } from '../../../utils/string';
 import { featureCost, meteredFeatureDisplayValue, pricingTiers } from '../../../utils/plan';
+
+type MeteredFeature = ResourcePlansQuery['resource']['plan']['meteredFeatures']['edges'][0];
 
 function meteredFeatureCost(numericDetails: PlanMeteredFeatureNumericDetails) {
   const tiers = pricingTiers(numericDetails);
@@ -36,7 +38,7 @@ function meteredFeatureCost(numericDetails: PlanMeteredFeatureNumericDetails) {
   return [displayValue.cost, displayValue.per ? <small>&nbsp;{displayValue.per}</small> : ''];
 }
 
-const MeteredFeature: FunctionalComponent<{ meteredFeature?: PlanMeteredFeatureEdge }> = ({
+const MeteredFeature: FunctionalComponent<{ meteredFeature?: MeteredFeature }> = ({
   meteredFeature,
 }) => {
   if (!meteredFeature) {

--- a/src/components/manifold-plan-menu/manifold-plan-menu.tsx
+++ b/src/components/manifold-plan-menu/manifold-plan-menu.tsx
@@ -1,7 +1,7 @@
 import { h, Prop, Component } from '@stencil/core';
 import { check, sliders } from '@manifoldco/icons';
 
-import { PlanEdge } from '../../types/graphql';
+import { PlansQuery } from '../../types/graphql';
 import logger from '../../utils/logger';
 import loadMark from '../../utils/loadMark';
 
@@ -11,7 +11,7 @@ import loadMark from '../../utils/loadMark';
   shadow: true,
 })
 export class ManifoldPlanMenu {
-  @Prop() plans?: PlanEdge[];
+  @Prop() plans?: PlansQuery['product']['paidPlans']['edges'];
   @Prop() selectedPlanId?: string;
   @Prop() selectPlan: (planId: string) => void = () => null;
 

--- a/src/components/manifold-plan-selector/manifold-plan-selector.tsx
+++ b/src/components/manifold-plan-selector/manifold-plan-selector.tsx
@@ -1,61 +1,12 @@
 import { h, Component, Element, State, Prop, Watch } from '@stencil/core';
-import { gql } from '@manifoldco/gql-zero';
 
 import connection from '../../state/connection';
 import logger from '../../utils/logger';
 import loadMark from '../../utils/loadMark';
 import { GraphqlFetch } from '../../utils/graphqlFetch';
-import planData from '../../data/plan-details-query';
-import { Product, Resource, PlanEdge } from '../../types/graphql';
-
-const plansQuery = gql`
-  query PLAN_LIST($productLabel: String!) {
-    product(label: $productLabel) {
-      id
-      displayName
-      label
-      logoUrl
-      plans(first: 25, orderBy: { field: COST, direction: ASC }) {
-        edges {
-          node {
-            ${planData}
-          }
-        }
-      }
-    }
-  }
-`;
-
-const freePlansQuery = gql`
-  query FREE_PLAN_LIST($productLabel: String!) {
-    product(label: $productLabel) {
-      id
-      displayName
-      label
-      logoUrl
-      plans(first: 25, free: true, orderBy: { field: COST, direction: ASC }) {
-        edges {
-          node {
-            ${planData}
-          }
-        }
-      }
-    }
-  }
-`;
-
-const resourceQuery = gql`
-  query RESOURCE_PRODUCT($resourceLabel: String!) {
-    resource(label: $resourceLabel) {
-      plan {
-        id
-        product {
-          label
-        }
-      }
-    }
-  }
-`;
+import { PlansQuery, ResourcePlansQuery } from '../../types/graphql';
+import plansQuery from './plans.graphql';
+import resourcePlansQuery from './resource-plans.graphql';
 
 @Component({ tag: 'manifold-plan-selector' })
 export class ManifoldPlanSelector {
@@ -66,20 +17,24 @@ export class ManifoldPlanSelector {
   @Prop() graphqlFetch?: GraphqlFetch = connection.graphqlFetch;
   /** URL-friendly slug (e.g. `"jawsdb-mysql"`) */
   @Prop() productLabel?: string;
-  /** Specify regions visible */
-  @Prop() regions?: string;
   /** Is this tied to an existing resource? */
   @Prop() resourceLabel?: string;
+  /** Specify regions visible */
+  @Prop() regions?: string;
   @Prop() hideUntilReady?: boolean = false;
-  @State() product?: Product;
-  @State() plans?: PlanEdge[];
-  @State() resource?: Resource;
+  @State() product?: PlansQuery['product'];
+  @State() plans?: PlansQuery['product']['paidPlans']['edges'];
   @State() parsedRegions: string[];
+  @State() resource?: ResourcePlansQuery['resource'];
   @Watch('productLabel') productChange(newProduct: string) {
-    this.fetchPlans(newProduct);
+    if (newProduct) {
+      this.fetchPlans(newProduct);
+    }
   }
   @Watch('resourceLabel') resourceChange(newResource: string) {
-    this.fetchResource(newResource);
+    if (newResource) {
+      this.fetchResource(newResource);
+    }
   }
 
   @loadMark()
@@ -104,35 +59,18 @@ export class ManifoldPlanSelector {
       return;
     }
 
-    this.product = undefined;
-
-    const { data } = await this.graphqlFetch({
-      query: this.freePlans ? freePlansQuery : plansQuery,
-      variables: {
-        productLabel,
-      },
+    const { data } = await this.graphqlFetch<PlansQuery>({
+      query: plansQuery,
+      variables: { productLabel },
       element: this.el,
     });
 
-    if (data && data.product) {
+    if (data) {
       this.product = data.product;
-
-      if (data.product.plans) {
-        // if plan is free then move to front (needed because GQL only sorts base cost not truly free plans)
-        const freePlansFirst = [...data.product.plans.edges].sort(a => {
-          if (a.node.free) {
-            return -1;
-          }
-          return 0;
-        });
-
-        // TODO: re-add configurable plans when GraphQL supports resource features
-        const TEMP_HIDE_CONFIGURABLE_PLANS = freePlansFirst.filter(
-          ({ node: { configurableFeatures } }) =>
-            !configurableFeatures || configurableFeatures.edges.length === 0
-        );
-        this.plans = TEMP_HIDE_CONFIGURABLE_PLANS;
-      }
+      this.plans = this.filterConfigurablePlans({
+        ...data.product.freePlans.edges,
+        ...data.product.paidPlans.edges,
+      });
     }
   }
 
@@ -141,22 +79,27 @@ export class ManifoldPlanSelector {
       return;
     }
 
-    this.resource = undefined;
-
-    const { data } = await this.graphqlFetch({
-      query: resourceQuery,
-      variables: {
-        resourceLabel,
-      },
+    const { data } = await this.graphqlFetch<ResourcePlansQuery>({
+      query: resourcePlansQuery,
+      variables: { resourceLabel },
       element: this.el,
     });
 
-    if (data && data.resource) {
+    if (data) {
       this.resource = data.resource;
-      if (data.resource && data.resource.plan && data.resource.plan.product) {
-        this.fetchPlans(data.resource.plan.product.label);
-      }
+      this.plans = this.filterConfigurablePlans({
+        ...data.resource.plan.product.freePlans.edges,
+        ...data.resource.plan.product.paidPlans.edges,
+      });
     }
+  }
+
+  // TODO: delete this filter when GraphQL supports configurable plans
+  filterConfigurablePlans(plans: PlansQuery['product']['paidPlans']['edges']) {
+    return plans.filter(
+      ({ node: { configurableFeatures } }) =>
+        !configurableFeatures || configurableFeatures.edges.length === 0
+    );
   }
 
   @logger()
@@ -165,12 +108,7 @@ export class ManifoldPlanSelector {
       (this.regions && this.regions.split(',').map(region => region.trim())) || undefined;
 
     return (
-      <manifold-active-plan
-        plans={this.plans}
-        product={this.product}
-        regions={regions}
-        selectedResource={this.resource}
-      >
+      <manifold-active-plan plans={this.plans} product={this.product} regions={regions}>
         <manifold-forward-slot slot="cta">
           <slot name="cta" />
         </manifold-forward-slot>

--- a/src/components/manifold-plan-selector/plans.graphql
+++ b/src/components/manifold-plan-selector/plans.graphql
@@ -1,0 +1,146 @@
+query plans($productLabel: String!) {
+  product(label: $productLabel) {
+    displayName
+    id
+    label
+    logoUrl
+    freePlans: plans(free: true, first: 25, orderBy: { field: COST, direction: ASC }) {
+      edges {
+        node {
+          configurableFeatures(first: 25) {
+            edges {
+              node {
+                label
+                displayName
+                type
+                options {
+                  displayName
+                  displayValue
+                  label
+                }
+                numericDetails {
+                  increment
+                  min
+                  max
+                  unit
+                  costTiers {
+                    limit
+                    cost
+                  }
+                }
+              }
+            }
+          }
+          cost
+          displayName
+          fixedFeatures(first: 25) {
+            edges {
+              node {
+                displayName
+                displayValue
+                label
+              }
+            }
+          }
+          free
+          id
+          label
+          meteredFeatures(first: 25) {
+            edges {
+              node {
+                label
+                displayName
+                numericDetails {
+                  unit
+                  costTiers {
+                    limit
+                    cost
+                  }
+                }
+              }
+            }
+          }
+          regions(first: 25, orderBy: { field: DISPLAY_NAME, direction: ASC }) {
+            edges {
+              node {
+                id
+                displayName
+                platform
+                dataCenter
+              }
+            }
+          }
+        }
+      }
+    }
+    paidPlans: plans(free: false, first: 25, orderBy: { field: COST, direction: ASC }) {
+      edges {
+        node {
+          configurableFeatures(first: 25) {
+            edges {
+              node {
+                label
+                displayName
+                type
+                options {
+                  displayName
+                  displayValue
+                  label
+                }
+                numericDetails {
+                  increment
+                  min
+                  max
+                  unit
+                  costTiers {
+                    limit
+                    cost
+                  }
+                }
+              }
+            }
+          }
+          cost
+          displayName
+          fixedFeatures(first: 25) {
+            edges {
+              node {
+                displayName
+                displayValue
+                label
+              }
+            }
+          }
+          free
+          id
+          label
+          meteredFeatures(first: 25) {
+            edges {
+              node {
+                label
+                displayName
+                numericDetails {
+                  unit
+                  costTiers {
+                    limit
+                    cost
+                  }
+                }
+              }
+            }
+          }
+          regions(first: 25, orderBy: { field: DISPLAY_NAME, direction: ASC }) {
+            edges {
+              node {
+                id
+                displayName
+                platform
+                dataCenter
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/components/manifold-plan-selector/resource-plans.graphql
+++ b/src/components/manifold-plan-selector/resource-plans.graphql
@@ -1,0 +1,219 @@
+query resourcePlans($resourceLabel: String!) {
+  resource(label: $resourceLabel) {
+    plan {
+      configurableFeatures(first: 25) {
+        edges {
+          node {
+            label
+            displayName
+            type
+            options {
+              displayName
+              displayValue
+              label
+            }
+            numericDetails {
+              increment
+              min
+              max
+              unit
+              costTiers {
+                limit
+                cost
+              }
+            }
+          }
+        }
+      }
+      cost
+      displayName
+      fixedFeatures(first: 25) {
+        edges {
+          node {
+            displayName
+            displayValue
+            label
+          }
+        }
+      }
+      free
+      id
+      label
+      meteredFeatures(first: 25) {
+        edges {
+          node {
+            label
+            displayName
+            numericDetails {
+              unit
+              costTiers {
+                limit
+                cost
+              }
+            }
+          }
+        }
+      }
+      product {
+        displayName
+        id
+        label
+        logoUrl
+        freePlans: plans(free: true, first: 25, orderBy: { field: COST, direction: ASC }) {
+          edges {
+            node {
+              configurableFeatures(first: 25) {
+                edges {
+                  node {
+                    label
+                    displayName
+                    type
+                    options {
+                      displayName
+                      displayValue
+                      label
+                    }
+                    numericDetails {
+                      increment
+                      min
+                      max
+                      unit
+                      costTiers {
+                        limit
+                        cost
+                      }
+                    }
+                  }
+                }
+              }
+              cost
+              displayName
+              fixedFeatures(first: 25) {
+                edges {
+                  node {
+                    displayName
+                    displayValue
+                    label
+                  }
+                }
+              }
+              free
+              id
+              label
+              meteredFeatures(first: 25) {
+                edges {
+                  node {
+                    label
+                    displayName
+                    numericDetails {
+                      unit
+                      costTiers {
+                        limit
+                        cost
+                      }
+                    }
+                  }
+                }
+              }
+              regions(first: 25, orderBy: { field: DISPLAY_NAME, direction: ASC }) {
+                edges {
+                  node {
+                    id
+                    displayName
+                    platform
+                    dataCenter
+                  }
+                }
+              }
+            }
+          }
+        }
+        paidPlans: plans(free: false, first: 25, orderBy: { field: COST, direction: ASC }) {
+          edges {
+            node {
+              configurableFeatures(first: 25) {
+                edges {
+                  node {
+                    label
+                    displayName
+                    type
+                    options {
+                      displayName
+                      displayValue
+                      label
+                    }
+                    numericDetails {
+                      increment
+                      min
+                      max
+                      unit
+                      costTiers {
+                        limit
+                        cost
+                      }
+                    }
+                  }
+                }
+              }
+              cost
+              displayName
+              fixedFeatures(first: 25) {
+                edges {
+                  node {
+                    displayName
+                    displayValue
+                    label
+                  }
+                }
+              }
+              free
+              id
+              label
+              meteredFeatures(first: 25) {
+                edges {
+                  node {
+                    label
+                    displayName
+                    numericDetails {
+                      unit
+                      costTiers {
+                        limit
+                        cost
+                      }
+                    }
+                  }
+                }
+              }
+              regions(first: 25, orderBy: { field: DISPLAY_NAME, direction: ASC }) {
+                edges {
+                  node {
+                    id
+                    displayName
+                    platform
+                    dataCenter
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      regions(first: 25, orderBy: { field: DISPLAY_NAME, direction: ASC }) {
+        edges {
+          node {
+            id
+            displayName
+            platform
+            dataCenter
+          }
+        }
+      }
+    }
+    region {
+      dataCenter
+      displayName
+      id
+      platform
+    }
+  }
+}

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1677,6 +1677,359 @@ export type ProductsQuery = (
   )> }
 );
 
+export type PlansQueryVariables = {
+  productLabel: Scalars['String']
+};
+
+
+export type PlansQuery = (
+  { __typename?: 'Query' }
+  & { product: Maybe<(
+    { __typename?: 'Product' }
+    & Pick<Product, 'displayName' | 'id' | 'label' | 'logoUrl'>
+    & { freePlans: Maybe<(
+      { __typename?: 'PlanConnection' }
+      & { edges: Array<(
+        { __typename?: 'PlanEdge' }
+        & { node: (
+          { __typename?: 'Plan' }
+          & Pick<Plan, 'cost' | 'displayName' | 'free' | 'id' | 'label'>
+          & { configurableFeatures: Maybe<(
+            { __typename?: 'PlanConfigurableFeatureConnection' }
+            & { edges: Array<(
+              { __typename?: 'PlanConfigurableFeatureEdge' }
+              & { node: (
+                { __typename?: 'PlanConfigurableFeature' }
+                & Pick<PlanConfigurableFeature, 'label' | 'displayName' | 'type'>
+                & { options: Maybe<Array<(
+                  { __typename?: 'PlanFixedFeature' }
+                  & Pick<PlanFixedFeature, 'displayName' | 'displayValue' | 'label'>
+                )>>, numericDetails: Maybe<(
+                  { __typename?: 'PlanConfigurableFeatureNumericDetails' }
+                  & Pick<PlanConfigurableFeatureNumericDetails, 'increment' | 'min' | 'max' | 'unit'>
+                  & { costTiers: Maybe<Array<(
+                    { __typename?: 'PlanFeatureCostTier' }
+                    & Pick<PlanFeatureCostTier, 'limit' | 'cost'>
+                  )>> }
+                )> }
+              ) }
+            )> }
+          )>, fixedFeatures: Maybe<(
+            { __typename?: 'PlanFixedFeatureConnection' }
+            & { edges: Array<(
+              { __typename?: 'PlanFixedFeatureEdge' }
+              & { node: (
+                { __typename?: 'PlanFixedFeature' }
+                & Pick<PlanFixedFeature, 'displayName' | 'displayValue' | 'label'>
+              ) }
+            )> }
+          )>, meteredFeatures: Maybe<(
+            { __typename?: 'PlanMeteredFeatureConnection' }
+            & { edges: Array<(
+              { __typename?: 'PlanMeteredFeatureEdge' }
+              & { node: (
+                { __typename?: 'PlanMeteredFeature' }
+                & Pick<PlanMeteredFeature, 'label' | 'displayName'>
+                & { numericDetails: (
+                  { __typename?: 'PlanMeteredFeatureNumericDetails' }
+                  & Pick<PlanMeteredFeatureNumericDetails, 'unit'>
+                  & { costTiers: Maybe<Array<(
+                    { __typename?: 'PlanFeatureCostTier' }
+                    & Pick<PlanFeatureCostTier, 'limit' | 'cost'>
+                  )>> }
+                ) }
+              ) }
+            )> }
+          )>, regions: Maybe<(
+            { __typename?: 'RegionConnection' }
+            & { edges: Array<(
+              { __typename?: 'RegionEdge' }
+              & { node: (
+                { __typename?: 'Region' }
+                & Pick<Region, 'id' | 'displayName' | 'platform' | 'dataCenter'>
+              ) }
+            )> }
+          )> }
+        ) }
+      )> }
+    )>, paidPlans: Maybe<(
+      { __typename?: 'PlanConnection' }
+      & { edges: Array<(
+        { __typename?: 'PlanEdge' }
+        & { node: (
+          { __typename?: 'Plan' }
+          & Pick<Plan, 'cost' | 'displayName' | 'free' | 'id' | 'label'>
+          & { configurableFeatures: Maybe<(
+            { __typename?: 'PlanConfigurableFeatureConnection' }
+            & { edges: Array<(
+              { __typename?: 'PlanConfigurableFeatureEdge' }
+              & { node: (
+                { __typename?: 'PlanConfigurableFeature' }
+                & Pick<PlanConfigurableFeature, 'label' | 'displayName' | 'type'>
+                & { options: Maybe<Array<(
+                  { __typename?: 'PlanFixedFeature' }
+                  & Pick<PlanFixedFeature, 'displayName' | 'displayValue' | 'label'>
+                )>>, numericDetails: Maybe<(
+                  { __typename?: 'PlanConfigurableFeatureNumericDetails' }
+                  & Pick<PlanConfigurableFeatureNumericDetails, 'increment' | 'min' | 'max' | 'unit'>
+                  & { costTiers: Maybe<Array<(
+                    { __typename?: 'PlanFeatureCostTier' }
+                    & Pick<PlanFeatureCostTier, 'limit' | 'cost'>
+                  )>> }
+                )> }
+              ) }
+            )> }
+          )>, fixedFeatures: Maybe<(
+            { __typename?: 'PlanFixedFeatureConnection' }
+            & { edges: Array<(
+              { __typename?: 'PlanFixedFeatureEdge' }
+              & { node: (
+                { __typename?: 'PlanFixedFeature' }
+                & Pick<PlanFixedFeature, 'displayName' | 'displayValue' | 'label'>
+              ) }
+            )> }
+          )>, meteredFeatures: Maybe<(
+            { __typename?: 'PlanMeteredFeatureConnection' }
+            & { edges: Array<(
+              { __typename?: 'PlanMeteredFeatureEdge' }
+              & { node: (
+                { __typename?: 'PlanMeteredFeature' }
+                & Pick<PlanMeteredFeature, 'label' | 'displayName'>
+                & { numericDetails: (
+                  { __typename?: 'PlanMeteredFeatureNumericDetails' }
+                  & Pick<PlanMeteredFeatureNumericDetails, 'unit'>
+                  & { costTiers: Maybe<Array<(
+                    { __typename?: 'PlanFeatureCostTier' }
+                    & Pick<PlanFeatureCostTier, 'limit' | 'cost'>
+                  )>> }
+                ) }
+              ) }
+            )> }
+          )>, regions: Maybe<(
+            { __typename?: 'RegionConnection' }
+            & { edges: Array<(
+              { __typename?: 'RegionEdge' }
+              & { node: (
+                { __typename?: 'Region' }
+                & Pick<Region, 'id' | 'displayName' | 'platform' | 'dataCenter'>
+              ) }
+            )> }
+          )> }
+        ) }
+      )> }
+    )> }
+  )> }
+);
+
+export type ResourcePlansQueryVariables = {
+  resourceLabel: Scalars['String']
+};
+
+
+export type ResourcePlansQuery = (
+  { __typename?: 'Query' }
+  & { resource: Maybe<(
+    { __typename?: 'Resource' }
+    & { plan: Maybe<(
+      { __typename?: 'Plan' }
+      & Pick<Plan, 'cost' | 'displayName' | 'free' | 'id' | 'label'>
+      & { configurableFeatures: Maybe<(
+        { __typename?: 'PlanConfigurableFeatureConnection' }
+        & { edges: Array<(
+          { __typename?: 'PlanConfigurableFeatureEdge' }
+          & { node: (
+            { __typename?: 'PlanConfigurableFeature' }
+            & Pick<PlanConfigurableFeature, 'label' | 'displayName' | 'type'>
+            & { options: Maybe<Array<(
+              { __typename?: 'PlanFixedFeature' }
+              & Pick<PlanFixedFeature, 'displayName' | 'displayValue' | 'label'>
+            )>>, numericDetails: Maybe<(
+              { __typename?: 'PlanConfigurableFeatureNumericDetails' }
+              & Pick<PlanConfigurableFeatureNumericDetails, 'increment' | 'min' | 'max' | 'unit'>
+              & { costTiers: Maybe<Array<(
+                { __typename?: 'PlanFeatureCostTier' }
+                & Pick<PlanFeatureCostTier, 'limit' | 'cost'>
+              )>> }
+            )> }
+          ) }
+        )> }
+      )>, fixedFeatures: Maybe<(
+        { __typename?: 'PlanFixedFeatureConnection' }
+        & { edges: Array<(
+          { __typename?: 'PlanFixedFeatureEdge' }
+          & { node: (
+            { __typename?: 'PlanFixedFeature' }
+            & Pick<PlanFixedFeature, 'displayName' | 'displayValue' | 'label'>
+          ) }
+        )> }
+      )>, meteredFeatures: Maybe<(
+        { __typename?: 'PlanMeteredFeatureConnection' }
+        & { edges: Array<(
+          { __typename?: 'PlanMeteredFeatureEdge' }
+          & { node: (
+            { __typename?: 'PlanMeteredFeature' }
+            & Pick<PlanMeteredFeature, 'label' | 'displayName'>
+            & { numericDetails: (
+              { __typename?: 'PlanMeteredFeatureNumericDetails' }
+              & Pick<PlanMeteredFeatureNumericDetails, 'unit'>
+              & { costTiers: Maybe<Array<(
+                { __typename?: 'PlanFeatureCostTier' }
+                & Pick<PlanFeatureCostTier, 'limit' | 'cost'>
+              )>> }
+            ) }
+          ) }
+        )> }
+      )>, product: Maybe<(
+        { __typename?: 'Product' }
+        & Pick<Product, 'displayName' | 'id' | 'label' | 'logoUrl'>
+        & { freePlans: Maybe<(
+          { __typename?: 'PlanConnection' }
+          & { edges: Array<(
+            { __typename?: 'PlanEdge' }
+            & { node: (
+              { __typename?: 'Plan' }
+              & Pick<Plan, 'cost' | 'displayName' | 'free' | 'id' | 'label'>
+              & { configurableFeatures: Maybe<(
+                { __typename?: 'PlanConfigurableFeatureConnection' }
+                & { edges: Array<(
+                  { __typename?: 'PlanConfigurableFeatureEdge' }
+                  & { node: (
+                    { __typename?: 'PlanConfigurableFeature' }
+                    & Pick<PlanConfigurableFeature, 'label' | 'displayName' | 'type'>
+                    & { options: Maybe<Array<(
+                      { __typename?: 'PlanFixedFeature' }
+                      & Pick<PlanFixedFeature, 'displayName' | 'displayValue' | 'label'>
+                    )>>, numericDetails: Maybe<(
+                      { __typename?: 'PlanConfigurableFeatureNumericDetails' }
+                      & Pick<PlanConfigurableFeatureNumericDetails, 'increment' | 'min' | 'max' | 'unit'>
+                      & { costTiers: Maybe<Array<(
+                        { __typename?: 'PlanFeatureCostTier' }
+                        & Pick<PlanFeatureCostTier, 'limit' | 'cost'>
+                      )>> }
+                    )> }
+                  ) }
+                )> }
+              )>, fixedFeatures: Maybe<(
+                { __typename?: 'PlanFixedFeatureConnection' }
+                & { edges: Array<(
+                  { __typename?: 'PlanFixedFeatureEdge' }
+                  & { node: (
+                    { __typename?: 'PlanFixedFeature' }
+                    & Pick<PlanFixedFeature, 'displayName' | 'displayValue' | 'label'>
+                  ) }
+                )> }
+              )>, meteredFeatures: Maybe<(
+                { __typename?: 'PlanMeteredFeatureConnection' }
+                & { edges: Array<(
+                  { __typename?: 'PlanMeteredFeatureEdge' }
+                  & { node: (
+                    { __typename?: 'PlanMeteredFeature' }
+                    & Pick<PlanMeteredFeature, 'label' | 'displayName'>
+                    & { numericDetails: (
+                      { __typename?: 'PlanMeteredFeatureNumericDetails' }
+                      & Pick<PlanMeteredFeatureNumericDetails, 'unit'>
+                      & { costTiers: Maybe<Array<(
+                        { __typename?: 'PlanFeatureCostTier' }
+                        & Pick<PlanFeatureCostTier, 'limit' | 'cost'>
+                      )>> }
+                    ) }
+                  ) }
+                )> }
+              )>, regions: Maybe<(
+                { __typename?: 'RegionConnection' }
+                & { edges: Array<(
+                  { __typename?: 'RegionEdge' }
+                  & { node: (
+                    { __typename?: 'Region' }
+                    & Pick<Region, 'id' | 'displayName' | 'platform' | 'dataCenter'>
+                  ) }
+                )> }
+              )> }
+            ) }
+          )> }
+        )>, paidPlans: Maybe<(
+          { __typename?: 'PlanConnection' }
+          & { edges: Array<(
+            { __typename?: 'PlanEdge' }
+            & { node: (
+              { __typename?: 'Plan' }
+              & Pick<Plan, 'cost' | 'displayName' | 'free' | 'id' | 'label'>
+              & { configurableFeatures: Maybe<(
+                { __typename?: 'PlanConfigurableFeatureConnection' }
+                & { edges: Array<(
+                  { __typename?: 'PlanConfigurableFeatureEdge' }
+                  & { node: (
+                    { __typename?: 'PlanConfigurableFeature' }
+                    & Pick<PlanConfigurableFeature, 'label' | 'displayName' | 'type'>
+                    & { options: Maybe<Array<(
+                      { __typename?: 'PlanFixedFeature' }
+                      & Pick<PlanFixedFeature, 'displayName' | 'displayValue' | 'label'>
+                    )>>, numericDetails: Maybe<(
+                      { __typename?: 'PlanConfigurableFeatureNumericDetails' }
+                      & Pick<PlanConfigurableFeatureNumericDetails, 'increment' | 'min' | 'max' | 'unit'>
+                      & { costTiers: Maybe<Array<(
+                        { __typename?: 'PlanFeatureCostTier' }
+                        & Pick<PlanFeatureCostTier, 'limit' | 'cost'>
+                      )>> }
+                    )> }
+                  ) }
+                )> }
+              )>, fixedFeatures: Maybe<(
+                { __typename?: 'PlanFixedFeatureConnection' }
+                & { edges: Array<(
+                  { __typename?: 'PlanFixedFeatureEdge' }
+                  & { node: (
+                    { __typename?: 'PlanFixedFeature' }
+                    & Pick<PlanFixedFeature, 'displayName' | 'displayValue' | 'label'>
+                  ) }
+                )> }
+              )>, meteredFeatures: Maybe<(
+                { __typename?: 'PlanMeteredFeatureConnection' }
+                & { edges: Array<(
+                  { __typename?: 'PlanMeteredFeatureEdge' }
+                  & { node: (
+                    { __typename?: 'PlanMeteredFeature' }
+                    & Pick<PlanMeteredFeature, 'label' | 'displayName'>
+                    & { numericDetails: (
+                      { __typename?: 'PlanMeteredFeatureNumericDetails' }
+                      & Pick<PlanMeteredFeatureNumericDetails, 'unit'>
+                      & { costTiers: Maybe<Array<(
+                        { __typename?: 'PlanFeatureCostTier' }
+                        & Pick<PlanFeatureCostTier, 'limit' | 'cost'>
+                      )>> }
+                    ) }
+                  ) }
+                )> }
+              )>, regions: Maybe<(
+                { __typename?: 'RegionConnection' }
+                & { edges: Array<(
+                  { __typename?: 'RegionEdge' }
+                  & { node: (
+                    { __typename?: 'Region' }
+                    & Pick<Region, 'id' | 'displayName' | 'platform' | 'dataCenter'>
+                  ) }
+                )> }
+              )> }
+            ) }
+          )> }
+        )> }
+      )>, regions: Maybe<(
+        { __typename?: 'RegionConnection' }
+        & { edges: Array<(
+          { __typename?: 'RegionEdge' }
+          & { node: (
+            { __typename?: 'Region' }
+            & Pick<Region, 'id' | 'displayName' | 'platform' | 'dataCenter'>
+          ) }
+        )> }
+      )> }
+    )>, region: Maybe<(
+      { __typename?: 'Region' }
+      & Pick<Region, 'dataCenter' | 'displayName' | 'id' | 'platform'>
+    )> }
+  )> }
+);
+
 export type Resources_With_OwnerQueryVariables = {
   first: Scalars['Int'],
   after: Scalars['String'],

--- a/src/utils/plan.ts
+++ b/src/utils/plan.ts
@@ -4,8 +4,8 @@ import { pluralize } from './string';
 import { RestFetch } from './restFetch';
 import {
   PlanMeteredFeatureNumericDetails,
-  PlanConfigurableFeatureEdge,
   PlanFeatureType,
+  ResourcePlansQuery,
 } from '../types/graphql';
 
 interface PlanCostOptions {
@@ -154,7 +154,8 @@ export function planCost(restFetch: RestFetch, { planID, features, init }: PlanC
 /**
  * Get default feature map for configurableFeatures
  */
-export function configurableFeatureDefaults(configurableFeatures: PlanConfigurableFeatureEdge[]) {
+type ConfigurableFeatures = ResourcePlansQuery['resource']['plan']['product']['paidPlans']['edges'][0]['node']['configurableFeatures']['edges'];
+export function configurableFeatureDefaults(configurableFeatures: ConfigurableFeatures) {
   const defaultFeatures: Gateway.FeatureMap = {};
 
   configurableFeatures.forEach(({ node: { label, numericDetails, options, type } }) => {


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

Converts `<manifold-plan-selector>` (and fam) to use typed queries

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
