### PR TITLE
Pause API calls while document is hidden

### DIFF
--- a/src/components/manifold-data-has-resource/manifold-data-has-resource.tsx
+++ b/src/components/manifold-data-has-resource/manifold-data-has-resource.tsx
@@ -70,7 +70,7 @@ export class ManifoldDataHasResource {
   }
 
   async fetchResources(label = this.label) {
-    if (!this.graphqlFetch) {
+    if (!this.graphqlFetch || document.hidden) {
       return;
     }
 

--- a/src/components/manifold-resource-list/manifold-resource-list.tsx
+++ b/src/components/manifold-resource-list/manifold-resource-list.tsx
@@ -52,7 +52,7 @@ export class ManifoldResourceList {
   }
 
   fetchResources = async () => {
-    if (!this.graphqlFetch) {
+    if (!this.graphqlFetch || document.hidden) {
       return;
     }
 

--- a/src/utils/awaitPageVisibility.ts
+++ b/src/utils/awaitPageVisibility.ts
@@ -1,0 +1,9 @@
+export default function awaitPageVisibility() {
+  if (!document.hidden) {
+    return Promise.resolve();
+  }
+
+  return new Promise(resolve => {
+    document.addEventListener('visibilitychange', resolve, { once: true });
+  });
+}

--- a/src/utils/graphqlFetch.ts
+++ b/src/utils/graphqlFetch.ts
@@ -1,6 +1,7 @@
 import { Query } from '../types/graphql';
 import { report } from './errorReport';
 import { waitForAuthToken } from './auth';
+import awaitPageVisibility from './awaitPageVisibility';
 
 interface CreateGraphqlFetch {
   endpoint?: () => string;
@@ -63,6 +64,7 @@ export function createGraphqlFetch({
     attempts: number
   ): Promise<GraphqlResponseBody<T>> {
     await onReady();
+    await awaitPageVisibility();
 
     const rttStart = performance.now();
     const { element, ...request } = args;

--- a/src/utils/restFetch.ts
+++ b/src/utils/restFetch.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from '@stencil/core';
 import { Connection, connections } from './connections';
 import { withAuth, waitForAuthToken } from './auth';
+import awaitPageVisibility from './awaitPageVisibility';
 import { report } from './errorReport';
 
 export interface CreateRestFetch {
@@ -44,6 +45,7 @@ export function createRestFetch({
 }: CreateRestFetch): RestFetch {
   async function restFetch<T>(args: RestFetchArguments, attempts: number): Promise<T | Success> {
     await onReady();
+    await awaitPageVisibility();
 
     const rttStart = performance.now();
 


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

We don't need to make API calls when users aren't viewing the page. And in fact, doing so can cause problems if the auth token is expired, because if we're using OAuth, re-authentication will not complete when the page is not visible.

### How it's done

When making a `graphqlFetch` or `restFetch` call, we'll check the `document.hidden` property. If it's true, we'll return a promise that doesn't resolve until the `visibilitychange` event is fired.

Additionally, components that are currently performing a polling loop will skip their API calls whenever `document.hidden` evaluates to true.

#### Isn't that redundant?

Consider the mechanism that's in `graphqlFetch` and `restFetch` to be the robust, catch-all way to make sure that we don't make a call when the page is hidden. Skipping the call from the components that poll is more of an optimization. If we skip that optimization, then leaving the tab for a full minute and then coming back to it is going to result in 20 API calls being made at once, which will cause the component to re-render 20 times. This doesn't seem to be noticeable to the user, but it's completely unnecessary.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

Try it out in your local Storybook instance. As shown in the screenshot below, go to the Resource -> list section, open the addons pane in order to authenticate with OAuth against Staging, and uncheck the "paused" box.

![image](https://user-images.githubusercontent.com/374078/68711693-c9915b80-055f-11ea-8da9-2c16a8d23e0e.png)

Open the network tab in your devtools and you'll observe a `graphql` call being made every 3 seconds. Now clear the network history, then switch tabs or windows for a minute or so. When you come back to the Storybook tab, you shouldn't observe any network calls having been made while you were away.

### Additional Testing

Since you're running this locally, try removing the `document.hidden` check from the polling loop in `manifold-resource-list`. Then try the above steps again. This time, when you come back to the Storybook tab, the network call list should be empty at first, but will then fill up with about 20 API calls all made at the same time. This is because the polling loop is still active, but when the tab is hidden, all of the calls are simply paused and waiting for restored visibility before they can resume.

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
