### PR TITLE
Adds features data (free boolean) to manifold-plan-selector custom event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Free features data to plan selector custom event. (#743)
+
+### Added
+
 - Added `metrics` property to `<manifold-connection>` to opt-in for metric collection (#724)
 - Added performance monitoring of GraphQL endpoints (#726)
 - Added performance monitoring of oauth token handshake (#730)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.0] - 2019-11-19
+## [Unreleased]
 
 ### Added
 
 - Free features data to plan selector custom event. (#743)
+
+## [0.7.0] - 2019-11-19
 
 ### Added
 

--- a/docs/docs/components/manifold-plan-selector.md
+++ b/docs/docs/components/manifold-plan-selector.md
@@ -46,9 +46,7 @@ document.addEventListener('manifold-planSelector-change', ({ detail }) => {
 //   planLabel: 'nvidia-1080ti-100gb-ssd',
 //   planName: 'NVIDIA 1080TI',
 //   productLabel: 'zerosix',
-//   features: {
-//     free: false
-//   },
+//   freePlan: false
 // }
 ```
 
@@ -56,8 +54,8 @@ The following events are emitted:
 
 | Event Name                     | Description                                                                                                                | Data                                                                                                 |
 | :----------------------------- | :------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------- |
-| `manifold-planSelector-change` | Fires whenever a user makes a change.                                                                                      | `planID`, `planLabel`, `planName`, `productId`, `productLabel`, `regionId`, `regionName`, `features` |
-| `manifold-planSelector-load`   | Identical to `-update` above, but this fires once on DOM mount to set the initial state (i.e. user hasn’t interacted yet). | `planID`, `planLabel`, `planName`, `productId`, `productLabel`, `regionId`, `regionName`, `features` |
+| `manifold-planSelector-change` | Fires whenever a user makes a change.                                                                                      | `planID`, `planLabel`, `planName`, `productId`, `productLabel`, `regionId`, `regionName`, `freePlan` |
+| `manifold-planSelector-load`   | Identical to `-update` above, but this fires once on DOM mount to set the initial state (i.e. user hasn’t interacted yet). | `planID`, `planLabel`, `planName`, `productId`, `productLabel`, `regionId`, `regionName`, `freePlan` |
 
 ## Free plans only
 

--- a/docs/docs/components/manifold-plan-selector.md
+++ b/docs/docs/components/manifold-plan-selector.md
@@ -47,17 +47,17 @@ document.addEventListener('manifold-planSelector-change', ({ detail }) => {
 //   planName: 'NVIDIA 1080TI',
 //   productLabel: 'zerosix',
 //   features: {
-//     // …
+//     free: false
 //   },
 // }
 ```
 
 The following events are emitted:
 
-| Event Name                     | Description                                                                                                                | Data                                                                                     |
-| :----------------------------- | :------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------- |
-| `manifold-planSelector-change` | Fires whenever a user makes a change.                                                                                      | `planID`, `planLabel`, `planName`, `productId`, `productLabel`, `regionId`, `regionName` |
-| `manifold-planSelector-load`   | Identical to `-update` above, but this fires once on DOM mount to set the initial state (i.e. user hasn’t interacted yet). | `planID`, `planLabel`, `planName`, `productId`, `productLabel`, `regionId`, `regionName` |
+| Event Name                     | Description                                                                                                                | Data                                                                                                 |
+| :----------------------------- | :------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------- |
+| `manifold-planSelector-change` | Fires whenever a user makes a change.                                                                                      | `planID`, `planLabel`, `planName`, `productId`, `productLabel`, `regionId`, `regionName`, `features` |
+| `manifold-planSelector-load`   | Identical to `-update` above, but this fires once on DOM mount to set the initial state (i.e. user hasn’t interacted yet). | `planID`, `planLabel`, `planName`, `productId`, `productLabel`, `regionId`, `regionName`, `features` |
 
 ## Free plans only
 

--- a/src/components/manifold-plan-details/manifold-plan-details.spec.ts
+++ b/src/components/manifold-plan-details/manifold-plan-details.spec.ts
@@ -49,6 +49,7 @@ describe('<manifold-plan-details>', () => {
             productLabel: product.label,
             regionId: region && region.id,
             regionName: region && region.displayName,
+            freePlan: paidPlan.free,
           },
         })
       );
@@ -77,6 +78,7 @@ describe('<manifold-plan-details>', () => {
             productLabel: product.label,
             regionId: region && region.id,
             regionName: region && region.displayName,
+            freePlan: freePlan.free,
           },
         })
       );

--- a/src/components/manifold-plan-details/manifold-plan-details.tsx
+++ b/src/components/manifold-plan-details/manifold-plan-details.tsx
@@ -18,6 +18,9 @@ interface EventDetail {
   productLabel: string | undefined;
   regionId?: string;
   regionName?: string;
+  feature?: {
+    free: boolean;
+  };
 }
 
 @Component({
@@ -48,6 +51,9 @@ export class ManifoldPlanDetails {
       productLabel: this.product && this.product.label,
       regionId: defaultRegion && defaultRegion.id,
       regionName: defaultRegion && defaultRegion.displayName,
+      feature: {
+        free: newPlan.free,
+      },
     };
 
     if (!oldPlan) {
@@ -83,6 +89,9 @@ export class ManifoldPlanDetails {
         productLabel: this.product && this.product.label,
         regionId: defaultRegion && defaultRegion.id,
         regionName: defaultRegion && defaultRegion.displayName,
+        feature: {
+          free: this.plan.free,
+        },
       };
       this.planLoad.emit(detail);
       // reset features
@@ -103,6 +112,9 @@ export class ManifoldPlanDetails {
         productLabel: this.product.label,
         regionId: defaultRegion && defaultRegion.id,
         regionName: defaultRegion && defaultRegion.displayName,
+        feature: {
+          free: this.plan.free,
+        },
       };
       this.planUpdate.emit(detail);
     }
@@ -123,6 +135,9 @@ export class ManifoldPlanDetails {
         productLabel: this.product.label,
         regionId: e.detail.value,
         regionName: defaultRegion && defaultRegion.displayName,
+        feature: {
+          free: this.plan.free,
+        },
       };
       this.planUpdate.emit(detail);
     }

--- a/src/components/manifold-plan-details/manifold-plan-details.tsx
+++ b/src/components/manifold-plan-details/manifold-plan-details.tsx
@@ -18,9 +18,7 @@ interface EventDetail {
   productLabel: string | undefined;
   regionId?: string;
   regionName?: string;
-  feature?: {
-    free: boolean;
-  };
+  freePlan: boolean;
 }
 
 @Component({
@@ -51,9 +49,7 @@ export class ManifoldPlanDetails {
       productLabel: this.product && this.product.label,
       regionId: defaultRegion && defaultRegion.id,
       regionName: defaultRegion && defaultRegion.displayName,
-      feature: {
-        free: newPlan.free,
-      },
+      freePlan: newPlan.free,
     };
 
     if (!oldPlan) {
@@ -89,9 +85,7 @@ export class ManifoldPlanDetails {
         productLabel: this.product && this.product.label,
         regionId: defaultRegion && defaultRegion.id,
         regionName: defaultRegion && defaultRegion.displayName,
-        feature: {
-          free: this.plan.free,
-        },
+        freePlan: this.plan.free,
       };
       this.planLoad.emit(detail);
       // reset features
@@ -112,9 +106,7 @@ export class ManifoldPlanDetails {
         productLabel: this.product.label,
         regionId: defaultRegion && defaultRegion.id,
         regionName: defaultRegion && defaultRegion.displayName,
-        feature: {
-          free: this.plan.free,
-        },
+        freePlan: this.plan.free,
       };
       this.planUpdate.emit(detail);
     }
@@ -135,9 +127,7 @@ export class ManifoldPlanDetails {
         productLabel: this.product.label,
         regionId: e.detail.value,
         regionName: defaultRegion && defaultRegion.displayName,
-        feature: {
-          free: this.plan.free,
-        },
+        freePlan: this.plan.free,
       };
       this.planUpdate.emit(detail);
     }


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

Adds free flag to custom plan selector events, which helps integration engineers to better add custom validations around Manifold UI.

## Testing

From storybook->plan selector ensure `manifold-planSelector-change` and `manifold-planSelector-load` custom events include features data.

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [x] **Prop changes**: [docs][docs] were updated
- [x] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [x] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
