### PR TITLE
fix: always display contents of manifold-resource-container

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manifoldco/ui",
   "description": "Manifold UI",
-  "version": "0.6.3-rc.0",
+  "version": "0.6.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/manifoldco/ui.git"

--- a/src/components/manifold-resource-container/manifold-resource-container.tsx
+++ b/src/components/manifold-resource-container/manifold-resource-container.tsx
@@ -156,7 +156,7 @@ export class ManifoldResourceContainer {
 
   @loadMark()
   componentWillLoad() {
-    return this.fetchResource(this.resourceLabel);
+    this.fetchResource(this.resourceLabel);
   }
 
   componentDidUnload() {


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
Resource container would hide it's contents until the `fetchResource` promise was resolved. Now the fetch no longer blocks the display of content and shows loading states.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->
- All the resource stories should never show a blank screen while the resource hasn't been fetched.
- All the resource stories should never show a blank screen while unauthenticated. (This can be tested by setting `env: Production` and `authType: Manual`)

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
