### PR TITLE
Add page visibility check to graphql fetch.

### DIFF
--- a/src/utils/graphqlFetch.ts
+++ b/src/utils/graphqlFetch.ts
@@ -121,7 +121,7 @@ export function createGraphqlFetch({
         return e.extensions && e.extensions.type === 'AuthFailed';
       });
 
-      if (authExpired) {
+      if (authExpired && !document.hidden) {
         setAuthToken('');
         if (attempts < retries) {
           return waitForAuthToken(getAuthToken, wait(), () => graphqlFetch(args, attempts + 1));


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

Refreshing authorization was failing on attempts while the page did not focus. This check prevents retry's till the page is brought into focus again.

## Testing

Local black magic @domenicrosati is performing.

Alternatively make sure you're authenticated, open up the network tab in it's own winder, then focus on another tab and watch for manifold network requests.

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
