### PR TITLE
add db33 gradient

### DIFF
--- a/src/components/manifold-product-page/manifold-product-page.css
+++ b/src/components/manifold-product-page/manifold-product-page.css
@@ -17,6 +17,7 @@
   --manifold-g-cloudamqp: linear-gradient(to right top, #ca6227, #077288);
   --manifold-g-cloudcube: linear-gradient(to right top, #b94e45, #1c7293);
   --manifold-g-custom-recognition: linear-gradient(to right top, #22457d, #2a93af);
+  --manifold-g-db33-mysql: linear-gradient(45deg, #001341 0%, #002F6F 100%);
   --manifold-g-dumper: linear-gradient(to right top, rgb(155, 0, 0), rgb(210, 32, 47));
   --manifold-g-elegant-cms: linear-gradient(to right top, rgb(14, 81, 126), rgb(33, 138, 181));
   --manifold-g-generic-tagging: linear-gradient(to right top, #556919, #899f3c);

--- a/stories/data/product-labels.js
+++ b/stories/data/product-labels.js
@@ -11,6 +11,7 @@ export default [
   'cloudcube',
   'custom-recognition',
   'dumper',
+  'db33-mysql',
   'elegant-cms',
   'generic-tagging',
   'hostedmetrics-influxdb',


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->
Add the gradient fo DB33 to the product page.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->
- Go to the product page component in storybook.
- Select `db33-mysql`.
- The product card should have a cool dark blue gradient that matches the DB33 logo.

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
