### PR TITLE
Add CTA slot to `<manifold-resource-plan>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Dependabot config (#677)
+- Added missing `cta` slot to `<manifold-resource-plan>` (#689)
 
 ## [v0.6.2]
 

--- a/src/components/manifold-resource-plan/manifold-resource-plan.tsx
+++ b/src/components/manifold-resource-plan/manifold-resource-plan.tsx
@@ -28,7 +28,11 @@ export class ManifoldResourcePlan {
     if (this.loading || !product || !plan) {
       return (
         // ☠
-        <manifold-plan-details scrollLocked={false} />
+        <manifold-plan-details scrollLocked={false}>
+          <manifold-forward-slot slot="cta">
+            <slot name="cta" />
+          </manifold-forward-slot>
+        </manifold-plan-details>
       );
     }
 
@@ -39,7 +43,11 @@ export class ManifoldResourcePlan {
         product={product}
         region={region}
         isExistingResource
-      />
+      >
+        <manifold-forward-slot slot="cta">
+          <slot name="cta" />
+        </manifold-forward-slot>
+      </manifold-plan-details>
     );
   }
 }


### PR DESCRIPTION
## Reason for change
I need `<manifold-resource-plan>` to behave identically to `<manifold-plan>` in handling the CTA slot. This adds that.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
