### PR TITLE
Don't rely on in-memory tokens for authentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@manifoldco/ui",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/manifold-auth-token/manifold-auth-token.tsx
+++ b/src/components/manifold-auth-token/manifold-auth-token.tsx
@@ -19,7 +19,7 @@ export class ManifoldAuthToken {
   @Prop() token?: string;
   @Prop() authType?: AuthType = 'oauth';
   @State() tick?: string;
-  @State() internalToken?: string = connection.authToken;
+  @State() internalToken?: string;
   @Event({ eventName: 'manifold-token-receive', bubbles: true })
   manifoldOauthTokenChange: EventEmitter<{ token: string }>;
   @Event({ eventName: 'manifold-token-clear', bubbles: true }) clear: EventEmitter;
@@ -52,6 +52,7 @@ export class ManifoldAuthToken {
   setExternalToken(token?: string) {
     if (token && this.setAuthToken) {
       this.setAuthToken(token);
+      this.internalToken = token;
       this.manifoldOauthTokenChange.emit({ token });
     }
   }


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

This prevents users with multiple accounts from using the wrong API token when they log in.

When trying to troubleshoot [an incident](https://github.com/manifoldco/engineering/issues/9873), we discovered that logging out and then logging back in with a different account was resulting in API requests being issued using the wrong token. This is happening because the `manifold-auth-token` component uses a default value for its `internalToken` that comes from `state/connection.ts`. This object will keep a token in memory after a user logs out, so if a user logs back in with a different account, this token value persists and will be used as the default value when `manifold-auth-token` loads up again.

This pull request changes things so that `manifold-auth-token` no longer defaults to the value saved in `state/connection.ts`. Instead, we will always use the token cached by the platform for our internal token value.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

The best way is to run Render locally against staging using a build of UI from this branch. When you have that running, you should verify two things:

1. Once initially authenticated with the Manifold API, when you switch between `/addons` and `/new/addon`, you should not see the oauth dance happening again in the network tab.
2. If you place a breakpoint in the `componentWillLoad` method of the `manifold-auth-token` component, you should observe that `this.internalToken` is not defined. If you also place a breakpoint in the `render` method, you'll notice that by the time you get to the first render, `this.internalToken` is defined, and the rendering of the iframe is therefore skipped.

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
