### PR TITLE
Update error endpoint

### DIFF
--- a/src/packages/analytics/index.ts
+++ b/src/packages/analytics/index.ts
@@ -1,9 +1,9 @@
 import { AnalyticsEvent } from './types';
 
 const endpoint = {
-  local: 'https://analytics.arigato.tools/v1/ui/events',
-  stage: 'https://analytics.stage.manifold.co/v1/ui/events',
-  prod: 'https://analytics.manifold.co/v1/ui/events',
+  local: 'https://analytics.arigato.tools/v1/events',
+  stage: 'https://analytics.stage.manifold.co/v1/events',
+  prod: 'https://analytics.manifold.co/v1/events',
 };
 
 interface AnalyticsOptions {


### PR DESCRIPTION
## Reason for change

Removes coupling of endpoint from source (but still includes `source` in request)

I **didn’t** update the CHANGELOG because this is part of “error reporting to Manifold;” the value before was just in-progress

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
