### PR TITLE
Make props optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Dependabot config (#677)
 - Added missing `cta` slot to `<manifold-resource-plan>` (#689)
+- Fixed `loading` being a required prop in TypeScript despite it being hidden (#687)
 
 ## [v0.6.2]
 

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -490,7 +490,7 @@ export namespace Components {
     /**
     * Set whether or not to refetch the resource from the api until it is in an available and valid state
     */
-    'refetchUntilValid': boolean;
+    'refetchUntilValid'?: boolean;
     /**
     * Which resource does this belong to?
     */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -111,7 +111,7 @@ export namespace Components {
   }
   interface ManifoldCredentialsView {
     'credentials'?: ResourceCredentialsQuery['resource']['credentials']['edges'];
-    'loading': boolean;
+    'loading'?: boolean;
   }
   interface ManifoldDataDeprovisionButton {
     /**
@@ -498,12 +498,12 @@ export namespace Components {
   }
   interface ManifoldResourceCredentials {
     'gqlData'?: Resource;
-    'loading': boolean;
+    'loading'?: boolean;
     'noCredentials'?: boolean;
   }
   interface ManifoldResourceDeprovision {
     'gqlData'?: Resource;
-    'loading': boolean;
+    'loading'?: boolean;
   }
   interface ManifoldResourceList {
     /**
@@ -529,16 +529,16 @@ export namespace Components {
   }
   interface ManifoldResourcePlan {
     'gqlData'?: Resource;
-    'loading': boolean;
+    'loading'?: boolean;
   }
   interface ManifoldResourceProduct {
     'gqlData'?: Resource;
-    'loading': boolean;
+    'loading'?: boolean;
   }
   interface ManifoldResourceRename {
     'disabled'?: boolean;
     'gqlData'?: Resource;
-    'loading': boolean;
+    'loading'?: boolean;
     /**
     * The new label to give to the resource
     */
@@ -546,11 +546,11 @@ export namespace Components {
   }
   interface ManifoldResourceSso {
     'gqlData'?: Resource;
-    'loading': boolean;
+    'loading'?: boolean;
   }
   interface ManifoldResourceStatus {
     'gqlData'?: Resource;
-    'loading': boolean;
+    'loading'?: boolean;
     'size'?: 'xsmall' | 'small' | 'medium';
   }
   interface ManifoldResourceStatusView {

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -211,7 +211,7 @@ export namespace Components {
     /**
     * The new label to give to the resource
     */
-    'newLabel': string;
+    'newLabel'?: string;
     /**
     * The id of the resource to rename, will be fetched if not set
     */
@@ -542,7 +542,7 @@ export namespace Components {
     /**
     * The new label to give to the resource
     */
-    'newLabel': string;
+    'newLabel'?: string;
   }
   interface ManifoldResourceSso {
     'gqlData'?: Resource;

--- a/src/components/manifold-credentials-view/manifold-credentials-view.tsx
+++ b/src/components/manifold-credentials-view/manifold-credentials-view.tsx
@@ -13,7 +13,7 @@ import loadMark from '../../utils/loadMark';
 export class ManifoldCredentialsView {
   @Element() private el: HTMLElement;
   @Prop() credentials?: ResourceCredentialsQuery['resource']['credentials']['edges'];
-  @Prop() loading: boolean = false;
+  @Prop() loading?: boolean = false;
   @State() shouldTransition: boolean = false;
   @Event() credentialsRequested: EventEmitter;
 

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
@@ -7,28 +7,28 @@ import logger from '../../utils/logger';
 import loadMark from '../../utils/loadMark';
 
 interface ClickMessage {
-  newLabel: string;
+  newLabel?: string;
   resourceLabel: string;
   resourceId: string;
 }
 
 interface InvalidMessage {
   message: string;
-  newLabel: string;
+  newLabel?: string;
   resourceLabel: string;
   resourceId: string;
 }
 
 interface SuccessMessage {
   message: string;
-  newLabel: string;
+  newLabel?: string;
   resourceLabel: string;
   resourceId: string;
 }
 
 interface ErrorMessage {
   message: string;
-  newLabel: string;
+  newLabel?: string;
   resourceLabel: string;
   resourceId?: string;
 }
@@ -61,7 +61,7 @@ export class ManifoldDataRenameButton {
   /** The label of the resource to rename */
   @Prop() resourceLabel?: string;
   /** The new label to give to the resource */
-  @Prop() newLabel: string = '';
+  @Prop() newLabel?: string;
   /** The id of the resource to rename, will be fetched if not set */
   @Prop({ mutable: true }) resourceId?: string = '';
   @Prop() loading?: boolean = false;
@@ -82,7 +82,8 @@ export class ManifoldDataRenameButton {
   }
 
   async rename() {
-    if (!this.graphqlFetch || this.loading) {
+    const newLabel = this.newLabel; // eslint-disable-line prefer-destructuring
+    if (!this.graphqlFetch || this.loading || !newLabel) {
       return;
     }
 
@@ -93,12 +94,12 @@ export class ManifoldDataRenameButton {
 
     const resourceDetails = {
       resourceLabel: this.resourceLabel || '',
-      newLabel: this.newLabel,
+      newLabel,
       resourceId: this.resourceId,
     };
 
     // invalid event
-    if (this.newLabel.length < 3) {
+    if (newLabel.length < 3) {
       const message: InvalidMessage = {
         ...resourceDetails,
         message: 'Must be at least 3 characters',
@@ -106,7 +107,7 @@ export class ManifoldDataRenameButton {
       this.invalid.emit(message);
       return;
     }
-    if (!this.validate(this.newLabel)) {
+    if (!this.validate(newLabel)) {
       const message: InvalidMessage = {
         ...resourceDetails,
         message: 'Must start with a lowercase letter, and use only lowercase, numbers, and hyphens',
@@ -124,7 +125,7 @@ export class ManifoldDataRenameButton {
       query: queryResourceRename,
       variables: {
         resourceId: this.resourceId,
-        newLabel: this.newLabel,
+        newLabel,
       },
       element: this.el,
     });
@@ -136,13 +137,13 @@ export class ManifoldDataRenameButton {
 
     if (data && data.resource) {
       this.newLabel = data.resource.label;
-      resourceDetails.newLabel = this.newLabel;
+      resourceDetails.newLabel = newLabel;
     }
 
     // success event
     const successMessage: SuccessMessage = {
       ...resourceDetails,
-      message: `${this.resourceLabel} renamed to ${this.newLabel}`,
+      message: `${this.resourceLabel} renamed to ${newLabel}`,
     };
 
     this.success.emit(successMessage);

--- a/src/components/manifold-resource-container/manifold-resource-container.tsx
+++ b/src/components/manifold-resource-container/manifold-resource-container.tsx
@@ -134,7 +134,7 @@ export class ManifoldResourceContainer {
   /** Which resource does this belong to? */
   @Prop() resourceLabel?: string;
   /** Set whether or not to refetch the resource from the api until it is in an available and valid state */
-  @Prop() refetchUntilValid: boolean = false;
+  @Prop() refetchUntilValid?: boolean = false;
   @State() gqlData?: Resource;
   @State() loading: boolean = true;
   @State() timeout?: number;

--- a/src/components/manifold-resource-credentials/manifold-resource-credentials.tsx
+++ b/src/components/manifold-resource-credentials/manifold-resource-credentials.tsx
@@ -8,7 +8,7 @@ import { Resource } from '../../types/graphql';
 @Component({ tag: 'manifold-resource-credentials' })
 export class ManifoldResourceCredentials {
   @Prop() gqlData?: Resource;
-  @Prop() loading: boolean = true;
+  @Prop() loading?: boolean = true;
   @Prop() noCredentials?: boolean = false;
 
   @loadMark()

--- a/src/components/manifold-resource-deprovision/manifold-resource-deprovision.tsx
+++ b/src/components/manifold-resource-deprovision/manifold-resource-deprovision.tsx
@@ -8,7 +8,7 @@ import { Resource } from '../../types/graphql';
 @Component({ tag: 'manifold-resource-deprovision' })
 export class ManifoldResourceDeprovision {
   @Prop() gqlData?: Resource;
-  @Prop() loading: boolean = true;
+  @Prop() loading?: boolean = true;
 
   @loadMark()
   componentWillLoad() {}

--- a/src/components/manifold-resource-plan/manifold-resource-plan.tsx
+++ b/src/components/manifold-resource-plan/manifold-resource-plan.tsx
@@ -8,7 +8,7 @@ import { Product, Plan, Resource, Region } from '../../types/graphql';
 @Component({ tag: 'manifold-resource-plan' })
 export class ManifoldResourcePlan {
   @Prop() gqlData?: Resource;
-  @Prop() loading: boolean = true;
+  @Prop() loading?: boolean = true;
 
   @loadMark()
   componentWillLoad() {}

--- a/src/components/manifold-resource-product/manifold-resource-product.tsx
+++ b/src/components/manifold-resource-product/manifold-resource-product.tsx
@@ -8,7 +8,7 @@ import loadMark from '../../utils/loadMark';
 @Component({ tag: 'manifold-resource-product' })
 export class ManifoldResourceProduct {
   @Prop() gqlData?: Resource;
-  @Prop() loading: boolean = true;
+  @Prop() loading?: boolean = true;
 
   @loadMark()
   componentWillLoad() {}

--- a/src/components/manifold-resource-rename/manifold-resource-rename.tsx
+++ b/src/components/manifold-resource-rename/manifold-resource-rename.tsx
@@ -11,7 +11,7 @@ export class ManifoldResourceRename {
   @Prop() loading?: boolean = true;
   @Prop() disabled?: boolean;
   /** The new label to give to the resource */
-  @Prop() newLabel: string = '';
+  @Prop() newLabel?: string = '';
 
   @loadMark()
   componentWillLoad() {}

--- a/src/components/manifold-resource-rename/manifold-resource-rename.tsx
+++ b/src/components/manifold-resource-rename/manifold-resource-rename.tsx
@@ -8,7 +8,7 @@ import { Resource } from '../../types/graphql';
 @Component({ tag: 'manifold-resource-rename' })
 export class ManifoldResourceRename {
   @Prop() gqlData?: Resource;
-  @Prop() loading: boolean = true;
+  @Prop() loading?: boolean = true;
   @Prop() disabled?: boolean;
   /** The new label to give to the resource */
   @Prop() newLabel: string = '';

--- a/src/components/manifold-resource-sso/manifold-resource-sso.tsx
+++ b/src/components/manifold-resource-sso/manifold-resource-sso.tsx
@@ -8,7 +8,7 @@ import { Resource } from '../../types/graphql';
 @Component({ tag: 'manifold-resource-sso' })
 export class ManifoldResourceSso {
   @Prop() gqlData?: Resource;
-  @Prop() loading: boolean = true;
+  @Prop() loading?: boolean = true;
 
   @loadMark()
   componentWillLoad() {}

--- a/src/components/manifold-resource-status/manifold-resource-status.tsx
+++ b/src/components/manifold-resource-status/manifold-resource-status.tsx
@@ -8,7 +8,7 @@ import { Resource } from '../../types/graphql';
 @Component({ tag: 'manifold-resource-status' })
 export class ManifoldResourceStatus {
   @Prop() gqlData?: Resource;
-  @Prop() loading: boolean = true;
+  @Prop() loading?: boolean = true;
   @Prop() size?: 'xsmall' | 'small' | 'medium' = 'medium';
 
   @loadMark()


### PR DESCRIPTION
## Reason for change

TypeScript throws the following error with `<manifold-resource-status>` (and related components)

```
  Property ''loading'' is missing in type '{ size: "small"; }' but required in type 'ManifoldResourceStatus'.ts(2322)
```

When we make a `prop` mandatory, we require a user manually specify it

## Testing

This should build

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
