### PR TITLE
Add rtt_graphql metrics event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Added `metrics` property to `<manifold-connection>` to opt-in for metric collection (#724)
+- Added performance monitoring of GraphQL endpoints (#726)
 
 ## [0.6.5] - 2019-11-13
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifoldco/ui",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/global/settings.ts
+++ b/src/global/settings.ts
@@ -1,0 +1,1 @@
+export const METRICS_ENABLED = false; // default setting for whether or not analytics.manifold.co receives metrics events

--- a/src/packages/analytics/index.spec.ts
+++ b/src/packages/analytics/index.spec.ts
@@ -35,7 +35,7 @@ describe('analytics', () => {
 
     it('prod', async () => {
       fetchMock.mock(prod, {});
-      await report(error);
+      await report(error, { env: 'prod' });
       expect(fetchMock.called(prod)).toBe(true);
     });
   });
@@ -45,7 +45,7 @@ describe('analytics', () => {
 
     describe('error', () => {
       it('error', async () => {
-        await report(error);
+        await report(error, { env: 'prod' });
         const res = fetchMock.calls()[0][1];
         expect(res && res.body && JSON.parse(res.body.toString())).toEqual(error);
       });

--- a/src/packages/analytics/index.spec.ts
+++ b/src/packages/analytics/index.spec.ts
@@ -1,11 +1,21 @@
 import fetchMock from 'fetch-mock';
 import report from './index';
-import { ErrorEvent } from './types';
+import { AnalyticsEvent } from './types';
 
 const local = 'begin:https://analytics.arigato.tools';
 const stage = 'begin:https://analytics.stage.manifold.co';
 const prod = 'begin:https://analytics.manifold.co';
-const error: ErrorEvent = {
+const event: AnalyticsEvent = {
+  type: 'event',
+  name: 'rtt_graphql',
+  properties: {
+    componentName: 'MANIFOLD_PRODUCT',
+    duration: 123,
+    uiVersion: '1.2.3',
+  },
+  source: 'ui',
+};
+const error: AnalyticsEvent = {
   type: 'error',
   name: 'ui_error',
   properties: {
@@ -42,12 +52,25 @@ describe('analytics', () => {
 
   describe('type', () => {
     beforeEach(() => fetchMock.mock(prod, {}));
+    afterEach(fetchMock.restore);
 
     describe('error', () => {
       it('error', async () => {
         await report(error, { env: 'prod' });
         const res = fetchMock.calls()[0][1];
         expect(res && res.body && JSON.parse(res.body.toString())).toEqual(error);
+      });
+
+      it('event', async () => {
+        await report(event, { env: 'prod' });
+        const res = fetchMock.calls()[0][1];
+        expect(res && res.body && JSON.parse(res.body.toString())).toEqual({
+          ...event,
+          properties: {
+            ...event.properties,
+            duration: '123', // numbers should submit as strings
+          },
+        });
       });
     });
   });

--- a/src/packages/analytics/index.spec.ts
+++ b/src/packages/analytics/index.spec.ts
@@ -5,8 +5,8 @@ import { AnalyticsEvent } from './types';
 const local = 'begin:https://analytics.arigato.tools';
 const stage = 'begin:https://analytics.stage.manifold.co';
 const prod = 'begin:https://analytics.manifold.co';
-const event: AnalyticsEvent = {
-  type: 'event',
+const metric: AnalyticsEvent = {
+  type: 'metric',
   name: 'rtt_graphql',
   properties: {
     componentName: 'MANIFOLD_PRODUCT',
@@ -61,13 +61,13 @@ describe('analytics', () => {
         expect(res && res.body && JSON.parse(res.body.toString())).toEqual(error);
       });
 
-      it('event', async () => {
-        await report(event, { env: 'prod' });
+      it('metric', async () => {
+        await report(metric, { env: 'prod' });
         const res = fetchMock.calls()[0][1];
         expect(res && res.body && JSON.parse(res.body.toString())).toEqual({
-          ...event,
+          ...metric,
           properties: {
-            ...event.properties,
+            ...metric.properties,
             duration: '123', // numbers should submit as strings
           },
         });

--- a/src/packages/analytics/index.ts
+++ b/src/packages/analytics/index.ts
@@ -7,7 +7,7 @@ const endpoint = {
 };
 
 interface AnalyticsOptions {
-  env?: 'local' | 'stage' | 'prod';
+  env: 'local' | 'stage' | 'prod';
 }
 
 /**
@@ -21,15 +21,8 @@ interface AnalyticsOptions {
  * @param {Object} [options] Analytics options
  * @param {string} [options.env] 'prod' (default) or 'stage'
  */
-export default function report(
-  evt: AnalyticsEvent,
-  userOptions: AnalyticsOptions = { env: 'prod' }
-) {
-  const options: AnalyticsOptions = {
-    env: 'prod',
-    ...(userOptions || {}),
-  };
-  const url = endpoint[options.env || 'prod'];
+export default function report(evt: AnalyticsEvent, options: AnalyticsOptions) {
+  const url = endpoint[options.env];
   return fetch(url, {
     method: 'POST',
     body: JSON.stringify({

--- a/src/packages/analytics/index.ts
+++ b/src/packages/analytics/index.ts
@@ -10,6 +10,16 @@ interface AnalyticsOptions {
   env: 'local' | 'stage' | 'prod';
 }
 
+function stringifyProperties(evt: AnalyticsEvent) {
+  return {
+    ...evt,
+    properties: Object.entries(evt.properties).reduce(
+      (properties, [key, value]) => ({ ...properties, [key]: `${value}` }),
+      {}
+    ),
+  };
+}
+
 /**
  * Report an error or analytics event to Manifold
  * @param {Object} eventData Event data to send to Manifold
@@ -26,7 +36,7 @@ export default function report(evt: AnalyticsEvent, options: AnalyticsOptions) {
   return fetch(url, {
     method: 'POST',
     body: JSON.stringify({
-      ...evt,
+      ...stringifyProperties(evt),
       source: 'ui', // add source
     }),
   });

--- a/src/packages/analytics/types.ts
+++ b/src/packages/analytics/types.ts
@@ -44,7 +44,7 @@ export type EventTypes =
     };
 
 export type EventEvent = {
-  type: 'event';
+  type: 'metric';
 } & SharedProperties &
   EventTypes;
 

--- a/src/packages/analytics/types.ts
+++ b/src/packages/analytics/types.ts
@@ -20,26 +20,26 @@ export type EventTypes =
         initialRender: number;
         renderWithData: number;
         rttGraphql: number;
-        time: number;
+        duration: number;
       };
     }
   | {
       name: 'render_with_data';
       properties: {
         rttGraphql: number;
-        time: number;
+        duration: number;
       };
     }
   | {
       name: 'rtt_graphql';
       properties: {
-        time: number;
+        duration: number;
       };
     }
   | {
       name: 'token_received';
       properties: {
-        time: number;
+        duration: number;
       };
     };
 

--- a/src/state/connection.ts
+++ b/src/state/connection.ts
@@ -1,6 +1,7 @@
 import { connections } from '../utils/connections';
 import { createGraphqlFetch } from '../utils/graphqlFetch';
 import { createRestFetch } from '../utils/restFetch';
+import { METRICS_ENABLED } from '../global/settings';
 
 const baseWait = 15000;
 
@@ -18,14 +19,18 @@ interface Initialization {
 export class ConnectionState {
   authToken?: string;
   env: 'local' | 'stage' | 'prod' = 'prod';
-  metrics: boolean = false; // IMPORTANT: metrics are OFF by default
+  metrics: boolean = METRICS_ENABLED;
   waitTime: number = baseWait;
 
   private subscribers: Subscriber[] = [];
 
   private initialized: boolean = false;
 
-  initialize = ({ env = 'prod', metrics = false, waitTime = baseWait }: Initialization) => {
+  initialize = ({
+    env = 'prod',
+    metrics = METRICS_ENABLED,
+    waitTime = baseWait,
+  }: Initialization) => {
     this.env = env;
     this.metrics = metrics;
     this.waitTime = typeof waitTime === 'number' ? waitTime : parseInt(waitTime, 10);

--- a/src/utils/graphqlFetch.ts
+++ b/src/utils/graphqlFetch.ts
@@ -135,7 +135,7 @@ export function createGraphqlFetch({
       analytics(
         {
           name: 'rtt_graphql',
-          type: 'event',
+          type: 'metric',
           properties: {
             componentName: detail.componentName,
             duration: detail.duration,

--- a/src/utils/graphqlFetch.ts
+++ b/src/utils/graphqlFetch.ts
@@ -1,5 +1,7 @@
 import { Query } from '../types/graphql';
 import { report } from './errorReport';
+import { METRICS_ENABLED } from '../global/settings';
+import analytics from '../packages/analytics';
 import { waitForAuthToken } from './auth';
 import awaitPageVisibility from './awaitPageVisibility';
 
@@ -54,11 +56,12 @@ export type GraphqlFetch = <T>(args: GraphqlArgs) => Promise<GraphqlResponseBody
 export function createGraphqlFetch({
   endpoint = () => 'https://api.manifold.co/graphql',
   env = () => 'prod',
-  wait = () => 15000,
-  retries = 0,
+  metrics = () => METRICS_ENABLED,
   getAuthToken = () => undefined,
-  setAuthToken = () => {},
   onReady = () => new Promise(resolve => resolve()),
+  retries = 0,
+  setAuthToken = () => {},
+  wait = () => 15000,
 }: CreateGraphqlFetch): GraphqlFetch {
   async function graphqlFetch<T = Query>(
     args: GraphqlArgs,
@@ -67,7 +70,6 @@ export function createGraphqlFetch({
     await onReady();
     await awaitPageVisibility();
 
-    const rttStart = performance.now();
     const { element, ...request } = args;
 
     const token = getAuthToken();
@@ -75,6 +77,7 @@ export function createGraphqlFetch({
     const auth: { [key: string]: string } =
       token && token !== 'undefined' ? { authorization: `Bearer ${token}` } : {};
 
+    const rttStart = performance.now(); // start RTT timer
     const response = await fetch(endpoint(), {
       method: 'POST',
       headers: {
@@ -90,6 +93,7 @@ export function createGraphqlFetch({
       report({ message: `${e.statusText || e.status}` }, { env: env(), element });
       return Promise.reject(e);
     });
+    const rttEnd = performance.now(); // end RTT timer
 
     const body: GraphqlResponseBody<T> = await response.json();
 
@@ -113,19 +117,34 @@ export function createGraphqlFetch({
       };
     }
 
-    const fetchDuration = performance.now() - rttStart;
     const detail: GraphqlFetchEventDetail = {
       componentName: element.tagName,
-      duration: fetchDuration,
+      duration: rttEnd - rttStart,
       errors: body.errors,
       request,
       type: 'manifold-graphql-fetch-duration',
       uiVersion: '<@NPM_PACKAGE_VERSION@>',
     };
 
+    // metric event: rtt_graphql
     (element || document).dispatchEvent(
       new CustomEvent('manifold-graphql-fetch-duration', { bubbles: true, detail })
     );
+    // emit metrics event only if permitted
+    if (metrics()) {
+      analytics(
+        {
+          name: 'rtt_graphql',
+          type: 'event',
+          properties: {
+            componentName: detail.componentName,
+            duration: detail.duration,
+            uiVersion: detail.uiVersion,
+          },
+        },
+        { env: env() }
+      );
+    }
 
     if (body.errors) {
       body.errors.forEach(e => {

--- a/stories/data/connectionDecorator.js
+++ b/stories/data/connectionDecorator.js
@@ -15,7 +15,7 @@ export const manifoldConnectionDecorator = storyFn => {
   localStorage.setItem('manifold_api_token', token); // update localStorage to persist
 
   return `
-  <manifold-connection env="${env}">
+  <manifold-connection env="${env}" metrics>
     <manifold-auth-token token="${token}" auth-type="${authType}"></manifold-auth-token>
     ${storyFn()}
   </manifold-connection>


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

Adds a `rtt_graphql` event to test the performance of GraphQL as perceived by the end-user

<img width="1224" alt="Screen Shot 2019-11-13 at 13 35 56" src="https://user-images.githubusercontent.com/1369770/68802134-8fd15b00-061a-11ea-8778-d5a95f80dddf.png">

## Testing

In Storybook, see that `analytics.manifold.co` is called after every GraphQL request

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
