### PR TITLE
Always re-authenticate when token is unset

### DIFF
--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -34,9 +34,9 @@ export class ManifoldAuthToken {
   componentWillLoad() {
     this.setExternalToken(this.token);
     if (this.subscribe) {
-      this.unsubscribe = this.subscribe((oldToken?: string, newToken?: string) => {
+      this.unsubscribe = this.subscribe((newToken?: string) => {
         this.internalToken = newToken;
-        if (oldToken && !newToken) {
+        if (!newToken) {
           // changing this to any new string will cause a token refresh. getTime() does that wonderfully.
           this.tick = new Date().getTime().toString();
           this.clear.emit();

--- a/src/state/connection.spec.ts
+++ b/src/state/connection.spec.ts
@@ -7,7 +7,7 @@ describe('connection state', () => {
     const subscriber = jest.fn();
     state.subscribe(subscriber);
     state.setAuthToken('new-token');
-    expect(subscriber).toHaveBeenCalledWith('old-token', 'new-token');
+    expect(subscriber).toHaveBeenCalledWith('new-token');
   });
 
   it('will not notify after unsubscribing', () => {

--- a/src/state/connection.ts
+++ b/src/state/connection.ts
@@ -4,7 +4,7 @@ import { createRestFetch } from '../utils/restFetch';
 
 const baseWait = 15000;
 
-export type Subscriber = (oldToken?: string, newToken?: string) => void;
+export type Subscriber = (newToken?: string) => void;
 
 const INITIALIZED = 'manifold-connection-initialize';
 
@@ -56,7 +56,7 @@ export class ConnectionState {
   };
 
   setAuthToken = (token: string) => {
-    this.subscribers.forEach(s => s(this.authToken, token));
+    this.subscribers.forEach(s => s(token));
     this.authToken = token;
   };
 


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

To make re-authentication more reliable!

Currently, we only re-authenticate if the token goes from having a value to having no value. With this change, we will attempt to re-authenticate every time a token is unset, regardless of whether or not the connection state previously had a token value present.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
