### PR TITLE
Use mutation observer to track load event start time

### DIFF
--- a/jest-setup.js
+++ b/jest-setup.js
@@ -1,0 +1,6 @@
+/* eslint-disable */
+global.MutationObserver = class {
+  constructor() {}
+  disconnect() {}
+  observe() {}
+};

--- a/src/components/manifold-connection/manifold-connection.tsx
+++ b/src/components/manifold-connection/manifold-connection.tsx
@@ -1,4 +1,4 @@
-import { h, Component, Prop } from '@stencil/core';
+import { h, Component, Prop, Element } from '@stencil/core';
 import '../../utils/fetchAllPages';
 
 import logger from '../../utils/logger';
@@ -7,13 +7,19 @@ import connection from '../../state/connection';
 
 @Component({ tag: 'manifold-connection' })
 export class ManifoldConnection {
+  @Element() el: HTMLElement;
   @Prop() env?: 'local' | 'stage' | 'prod';
   @Prop() metrics?: boolean;
   @Prop() waitTime?: number | string;
 
   @loadMark()
   componentWillLoad() {
-    connection.initialize({ env: this.env, metrics: this.metrics, waitTime: this.waitTime });
+    connection.initialize({
+      env: this.env,
+      metrics: this.metrics,
+      waitTime: this.waitTime,
+      connectionEl: this.el,
+    });
   }
 
   @logger()

--- a/src/components/manifold-connection/manifold-connection.tsx
+++ b/src/components/manifold-connection/manifold-connection.tsx
@@ -1,4 +1,4 @@
-import { h, Component, Prop, Element } from '@stencil/core';
+import { h, Component, Prop } from '@stencil/core';
 import '../../utils/fetchAllPages';
 
 import logger from '../../utils/logger';
@@ -7,7 +7,6 @@ import connection from '../../state/connection';
 
 @Component({ tag: 'manifold-connection' })
 export class ManifoldConnection {
-  @Element() el: HTMLElement;
   @Prop() env?: 'local' | 'stage' | 'prod';
   @Prop() metrics?: boolean;
   @Prop() waitTime?: number | string;
@@ -18,7 +17,6 @@ export class ManifoldConnection {
       env: this.env,
       metrics: this.metrics,
       waitTime: this.waitTime,
-      connectionEl: this.el,
     });
   }
 

--- a/src/components/manifold-oauth/manifold-oauth.tsx
+++ b/src/components/manifold-oauth/manifold-oauth.tsx
@@ -31,7 +31,7 @@ export class ManifoldOauth {
         expiry: pumaToken.expiry,
         error: pumaToken.error,
       });
-      if ((connection.metrics || METRICS_ENABLED) && this.loadTime){
+      if ((connection.metrics || METRICS_ENABLED) && this.loadTime) {
         report(
           {
             name: 'token_received',

--- a/src/global/app.ts
+++ b/src/global/app.ts
@@ -1,0 +1,39 @@
+const connectionEl = document.getElementsByTagName('manifold-connection').length
+  ? document.getElementsByTagName('manifold-connection')[0]
+  : undefined;
+if (connectionEl) {
+  performance.mark(`${connectionEl.tagName}-load-start`);
+  Array.prototype.slice
+    .call(connectionEl.getElementsByTagName('*'))
+    .filter((el: HTMLElement) => el.tagName.startsWith('MANIFOLD-'))
+    .forEach((el: HTMLElement) => {
+      const markName = `${el.tagName}-load-start`;
+      if (performance.getEntriesByName(markName, 'mark').length === 0) {
+        performance.mark(markName);
+      }
+    });
+}
+
+let observer: MutationObserver;
+function mutationCallback(mutationsList: MutationRecord[]) {
+  mutationsList
+    .filter(mutation => mutation.type === 'childList')
+    .forEach(mutation => {
+      if (mutation.addedNodes) {
+        mutation.addedNodes.forEach((node: HTMLElement) => {
+          if (node.tagName && node.tagName.startsWith('MANIFOLD-')) {
+            const markName = `${node.tagName}-load-start`;
+            if (performance.getEntriesByName(markName, 'mark').length === 0) {
+              performance.mark(markName);
+            }
+            if (node.shadowRoot) {
+              observer.observe(node.shadowRoot, { childList: true, subtree: true });
+            }
+          }
+        });
+      }
+    });
+}
+
+observer = new MutationObserver(mutationCallback);
+observer.observe(document, { childList: true, subtree: true });

--- a/src/global/app.ts
+++ b/src/global/app.ts
@@ -1,16 +1,15 @@
+import { mark } from '../packages/analytics';
+
 const connectionEl = document.getElementsByTagName('manifold-connection').length
   ? document.getElementsByTagName('manifold-connection')[0]
   : undefined;
 if (connectionEl) {
-  performance.mark(`${connectionEl.tagName}-load-start`);
+  mark(connectionEl, 'load');
   Array.prototype.slice
     .call(connectionEl.getElementsByTagName('*'))
     .filter((el: HTMLElement) => el.tagName.startsWith('MANIFOLD-'))
     .forEach((el: HTMLElement) => {
-      const markName = `${el.tagName}-load-start`;
-      if (performance.getEntriesByName(markName, 'mark').length === 0) {
-        performance.mark(markName);
-      }
+      mark(el, 'load');
     });
 }
 
@@ -22,10 +21,7 @@ function mutationCallback(mutationsList: MutationRecord[]) {
       if (mutation.addedNodes) {
         mutation.addedNodes.forEach((node: HTMLElement) => {
           if (node.tagName && node.tagName.startsWith('MANIFOLD-')) {
-            const markName = `${node.tagName}-load-start`;
-            if (performance.getEntriesByName(markName, 'mark').length === 0) {
-              performance.mark(markName);
-            }
+            mark(node, 'load');
             if (node.shadowRoot) {
               observer.observe(node.shadowRoot, { childList: true, subtree: true });
             }

--- a/src/packages/analytics/index.ts
+++ b/src/packages/analytics/index.ts
@@ -41,3 +41,32 @@ export default function report(evt: AnalyticsEvent, options: AnalyticsOptions) {
     }),
   });
 }
+
+export function mark(el: HTMLElement, name: AnalyticsEvent['name']) {
+  const markName = `${el.tagName}-${name}-start`;
+  if (performance.getEntriesByName(markName, 'mark').length === 0) {
+    performance.mark(markName);
+  }
+}
+
+export function measure(el: HTMLElement, name: AnalyticsEvent['name']) {
+  const startMarkName = `${el.tagName}-${name}-start`;
+  const endMarkName = `${el.tagName}-${name}-end`;
+  const startMarks = performance.getEntriesByName(startMarkName, 'mark');
+  const endMarks = performance.getEntriesByName(endMarkName, 'mark');
+  if (startMarks.length) {
+    if (!endMarks.length) {
+      performance.mark(endMarkName);
+      const endMark = performance.getEntriesByName(endMarkName, 'mark')[0];
+      return {
+        duration: endMark.startTime - startMarks[0].startTime,
+        firstReport: true,
+      };
+    }
+    return {
+      duration: endMarks[0].startTime - startMarks[0].startTime,
+      firstReport: false,
+    };
+  }
+  return null;
+}

--- a/src/packages/analytics/types.ts
+++ b/src/packages/analytics/types.ts
@@ -17,16 +17,12 @@ export type EventTypes =
   | {
       name: 'load';
       properties: {
-        initialRender: number;
-        renderWithData: number;
-        rttGraphql: number;
         duration: number;
       };
     }
   | {
-      name: 'render_with_data';
+      name: 'first_render';
       properties: {
-        rttGraphql: number;
         duration: number;
       };
     }
@@ -40,6 +36,14 @@ export type EventTypes =
       name: 'token_received';
       properties: {
         duration: number;
+      };
+    }
+  | {
+      name: 'first_render_with_data';
+      properties: {
+        duration: number;
+        rttGraphql: number;
+        load: number;
       };
     };
 

--- a/src/state/connection.ts
+++ b/src/state/connection.ts
@@ -11,7 +11,7 @@ const INITIALIZED = 'manifold-connection-initialize';
 
 interface NodeMapEntry {
   el: HTMLElement;
-  loadTime: number;
+  loadMark: number;
 }
 
 export interface NodeMap {
@@ -52,7 +52,7 @@ export class ConnectionState {
     this.nodeMap = {};
     this.initialized = true;
     if (connectionEl) {
-      this.observer.observe(connectionEl, { childList: true });
+      this.observer.observe(connectionEl, { childList: true, subtree: true });
     }
     const event = new CustomEvent(INITIALIZED);
     document.dispatchEvent(event);
@@ -121,15 +121,14 @@ export class ConnectionState {
             if (tagName && tagName.startsWith('manifold-')) {
               const entry = {
                 el: node,
-                loadTime: performance.now(),
+                loadMark: performance.now(),
               };
               if (!this.nodeMap[tagName]) {
                 this.nodeMap[tagName] = [];
               }
               this.nodeMap[tagName].push(entry);
-              this.observer.observe(node, { childList: true });
               if (node.shadowRoot) {
-                this.observer.observe(node.shadowRoot, { childList: true });
+                this.observer.observe(node.shadowRoot, { childList: true, subtree: true });
               }
             }
           });

--- a/src/state/connection.ts
+++ b/src/state/connection.ts
@@ -31,9 +31,6 @@ export class ConnectionState {
   env: 'local' | 'stage' | 'prod' = 'prod';
   metrics: boolean = METRICS_ENABLED;
   waitTime: number = baseWait;
-  observer: MutationObserver = new MutationObserver(mutationList =>
-    this.mutationCallback(mutationList)
-  );
   nodeMap: NodeMap = {};
 
   private subscribers: Subscriber[] = [];
@@ -44,16 +41,12 @@ export class ConnectionState {
     env = 'prod',
     metrics = METRICS_ENABLED,
     waitTime = baseWait,
-    connectionEl = undefined,
   }: Initialization) => {
     this.env = env;
     this.metrics = metrics;
     this.waitTime = typeof waitTime === 'number' ? waitTime : parseInt(waitTime, 10);
     this.nodeMap = {};
     this.initialized = true;
-    if (connectionEl) {
-      this.observer.observe(connectionEl, { childList: true, subtree: true });
-    }
     const event = new CustomEvent(INITIALIZED);
     document.dispatchEvent(event);
   };
@@ -110,31 +103,6 @@ export class ConnectionState {
     setAuthToken: this.setAuthToken,
     wait: () => this.waitTime,
   });
-
-  mutationCallback(mutationsList: MutationRecord[]) {
-    mutationsList
-      .filter(mutation => mutation.type === 'childList')
-      .forEach(mutation => {
-        if (mutation.addedNodes) {
-          mutation.addedNodes.forEach((node: HTMLElement) => {
-            const tagName = node.tagName && node.tagName.toLowerCase();
-            if (tagName && tagName.startsWith('manifold-')) {
-              const entry = {
-                el: node,
-                loadMark: performance.now(),
-              };
-              if (!this.nodeMap[tagName]) {
-                this.nodeMap[tagName] = [];
-              }
-              this.nodeMap[tagName].push(entry);
-              if (node.shadowRoot) {
-                this.observer.observe(node.shadowRoot, { childList: true, subtree: true });
-              }
-            }
-          });
-        }
-      });
-  }
 }
 
 export default new ConnectionState();

--- a/src/utils/graphqlFetch.ts
+++ b/src/utils/graphqlFetch.ts
@@ -1,7 +1,7 @@
 import { Query } from '../types/graphql';
 import { report } from './errorReport';
 import { METRICS_ENABLED } from '../global/settings';
-import analytics from '../packages/analytics';
+import analytics, { mark, measure } from '../packages/analytics';
 import { waitForAuthToken } from './auth';
 import awaitPageVisibility from './awaitPageVisibility';
 
@@ -78,6 +78,7 @@ export function createGraphqlFetch({
       token && token !== 'undefined' ? { authorization: `Bearer ${token}` } : {};
 
     const rttStart = performance.now(); // start RTT timer
+    mark(element, 'rtt_graphql'); // Not using this for reporting, only to help track first_render_with_data
     const response = await fetch(endpoint(), {
       method: 'POST',
       headers: {
@@ -94,6 +95,7 @@ export function createGraphqlFetch({
       return Promise.reject(e);
     });
     const rttEnd = performance.now(); // end RTT timer
+    measure(element, 'rtt_graphql'); // Not using this for reporting, only to help track first_render_with_data
 
     const body: GraphqlResponseBody<T> = await response.json();
 

--- a/src/utils/loadMark.ts
+++ b/src/utils/loadMark.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-param-reassign */
+import { mark } from '../packages/analytics';
 
 export default function loadMark<T>() {
   return function loadMarkDecorator(
@@ -9,7 +10,10 @@ export default function loadMark<T>() {
     const originalMethod = descriptor.value;
 
     descriptor.value = function componentWillLoad() {
-      this.performanceLoadMark = performance.now();
+      if (this.el) {
+        mark(this.el, 'first_render');
+        mark(this.el, 'first_render_with_data');
+      }
       return originalMethod.apply(this); // call original method
     };
 

--- a/src/utils/logger.e2e.tsx
+++ b/src/utils/logger.e2e.tsx
@@ -1,5 +1,5 @@
 import { h } from '@stencil/core';
-import logger, { hasSkeletonElements } from './logger';
+import logger from './logger';
 
 /* eslint max-classes-per-file: ["error", 3] */
 
@@ -41,40 +41,5 @@ describe('@logger', () => {
       message: 'oops', // event should contain original error message
       uiVersion: '<@NPM_PACKAGE_VERSION@>',
     });
-  });
-});
-
-describe('hasSkeletonElements', () => {
-  it('returns true if rendered result has any <skeleton-*> descendents', () => {
-    class ComponentWithSkeletons {
-      @logger()
-      public render() {
-        return (
-          <div>
-            <section>
-              <manifold-skeleton-text>☠️</manifold-skeleton-text>
-            </section>
-          </div>
-        );
-      }
-    }
-    const render = new ComponentWithSkeletons().render();
-    expect(hasSkeletonElements(render)).toEqual(true);
-  });
-  it('returns false if rendered result contains no <skeleton-*> descendents', () => {
-    class ComponentWithoutSkeletons {
-      @logger()
-      public render() {
-        return (
-          <div>
-            <section>
-              <p>💁‍</p>
-            </section>
-          </div>
-        );
-      }
-    }
-    const render = new ComponentWithoutSkeletons().render();
-    expect(hasSkeletonElements(render)).toEqual(false);
   });
 });

--- a/src/utils/logger.e2e.tsx
+++ b/src/utils/logger.e2e.tsx
@@ -1,4 +1,3 @@
-import { h } from '@stencil/core';
 import logger from './logger';
 
 /* eslint max-classes-per-file: ["error", 3] */

--- a/src/utils/logger.tsx
+++ b/src/utils/logger.tsx
@@ -42,9 +42,10 @@ export default function logger<T>() {
       try {
         const rendered = originalMethod.apply(this); // attempt to call render()
         if (
+          this.el &&
+          this.el.tagName.toLowerCase().startsWith('manifold-') &&
           this.performanceLoadMark &&
           !this.performanceRenderedMark &&
-          target.constructor.name.startsWith('Manifold') &&
           !hasSkeletonElements(rendered)
         ) {
           this.performanceRenderedMark = performance.now();
@@ -63,7 +64,7 @@ export default function logger<T>() {
               /* eslint-disable no-console */
               console.log(
                 el.tagName.toLowerCase(),
-                performance.now() - nodeMapEntry.loadTime,
+                this.performanceRenderedMark - nodeMapEntry.loadMark,
                 evt.detail.duration
               );
               /* eslint-enable no-console */

--- a/src/utils/logger.tsx
+++ b/src/utils/logger.tsx
@@ -43,7 +43,7 @@ export default function logger<T>() {
         const rendered = originalMethod.apply(this); // attempt to call render()
         if (
           this.el &&
-          this.el.tagName.toLowerCase().startsWith('manifold-') &&
+          this.el.tagName.startsWith('MANIFOLD-') &&
           this.performanceLoadMark &&
           !this.performanceRenderedMark &&
           !hasSkeletonElements(rendered)
@@ -58,13 +58,16 @@ export default function logger<T>() {
           });
           if (this.el) {
             const el = this.el as HTMLElement;
-            const nodeMapList = connection.nodeMap[el.tagName.toLowerCase()];
-            const nodeMapEntry = nodeMapList && nodeMapList.find(entry => entry.el === el);
-            if (nodeMapEntry) {
+            const startMarkName = `${el.tagName}-load-start`;
+            const endMarkName = `${el.tagName}-load-end`;
+            const startMarks = performance.getEntriesByName(startMarkName, 'mark');
+            const endMarks = performance.getEntriesByName(endMarkName, 'mark');
+            if (startMarks.length && !endMarks.length) {
+              performance.mark(endMarkName);
               /* eslint-disable no-console */
               console.log(
-                el.tagName.toLowerCase(),
-                this.performanceRenderedMark - nodeMapEntry.loadMark,
+                el.tagName,
+                this.performanceRenderedMark - startMarks[0].startTime,
                 evt.detail.duration
               );
               /* eslint-enable no-console */

--- a/src/utils/logger.tsx
+++ b/src/utils/logger.tsx
@@ -1,31 +1,12 @@
 import { h } from '@stencil/core';
 import { report } from './errorReport';
 import connection from '../state/connection';
+import analytics, { measure } from '../packages/analytics';
 
 interface StencilComponent {
   constructor: {
     name: string;
   };
-}
-
-interface RenderResult {
-  $children$: [RenderResult];
-  $tag$: string;
-}
-
-export function hasSkeletonElements(rendered: RenderResult): boolean {
-  if (
-    rendered &&
-    rendered.$tag$ &&
-    rendered.$tag$.startsWith &&
-    rendered.$tag$.startsWith('manifold-skeleton-')
-  ) {
-    return true;
-  }
-  if (rendered && rendered.$children$) {
-    return rendered.$children$.map(c => hasSkeletonElements(c)).includes(true);
-  }
-  return false;
 }
 
 /* eslint-disable no-param-reassign */
@@ -41,41 +22,69 @@ export default function logger<T>() {
     descriptor.value = function render() {
       try {
         const rendered = originalMethod.apply(this); // attempt to call render()
-        if (
-          this.el &&
-          this.el.tagName.startsWith('MANIFOLD-') &&
-          this.performanceLoadMark &&
-          !this.performanceRenderedMark &&
-          !hasSkeletonElements(rendered)
-        ) {
-          this.performanceRenderedMark = performance.now();
-          const evt = new CustomEvent('manifold-time-to-render', {
-            bubbles: true,
-            detail: {
-              component: target.constructor.name,
-              duration: this.performanceRenderedMark - this.performanceLoadMark,
-            },
-          });
-          if (this.el) {
-            const el = this.el as HTMLElement;
-            const startMarkName = `${el.tagName}-load-start`;
-            const endMarkName = `${el.tagName}-load-end`;
-            const startMarks = performance.getEntriesByName(startMarkName, 'mark');
-            const endMarks = performance.getEntriesByName(endMarkName, 'mark');
-            if (startMarks.length && !endMarks.length) {
-              performance.mark(endMarkName);
-              /* eslint-disable no-console */
-              console.log(
-                el.tagName,
-                this.performanceRenderedMark - startMarks[0].startTime,
-                evt.detail.duration
+        if (this.el && this.el.tagName.startsWith('MANIFOLD-')) {
+          const el = this.el as HTMLElement;
+
+          const loadMeasure = measure(el, 'load');
+          const firstRenderMeasure = measure(el, 'first_render');
+          if (performance.getEntriesByName(`${el.tagName}-rtt_graphql-end`).length) {
+            // This element has loaded data via graphql, we can report first_render_with_data
+            const rttGraphqlMeasure = measure(el, 'rtt_graphql');
+            const firstRenderWithDataMeasure = measure(el, 'first_render_with_data');
+            if (
+              firstRenderWithDataMeasure &&
+              firstRenderWithDataMeasure.firstReport &&
+              rttGraphqlMeasure &&
+              loadMeasure
+            ) {
+              analytics(
+                {
+                  name: 'first_render_with_data',
+                  type: 'metric',
+                  properties: {
+                    componentName: el.tagName,
+                    uiVersion: '<@NPM_PACKAGE_VERSION@>',
+                    duration: firstRenderWithDataMeasure.duration,
+                    rttGraphql: rttGraphqlMeasure.duration,
+                    load: loadMeasure.duration,
+                  },
+                },
+                { env: connection.env }
               );
-              /* eslint-enable no-console */
             }
           }
 
-          document.dispatchEvent(evt);
+          if (loadMeasure && loadMeasure.firstReport) {
+            analytics(
+              {
+                name: 'load',
+                type: 'metric',
+                properties: {
+                  componentName: el.tagName,
+                  uiVersion: '<@NPM_PACKAGE_VERSION@>',
+                  duration: loadMeasure.duration,
+                },
+              },
+              { env: connection.env }
+            );
+          }
+
+          if (firstRenderMeasure && firstRenderMeasure.firstReport) {
+            analytics(
+              {
+                name: 'first_render',
+                type: 'metric',
+                properties: {
+                  componentName: el.tagName,
+                  uiVersion: '<@NPM_PACKAGE_VERSION@>',
+                  duration: firstRenderMeasure.duration,
+                },
+              },
+              { env: connection.env }
+            );
+          }
         }
+
         return rendered;
       } catch (e) {
         report(

--- a/src/utils/logger.tsx
+++ b/src/utils/logger.tsx
@@ -55,6 +55,21 @@ export default function logger<T>() {
               duration: this.performanceRenderedMark - this.performanceLoadMark,
             },
           });
+          if (this.el) {
+            const el = this.el as HTMLElement;
+            const nodeMapList = connection.nodeMap[el.tagName.toLowerCase()];
+            const nodeMapEntry = nodeMapList && nodeMapList.find(entry => entry.el === el);
+            if (nodeMapEntry) {
+              /* eslint-disable no-console */
+              console.log(
+                el.tagName.toLowerCase(),
+                performance.now() - nodeMapEntry.loadTime,
+                evt.detail.duration
+              );
+              /* eslint-enable no-console */
+            }
+          }
+
           document.dispatchEvent(evt);
         }
         return rendered;

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -61,6 +61,7 @@ export const config: Config = {
     }),
   ],
   testing: {
+    setupFiles: ['./jest-setup'],
     testPathIgnorePatterns: [
       '<rootDir>/dist/',
       '<rootDir>/docs/',


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

Proof of concept for using a `MutationObserver` on `<manifold-connection>` to track load event start time (i.e. time that any `<manifold-*>` element is inserted into the DOM).

This PoC is blocked by `time_to_render` event being inaccurate.

If we proceed with this approach, I also need some code in the mutation callback to cleanup removed nodes.

## Testing

1. There is currently an _illegal_ `console.log` in the `logger` decorator where you can see logs of the format `<tagname> <time from load to first render> <time from component js initialization to first render>`
2. You should see that the first number is always greater than or equal to the second, which accounts for the time from component being added to the DOM until that component's `componentWillLoad` method is called

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
