### PR TITLE
Make image gallery display full images uncropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Screenshots now display full images (uncropped). (#751)
+
 ## [0.7.2] - 2019-11-19
 
 ### Added

--- a/src/components/manifold-image-gallery/manifold-image-gallery.css
+++ b/src/components/manifold-image-gallery/manifold-image-gallery.css
@@ -54,6 +54,10 @@ img {
   width: 100%;
   height: 100%;
   overflow: hidden;
+
+  & img {
+    object-fit: contain;
+  }
 }
 
 .image-button {


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

- Image gallery was displaying images cropped to fit the aspect ratio

### Before

<img width="956" alt="logdna-screenshots" src="https://user-images.githubusercontent.com/10498708/69252563-96675180-0b89-11ea-8607-fdb8f541a41a.png">

### After

<img width="593" alt="Screen Shot 2019-11-20 at 11 30 40 AM" src="https://user-images.githubusercontent.com/10498708/69252542-8e0f1680-0b89-11ea-9616-fa4c63f33e0c.png">


## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

- go to product-page component in storybook
- choose a product with screenshots (logdna, db33)
- flip through screenshots
- screenshots should be sized to display the entire image and not be cropped

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
