### PR TITLE
fix: added read-only state for regions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifoldco/ui",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -13,6 +13,7 @@ import {
   PlanMeteredFeatureEdge,
   Product,
   ProductEdge,
+  Region,
   Resource,
   ResourceCredentialsQuery,
   ResourceStatusLabel,
@@ -408,6 +409,8 @@ export namespace Components {
     'isExistingResource'?: boolean;
     'plan'?: Plan;
     'product'?: Product;
+    'readOnly'?: boolean;
+    'region'?: Region;
     'regions'?: string[];
     'resourceRegion'?: string;
     'scrollLocked'?: boolean;
@@ -1429,6 +1432,8 @@ declare namespace LocalJSX {
     'onManifold-planSelector-load'?: (event: CustomEvent<any>) => void;
     'plan'?: Plan;
     'product'?: Product;
+    'readOnly'?: boolean;
+    'region'?: Region;
     'regions'?: string[];
     'resourceRegion'?: string;
     'scrollLocked'?: boolean;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -409,7 +409,6 @@ export namespace Components {
     'isExistingResource'?: boolean;
     'plan'?: Plan;
     'product'?: Product;
-    'readOnly'?: boolean;
     'region'?: Region;
     'regions'?: string[];
     'resourceRegion'?: string;
@@ -1432,7 +1431,6 @@ declare namespace LocalJSX {
     'onManifold-planSelector-load'?: (event: CustomEvent<any>) => void;
     'plan'?: Plan;
     'product'?: Product;
-    'readOnly'?: boolean;
     'region'?: Region;
     'regions'?: string[];
     'resourceRegion'?: string;

--- a/src/components/manifold-active-plan/manifold-active-plan.tsx
+++ b/src/components/manifold-active-plan/manifold-active-plan.tsx
@@ -63,6 +63,7 @@ export class ManifoldActivePlan {
         regions={this.regions}
         resourceRegion={resourceRegion}
         scrollLocked={true}
+        region={this.selectedResource && this.selectedResource.region}
       >
         <manifold-forward-slot slot="cta">
           <slot name="cta" />

--- a/src/components/manifold-plan-details/manifold-plan-details.tsx
+++ b/src/components/manifold-plan-details/manifold-plan-details.tsx
@@ -34,7 +34,6 @@ export class ManifoldPlanDetails {
   @Prop() region?: Region;
   @Prop() regions?: string[];
   @Prop() resourceRegion?: string;
-  @Prop() readOnly?: boolean;
   @State() features: Gateway.FeatureMap = {};
   @State() regionId?: string;
   @Event({ eventName: 'manifold-planSelector-change', bubbles: true }) planUpdate: EventEmitter;
@@ -251,7 +250,7 @@ export class ManifoldPlanDetails {
                   />
                 ))}
             </dl>
-            {this.regionOptions && (
+            {(this.regionOptions || this.region) && (
               <div class="region">
                 <label
                   class="region-label"
@@ -260,9 +259,7 @@ export class ManifoldPlanDetails {
                 >
                   Region
                 </label>
-                {this.readOnly ? (
-                  this.region && this.region.displayName
-                ) : (
+                {!this.isExistingResource && this.regionOptions && (
                   <manifold-select
                     aria-label="plan region selection"
                     defaultValue={this.regionId}
@@ -272,8 +269,10 @@ export class ManifoldPlanDetails {
                     options={this.regionOptions}
                   />
                 )}
+                {this.isExistingResource && this.region && this.region.displayName}
               </div>
             )}
+
             <footer class="footer">
               <manifold-plan-cost plan={this.plan} selectedFeatures={this.features} />
               <slot name="cta" />

--- a/src/components/manifold-plan-details/manifold-plan-details.tsx
+++ b/src/components/manifold-plan-details/manifold-plan-details.tsx
@@ -211,7 +211,6 @@ export class ManifoldPlanDetails {
   @logger()
   render() {
     if (this.plan && this.product) {
-      console.log(this.region);
       return (
         <section
           class="wrapper"

--- a/src/components/manifold-plan-details/manifold-plan-details.tsx
+++ b/src/components/manifold-plan-details/manifold-plan-details.tsx
@@ -31,8 +31,10 @@ export class ManifoldPlanDetails {
   @Prop() scrollLocked?: boolean = false;
   @Prop() plan?: Plan;
   @Prop() product?: Product;
+  @Prop() region?: Region;
   @Prop() regions?: string[];
   @Prop() resourceRegion?: string;
+  @Prop() readOnly?: boolean;
   @State() features: Gateway.FeatureMap = {};
   @State() regionId?: string;
   @Event({ eventName: 'manifold-planSelector-change', bubbles: true }) planUpdate: EventEmitter;
@@ -209,6 +211,7 @@ export class ManifoldPlanDetails {
   @logger()
   render() {
     if (this.plan && this.product) {
+      console.log(this.region);
       return (
         <section
           class="wrapper"
@@ -258,14 +261,18 @@ export class ManifoldPlanDetails {
                 >
                   Region
                 </label>
-                <manifold-select
-                  aria-label="plan region selection"
-                  defaultValue={this.regionId}
-                  id="manifold-region-selector"
-                  name="manifold-region-selector"
-                  onUpdateValue={this.handleChangeRegion}
-                  options={this.regionOptions}
-                />
+                {this.readOnly ? (
+                  this.region && this.region.displayName
+                ) : (
+                  <manifold-select
+                    aria-label="plan region selection"
+                    defaultValue={this.regionId}
+                    id="manifold-region-selector"
+                    name="manifold-region-selector"
+                    onUpdateValue={this.handleChangeRegion}
+                    options={this.regionOptions}
+                  />
+                )}
               </div>
             )}
             <footer class="footer">

--- a/src/components/manifold-plan-selector/manifold-plan-selector.tsx
+++ b/src/components/manifold-plan-selector/manifold-plan-selector.tsx
@@ -29,6 +29,10 @@ const plansQuery = gql`
 const resourceQuery = gql`
   query RESOURCE_PRODUCT($resourceLabel: String!) {
     resource(label: $resourceLabel) {
+      region {
+        id
+        displayName
+      }
       plan {
         id
         product {
@@ -128,6 +132,7 @@ export class ManifoldPlanSelector {
     if (data && data.resource) {
       this.resource = data.resource;
       if (data.resource && data.resource.plan && data.resource.plan.product) {
+        // TODO move plan fetching to resource query
         this.fetchPlans(data.resource.plan.product.label);
       }
     }
@@ -156,6 +161,7 @@ export class ManifoldPlanSelector {
         product={this.product}
         regions={regions}
         selectedResource={this.resource}
+        isExistingResource={!!this.resource}
       >
         <manifold-forward-slot slot="cta">
           <slot name="cta" />

--- a/src/components/manifold-resource-container/manifold-resource-container.tsx
+++ b/src/components/manifold-resource-container/manifold-resource-container.tsx
@@ -13,6 +13,10 @@ const query = gql`
     resource(label: $resourceLabel) {
       id
       label
+      region {
+        id
+        displayName
+      }
       status {
         label
       }

--- a/src/components/manifold-resource-plan/manifold-resource-plan.tsx
+++ b/src/components/manifold-resource-plan/manifold-resource-plan.tsx
@@ -3,7 +3,7 @@ import { h, Component, Prop } from '@stencil/core';
 import ResourceTunnel from '../../data/resource';
 import logger from '../../utils/logger';
 import loadMark from '../../utils/loadMark';
-import { Product, Plan, Resource } from '../../types/graphql';
+import { Product, Plan, Resource, Region } from '../../types/graphql';
 
 @Component({ tag: 'manifold-resource-plan' })
 export class ManifoldResourcePlan {
@@ -17,11 +17,12 @@ export class ManifoldResourcePlan {
   render() {
     let product: Product | null | undefined;
     let plan: Plan | null = null;
-    if (!this.loading && this.gqlData) {
-      if (this.gqlData.plan) {
-        plan = this.gqlData.plan;
-        product = this.gqlData.plan.product;
-      }
+    let region: Region | undefined;
+
+    if (!this.loading && this.gqlData && this.gqlData.plan) {
+      plan = this.gqlData.plan;
+      product = this.gqlData.plan.product;
+      region = this.gqlData.region;
     }
 
     if (this.loading || !product || !plan) {
@@ -31,7 +32,15 @@ export class ManifoldResourcePlan {
       );
     }
 
-    return <manifold-plan-details scrollLocked={false} plan={plan} product={product as Product} />;
+    return (
+      <manifold-plan-details
+        scrollLocked={false}
+        plan={plan}
+        product={product}
+        region={region}
+        readOnly
+      />
+    );
   }
 }
 

--- a/src/components/manifold-resource-plan/manifold-resource-plan.tsx
+++ b/src/components/manifold-resource-plan/manifold-resource-plan.tsx
@@ -38,7 +38,7 @@ export class ManifoldResourcePlan {
         plan={plan}
         product={product}
         region={region}
-        readOnly
+        isExistingResource
       />
     );
   }

--- a/stories/resource.stories.js
+++ b/stories/resource.stories.js
@@ -127,7 +127,7 @@ storiesOf('Resource', module)
         }
       </style>
       <manifold-resource-container resource-label="${resourceLabel}">
-        <manifold-plan-selector product-label="${productLabel}"></manifold-plan-selector>
+        <manifold-plan-selector product-label="${productLabel}" resource-label="${resourceLabel}"></manifold-plan-selector>
         <menu>
           <manifold-data-resize-button
             resource-label="${resourceLabel}"


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

Add the option for regions to be read-only in `<manifold-plan-details>` so that it can be used in `<manifold-resource-plan>` in a read-only state.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->
- check that the region display in resource details as plain text
- check that the select dropdown is displayed in the plan selector

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
