### PR TITLE
Add metrics opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added `metrics` property to `<manifold-connection>` to opt-in for metric collection (#724)
+
 ## [0.6.5] - 2019-11-13
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -3431,202 +3431,6 @@
         }
       }
     },
-    "@storybook/api": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.2.5.tgz",
-      "integrity": "sha512-JvLafqFVgA3dIWpLMoGNk4sRuogE5imhD6/g0d8DOwnCID9xowj5xIptSrCTKvGGGxuN3wWRGn6I2lEbY6969g==",
-      "dev": true,
-      "requires": {
-        "@storybook/channels": "5.2.5",
-        "@storybook/client-logger": "5.2.5",
-        "@storybook/core-events": "5.2.5",
-        "@storybook/router": "5.2.5",
-        "@storybook/theming": "5.2.5",
-        "core-js": "^3.0.1",
-        "fast-deep-equal": "^2.0.1",
-        "global": "^4.3.2",
-        "lodash": "^4.17.15",
-        "memoizerific": "^1.11.3",
-        "prop-types": "^15.6.2",
-        "react": "^16.8.3",
-        "semver": "^6.0.0",
-        "shallow-equal": "^1.1.0",
-        "store2": "^2.7.1",
-        "telejson": "^3.0.2",
-        "util-deprecate": "^1.0.2"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.3.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.5.tgz",
-          "integrity": "sha512-0J3K+Par/ZydhKg8pEiTcK/9d65/nqJOzY62uMkjeBmt05fDOt/khUVjDdh8TpeIuGQDy1yLDDCjiWN/8pFIuw==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
-      }
-    },
-    "@storybook/channel-postmessage": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-5.2.5.tgz",
-      "integrity": "sha512-GoiC6dUM3YfNKpvj3syxQIQJLHBnH61CfLJzz4xygmn+3keHtjtz6yPHaU4+00MSSP2uDzqePkjgXx4DcLedHA==",
-      "dev": true,
-      "requires": {
-        "@storybook/channels": "5.2.5",
-        "@storybook/client-logger": "5.2.5",
-        "core-js": "^3.0.1",
-        "global": "^4.3.2",
-        "telejson": "^3.0.2"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.3.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.5.tgz",
-          "integrity": "sha512-0J3K+Par/ZydhKg8pEiTcK/9d65/nqJOzY62uMkjeBmt05fDOt/khUVjDdh8TpeIuGQDy1yLDDCjiWN/8pFIuw==",
-          "dev": true
-        }
-      }
-    },
-    "@storybook/channels": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.2.5.tgz",
-      "integrity": "sha512-I+zB3ym5ozBcNBqyzZbvB6gRIG/ZKKkqy5k6LwKd5NMx7NU7zU74+LQUBBOcSIrigj8kCArZz7rlgb0tlSKXxQ==",
-      "dev": true,
-      "requires": {
-        "core-js": "^3.0.1"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.3.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.5.tgz",
-          "integrity": "sha512-0J3K+Par/ZydhKg8pEiTcK/9d65/nqJOzY62uMkjeBmt05fDOt/khUVjDdh8TpeIuGQDy1yLDDCjiWN/8pFIuw==",
-          "dev": true
-        }
-      }
-    },
-    "@storybook/client-api": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-5.2.5.tgz",
-      "integrity": "sha512-n7CAZ3+DZ7EUdmXbq8mXRb+stOavC8GMw3CzjGSo8O6t4rFcMpZQAzjS0YRX1RG/CGFSv9d3R3TNvEBcBGTwRg==",
-      "dev": true,
-      "requires": {
-        "@storybook/addons": "5.2.5",
-        "@storybook/channel-postmessage": "5.2.5",
-        "@storybook/channels": "5.2.5",
-        "@storybook/client-logger": "5.2.5",
-        "@storybook/core-events": "5.2.5",
-        "@storybook/router": "5.2.5",
-        "common-tags": "^1.8.0",
-        "core-js": "^3.0.1",
-        "eventemitter3": "^4.0.0",
-        "global": "^4.3.2",
-        "is-plain-object": "^3.0.0",
-        "lodash": "^4.17.15",
-        "memoizerific": "^1.11.3",
-        "qs": "^6.6.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "dependencies": {
-        "@storybook/addons": {
-          "version": "5.2.5",
-          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.2.5.tgz",
-          "integrity": "sha512-CvMj7Bs3go9tv5rZuAvFwuwe8p/16LDCHS7+5nVFosvcL8nuN339V3rzakw8nLy/S6XKeZ1ACu4t3vYkreRE3w==",
-          "dev": true,
-          "requires": {
-            "@storybook/api": "5.2.5",
-            "@storybook/channels": "5.2.5",
-            "@storybook/client-logger": "5.2.5",
-            "@storybook/core-events": "5.2.5",
-            "core-js": "^3.0.1",
-            "global": "^4.3.2",
-            "util-deprecate": "^1.0.2"
-          }
-        },
-        "core-js": {
-          "version": "3.3.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.5.tgz",
-          "integrity": "sha512-0J3K+Par/ZydhKg8pEiTcK/9d65/nqJOzY62uMkjeBmt05fDOt/khUVjDdh8TpeIuGQDy1yLDDCjiWN/8pFIuw==",
-          "dev": true
-        },
-        "is-plain-object": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-          "dev": true,
-          "requires": {
-            "isobject": "^4.0.0"
-          }
-        },
-        "isobject": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.9.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.0.tgz",
-          "integrity": "sha512-27RP4UotQORTpmNQDX8BHPukOnBP3p1uUJY5UnDhaJB+rMt9iMsok724XL+UHU23bEFOHRMQ2ZhI99qOWUMGFA==",
-          "dev": true
-        }
-      }
-    },
-    "@storybook/client-logger": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.2.5.tgz",
-      "integrity": "sha512-6DyYUrMgAvF+th0foH7UNz+2JJpRdvNbpvYKtvi/+hlvRIaI6AqANgLkPUgMibaif5TLzjCr0bLdAYcjeJz03w==",
-      "dev": true,
-      "requires": {
-        "core-js": "^3.0.1"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.3.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.5.tgz",
-          "integrity": "sha512-0J3K+Par/ZydhKg8pEiTcK/9d65/nqJOzY62uMkjeBmt05fDOt/khUVjDdh8TpeIuGQDy1yLDDCjiWN/8pFIuw==",
-          "dev": true
-        }
-      }
-    },
-    "@storybook/components": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-5.2.5.tgz",
-      "integrity": "sha512-6NVaBJm5wY53e9k+2ZiL2ABsHghE1ssQciLTG3jJPahnM6rfkM8ue66rhxhP88jE9isT48JgOZOJepEyxDz/fg==",
-      "dev": true,
-      "requires": {
-        "@storybook/client-logger": "5.2.5",
-        "@storybook/theming": "5.2.5",
-        "@types/react-syntax-highlighter": "10.1.0",
-        "@types/react-textarea-autosize": "^4.3.3",
-        "core-js": "^3.0.1",
-        "global": "^4.3.2",
-        "markdown-to-jsx": "^6.9.1",
-        "memoizerific": "^1.11.3",
-        "polished": "^3.3.1",
-        "popper.js": "^1.14.7",
-        "prop-types": "^15.7.2",
-        "react": "^16.8.3",
-        "react-dom": "^16.8.3",
-        "react-focus-lock": "^1.18.3",
-        "react-helmet-async": "^1.0.2",
-        "react-popper-tooltip": "^2.8.3",
-        "react-syntax-highlighter": "^8.0.1",
-        "react-textarea-autosize": "^7.1.0",
-        "simplebar-react": "^1.0.0-alpha.6"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.3.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.5.tgz",
-          "integrity": "sha512-0J3K+Par/ZydhKg8pEiTcK/9d65/nqJOzY62uMkjeBmt05fDOt/khUVjDdh8TpeIuGQDy1yLDDCjiWN/8pFIuw==",
-          "dev": true
-        }
-      }
-    },
     "@storybook/core": {
       "version": "5.2.6",
       "resolved": "https://registry.npmjs.org/@storybook/core/-/core-5.2.6.tgz",
@@ -3986,23 +3790,6 @@
         }
       }
     },
-    "@storybook/core-events": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.2.5.tgz",
-      "integrity": "sha512-O5GM8XEBbYNbM6Z7a4H1bbnbO2cxQrXMhEwansC7a7YinQdkTPiuGxke3NiyK+7pLDh778kpQyjoCjXq6UfAoQ==",
-      "dev": true,
-      "requires": {
-        "core-js": "^3.0.1"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.3.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.5.tgz",
-          "integrity": "sha512-0J3K+Par/ZydhKg8pEiTcK/9d65/nqJOzY62uMkjeBmt05fDOt/khUVjDdh8TpeIuGQDy1yLDDCjiWN/8pFIuw==",
-          "dev": true
-        }
-      }
-    },
     "@storybook/html": {
       "version": "5.2.6",
       "resolved": "https://registry.npmjs.org/@storybook/html/-/html-5.2.6.tgz",
@@ -4056,63 +3843,6 @@
           "version": "0.12.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
           "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
-          "dev": true
-        }
-      }
-    },
-    "@storybook/router": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.2.5.tgz",
-      "integrity": "sha512-e6ElDAWSoEW1KSnsTbVwbpzaZ8CNWYw0Ok3b5AHfY2fuSH5L4l6s6k/bP7QSYqvWUeTvkFQYux7A2rOFCriAgA==",
-      "dev": true,
-      "requires": {
-        "@reach/router": "^1.2.1",
-        "@types/reach__router": "^1.2.3",
-        "core-js": "^3.0.1",
-        "global": "^4.3.2",
-        "lodash": "^4.17.15",
-        "memoizerific": "^1.11.3",
-        "qs": "^6.6.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.3.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.5.tgz",
-          "integrity": "sha512-0J3K+Par/ZydhKg8pEiTcK/9d65/nqJOzY62uMkjeBmt05fDOt/khUVjDdh8TpeIuGQDy1yLDDCjiWN/8pFIuw==",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.9.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.0.tgz",
-          "integrity": "sha512-27RP4UotQORTpmNQDX8BHPukOnBP3p1uUJY5UnDhaJB+rMt9iMsok724XL+UHU23bEFOHRMQ2ZhI99qOWUMGFA==",
-          "dev": true
-        }
-      }
-    },
-    "@storybook/theming": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.2.5.tgz",
-      "integrity": "sha512-PGZNYrRgAhXFJKnktFpyyKlaDXEhtTi5XPq5ASVJrsPW6l963Mk2EMKSm4TCTxIJhs0Kx4cv2MnNZFDqHf47eg==",
-      "dev": true,
-      "requires": {
-        "@emotion/core": "^10.0.14",
-        "@emotion/styled": "^10.0.14",
-        "@storybook/client-logger": "5.2.5",
-        "common-tags": "^1.8.0",
-        "core-js": "^3.0.1",
-        "deep-object-diff": "^1.1.0",
-        "emotion-theming": "^10.0.14",
-        "global": "^4.3.2",
-        "memoizerific": "^1.11.3",
-        "polished": "^3.3.1",
-        "prop-types": "^15.7.2",
-        "resolve-from": "^5.0.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.3.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.5.tgz",
-          "integrity": "sha512-0J3K+Par/ZydhKg8pEiTcK/9d65/nqJOzY62uMkjeBmt05fDOt/khUVjDdh8TpeIuGQDy1yLDDCjiWN/8pFIuw==",
           "dev": true
         }
       }
@@ -22850,6 +22580,7 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.5.tgz",
       "integrity": "sha512-7L3W+Npia1OCr5Blp4/Vw83tK1mu5gnoIURtT1fUVfQ3Kf8WStWV6NJz0fdoBJZls0KlweruRTLVe6XLafmy5g==",
       "dev": true,
+      "optional": true,
       "requires": {
         "commander": "~2.20.3",
         "source-map": "~0.6.1"
@@ -22859,13 +22590,15 @@
           "version": "2.20.3",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
           "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manifoldco/ui",
   "description": "Manifold UI",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/manifoldco/ui.git"

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -81,6 +81,7 @@ export namespace Components {
   }
   interface ManifoldConnection {
     'env'?: 'local' | 'stage' | 'prod';
+    'metrics'?: boolean;
     'waitTime'?: number | string;
   }
   interface ManifoldCopyCredentials {
@@ -1091,6 +1092,7 @@ declare namespace LocalJSX {
   }
   interface ManifoldConnection {
     'env'?: 'local' | 'stage' | 'prod';
+    'metrics'?: boolean;
     'waitTime'?: number | string;
   }
   interface ManifoldCopyCredentials {

--- a/src/components/manifold-connection/manifold-connection.tsx
+++ b/src/components/manifold-connection/manifold-connection.tsx
@@ -8,11 +8,12 @@ import connection from '../../state/connection';
 @Component({ tag: 'manifold-connection' })
 export class ManifoldConnection {
   @Prop() env?: 'local' | 'stage' | 'prod';
+  @Prop() metrics?: boolean;
   @Prop() waitTime?: number | string;
 
   @loadMark()
   componentWillLoad() {
-    connection.initialize({ env: this.env, waitTime: this.waitTime });
+    connection.initialize({ env: this.env, metrics: this.metrics, waitTime: this.waitTime });
   }
 
   @logger()

--- a/src/utils/graphqlFetch.ts
+++ b/src/utils/graphqlFetch.ts
@@ -6,11 +6,12 @@ import awaitPageVisibility from './awaitPageVisibility';
 interface CreateGraphqlFetch {
   endpoint?: () => string;
   env?: () => 'local' | 'stage' | 'prod';
-  wait?: () => number;
-  retries?: number;
   getAuthToken?: () => string | undefined;
-  setAuthToken?: (token: string) => void;
+  metrics?: () => boolean;
   onReady?: () => Promise<unknown>;
+  retries?: number;
+  setAuthToken?: (token: string) => void;
+  wait?: () => number;
 }
 
 type GraphqlRequest =

--- a/src/utils/restFetch.ts
+++ b/src/utils/restFetch.ts
@@ -7,11 +7,12 @@ import { report } from './errorReport';
 export interface CreateRestFetch {
   endpoints?: () => Connection;
   env?: () => 'local' | 'stage' | 'prod';
-  wait?: () => number;
-  retries?: number;
   getAuthToken?: () => string | undefined;
-  setAuthToken?: (token: string) => void;
+  metrics?: () => boolean;
   onReady?: () => Promise<unknown>;
+  retries?: number;
+  setAuthToken?: (token: string) => void;
+  wait?: () => number;
 }
 
 interface RestFetchArguments {


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

Adds a `<manifold-connection metrics>` property to opt-in for analytics.

This PR **basically does nothing** right now, because we don’t have any analytics events. But it gives us a hook on the connection state to see if we should send analytics events or not.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
