### PR TITLE
refactor: graphql queries for product-name and product-logo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manifoldco/ui",
   "description": "Manifold UI",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/manifoldco/ui.git"

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -151,7 +151,7 @@ export namespace Components {
     /**
     * URL-friendly slug (e.g. `"jawsdb-mysql"`)
     */
-    'productLabel'?: string;
+    'productLabel': string;
     /**
     * _(Deprecated)_ Look up product logo from resource
     */

--- a/src/components/manifold-data-product-logo/manifold-data-product-logo.tsx
+++ b/src/components/manifold-data-product-logo/manifold-data-product-logo.tsx
@@ -1,7 +1,7 @@
 import { h, Component, Element, Prop, State, Watch } from '@stencil/core';
 
 import { GraphqlFetch } from '../../utils/graphqlFetch';
-import { Product, ProductLogoQuery } from '../../types/graphql';
+import { Product, ProductLogoQuery, ProductLogoQueryVariables } from '../../types/graphql';
 import connection from '../../state/connection';
 import logger from '../../utils/logger';
 import loadMark from '../../utils/loadMark';
@@ -16,7 +16,7 @@ export class ManifoldDataProductLogo {
   /** _(hidden)_ */
   @Prop() graphqlFetch?: GraphqlFetch = connection.graphqlFetch;
   /** URL-friendly slug (e.g. `"jawsdb-mysql"`) */
-  @Prop() productLabel?: string;
+  @Prop() productLabel: string;
   /** _(Deprecated)_ Look up product logo from resource */
   @Prop() resourceLabel?: string;
   @State() product?: Pick<Product, 'displayName' | 'logoUrl'>;
@@ -30,13 +30,13 @@ export class ManifoldDataProductLogo {
     this.fetchProduct(this.productLabel);
   }
 
-  fetchProduct = async (productLabel?: string) => {
+  fetchProduct = async (productLabel: string) => {
     if (!this.graphqlFetch || !this.productLabel) {
       return;
     }
 
     this.product = undefined;
-    const variables = { productLabel };
+    const variables: ProductLogoQueryVariables = { productLabel };
     const { data } = await this.graphqlFetch<ProductLogoQuery>({
       query: productLogoQuery,
       variables,

--- a/src/components/manifold-data-product-logo/manifold-data-product-logo.tsx
+++ b/src/components/manifold-data-product-logo/manifold-data-product-logo.tsx
@@ -1,20 +1,12 @@
 import { h, Component, Element, Prop, State, Watch } from '@stencil/core';
-import { gql } from '@manifoldco/gql-zero';
 
 import { GraphqlFetch } from '../../utils/graphqlFetch';
-import { Product } from '../../types/graphql';
+import { Product, ProductLogoQuery } from '../../types/graphql';
 import connection from '../../state/connection';
 import logger from '../../utils/logger';
 import loadMark from '../../utils/loadMark';
 
-const query = gql`
-  query PRODUCT_LOGO($productLabel: String!) {
-    product(label: $productLabel) {
-      displayName
-      logoUrl
-    }
-  }
-`;
+import productLogoQuery from './product-logo.graphql';
 
 @Component({ tag: 'manifold-data-product-logo' })
 export class ManifoldDataProductLogo {
@@ -27,7 +19,7 @@ export class ManifoldDataProductLogo {
   @Prop() productLabel?: string;
   /** _(Deprecated)_ Look up product logo from resource */
   @Prop() resourceLabel?: string;
-  @State() product?: Product;
+  @State() product?: Pick<Product, 'displayName' | 'logoUrl'>;
 
   @Watch('productLabel') productChange(newProduct: string) {
     this.fetchProduct(newProduct);
@@ -45,7 +37,11 @@ export class ManifoldDataProductLogo {
 
     this.product = undefined;
     const variables = { productLabel };
-    const { data } = await this.graphqlFetch({ query, variables, element: this.el });
+    const { data } = await this.graphqlFetch<ProductLogoQuery>({
+      query: productLogoQuery,
+      variables,
+      element: this.el,
+    });
 
     this.product = (data && data.product) || undefined;
   };

--- a/src/components/manifold-data-product-logo/product-logo.graphql
+++ b/src/components/manifold-data-product-logo/product-logo.graphql
@@ -1,0 +1,6 @@
+query ProductLogo($productLabel: String!) {
+  product(label: $productLabel) {
+    displayName
+    logoUrl
+  }
+}

--- a/src/components/manifold-data-product-name/manifold-data-product-name.tsx
+++ b/src/components/manifold-data-product-name/manifold-data-product-name.tsx
@@ -7,7 +7,12 @@ import loadMark from '../../utils/loadMark';
 
 import productNameQuery from './product-name.graphql';
 import resourceProductNameQuery from './resource-product-name.graphql';
-import { ProductNameQuery, ResourceProductNameQuery } from '../../types/graphql';
+import {
+  ProductNameQuery,
+  ProductNameQueryVariables,
+  ResourceProductNameQuery,
+  ResourceProductNameQueryVariables,
+} from '../../types/graphql';
 
 @Component({ tag: 'manifold-data-product-name' })
 export class ManifoldDataProductName {
@@ -44,9 +49,10 @@ export class ManifoldDataProductName {
 
     this.productName = undefined;
 
+    const variables: ProductNameQueryVariables = { productLabel };
     const { data, errors } = await this.graphqlFetch<ProductNameQuery>({
       query: productNameQuery,
-      variables: { productLabel },
+      variables,
       element: this.el,
     });
 
@@ -64,9 +70,10 @@ export class ManifoldDataProductName {
 
     this.productName = undefined;
 
+    const variables: ResourceProductNameQueryVariables = { resourceLabel };
     const { data, errors } = await this.graphqlFetch<ResourceProductNameQuery>({
       query: resourceProductNameQuery,
-      variables: { resourceLabel },
+      variables,
       element: this.el,
     });
 

--- a/src/components/manifold-data-product-name/manifold-data-product-name.tsx
+++ b/src/components/manifold-data-product-name/manifold-data-product-name.tsx
@@ -1,10 +1,13 @@
 import { Component, Prop, State, Element, Watch } from '@stencil/core';
-import { gql } from '@manifoldco/gql-zero';
 
 import connection from '../../state/connection';
 import { GraphqlFetch, GraphqlError } from '../../utils/graphqlFetch';
 import logger from '../../utils/logger';
 import loadMark from '../../utils/loadMark';
+
+import productNameQuery from './product-name.graphql';
+import resourceProductNameQuery from './resource-product-name.graphql';
+import { ProductNameQuery, ResourceProductNameQuery } from '../../types/graphql';
 
 @Component({ tag: 'manifold-data-product-name' })
 export class ManifoldDataProductName {
@@ -41,14 +44,8 @@ export class ManifoldDataProductName {
 
     this.productName = undefined;
 
-    const { data, errors } = await this.graphqlFetch({
-      query: gql`
-        query PRODUCT_NAME($productLabel: String!) {
-          product(label: $productLabel) {
-            displayName
-          }
-        }
-      `,
+    const { data, errors } = await this.graphqlFetch<ProductNameQuery>({
+      query: productNameQuery,
       variables: { productLabel },
       element: this.el,
     });
@@ -67,18 +64,8 @@ export class ManifoldDataProductName {
 
     this.productName = undefined;
 
-    const { data, errors } = await this.graphqlFetch({
-      query: gql`
-        query RESOURCE($resourceLabel: String!) {
-          resource(label: $resourceLabel) {
-            plan {
-              product {
-                displayName
-              }
-            }
-          }
-        }
-      `,
+    const { data, errors } = await this.graphqlFetch<ResourceProductNameQuery>({
+      query: resourceProductNameQuery,
       variables: { resourceLabel },
       element: this.el,
     });

--- a/src/components/manifold-data-product-name/product-name.graphql
+++ b/src/components/manifold-data-product-name/product-name.graphql
@@ -1,0 +1,5 @@
+query ProductName($productLabel: String!) {
+  product(label: $productLabel) {
+    displayName
+  }
+}

--- a/src/components/manifold-data-product-name/resource-product-name.graphql
+++ b/src/components/manifold-data-product-name/resource-product-name.graphql
@@ -1,0 +1,9 @@
+query ResourceProductName($resourceLabel: String!) {
+  resource(label: $resourceLabel) {
+    plan {
+      product {
+        displayName
+      }
+    }
+  }
+}

--- a/src/components/manifold-data-sso-button/sso-id.graphql
+++ b/src/components/manifold-data-sso-button/sso-id.graphql
@@ -1,4 +1,4 @@
-query ResourceSSOByLabel($resourceId: ID!) {
+query ResourceSSOByID($resourceId: ID!) {
   resource(id: $resourceId) {
     id
     label

--- a/src/components/manifold-data-sso-button/sso-label.graphql
+++ b/src/components/manifold-data-sso-button/sso-label.graphql
@@ -1,4 +1,4 @@
-query ResourceSSOByID($resourceLabel: String!) {
+query ResourceSSOByLabel($resourceLabel: String!) {
   resource(label: $resourceLabel) {
     id
     label

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1554,6 +1554,51 @@ export type DeleteResourceMutation = (
   ) }
 );
 
+export type ProductLogoQueryVariables = {
+  productLabel: Scalars['String']
+};
+
+
+export type ProductLogoQuery = (
+  { __typename?: 'Query' }
+  & { product: Maybe<(
+    { __typename?: 'Product' }
+    & Pick<Product, 'displayName' | 'logoUrl'>
+  )> }
+);
+
+export type ProductNameQueryVariables = {
+  productLabel: Scalars['String']
+};
+
+
+export type ProductNameQuery = (
+  { __typename?: 'Query' }
+  & { product: Maybe<(
+    { __typename?: 'Product' }
+    & Pick<Product, 'displayName'>
+  )> }
+);
+
+export type ResourceProductNameQueryVariables = {
+  resourceLabel: Scalars['String']
+};
+
+
+export type ResourceProductNameQuery = (
+  { __typename?: 'Query' }
+  & { resource: Maybe<(
+    { __typename?: 'Resource' }
+    & { plan: Maybe<(
+      { __typename?: 'Plan' }
+      & { product: Maybe<(
+        { __typename?: 'Product' }
+        & Pick<Product, 'displayName'>
+      )> }
+    )> }
+  )> }
+);
+
 export type CreateResourceWithOwnerMutationVariables = {
   planId: Scalars['ID'],
   productId: Scalars['ID'],
@@ -1690,12 +1735,12 @@ export type ResourceLogoQuery = (
   )> }
 );
 
-export type ResourceSsoByLabelQueryVariables = {
+export type ResourceSsoByIdQueryVariables = {
   resourceId: Scalars['ID']
 };
 
 
-export type ResourceSsoByLabelQuery = (
+export type ResourceSsoByIdQuery = (
   { __typename?: 'Query' }
   & { resource: Maybe<(
     { __typename?: 'Resource' }
@@ -1703,12 +1748,12 @@ export type ResourceSsoByLabelQuery = (
   )> }
 );
 
-export type ResourceSsoByIdQueryVariables = {
+export type ResourceSsoByLabelQueryVariables = {
   resourceLabel: Scalars['String']
 };
 
 
-export type ResourceSsoByIdQuery = (
+export type ResourceSsoByLabelQuery = (
   { __typename?: 'Query' }
   & { resource: Maybe<(
     { __typename?: 'Resource' }


### PR DESCRIPTION


<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
- move queries to `.graphql` files
- fix naming for SSO queries

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
