### PR TITLE
remove gql-zero dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2992,11 +2992,6 @@
       "integrity": "sha512-De66pcm7LAUqRJPhofJaPZtgFPzM8JwpxEku/Lu2O900CEDPstdAqZ0yfgVtjGPBfx3kSpQu2OsPI3zpcvIkzg==",
       "dev": true
     },
-    "@manifoldco/gql-zero": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@manifoldco/gql-zero/-/gql-zero-0.2.0.tgz",
-      "integrity": "sha512-s0nPkp5PUzvqK8SaIQEMw5AYArC4slq+YQ9xL9lG8QImMO1NIWfnrvwJRVAO+Ns5dmeZeAdXACX+1g2k27I0Yg=="
-    },
     "@manifoldco/icons": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@manifoldco/icons/-/icons-0.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     }
   ],
   "dependencies": {
-    "@manifoldco/gql-zero": "^0.2.0",
     "@stencil/state-tunnel": "^1.0.1",
     "clipboard-polyfill": "^2.8.6"
   },

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -2379,3 +2379,39 @@ export type ResourceIdQuery = (
     & Pick<Resource, 'id'>
   )> }
 );
+
+export type AllCategoriesQueryVariables = {
+  first: Scalars['Int'],
+  after: Scalars['String']
+};
+
+
+export type AllCategoriesQuery = (
+  { __typename?: 'Query' }
+  & { categories: (
+    { __typename?: 'CategoryConnection' }
+    & { edges: Array<(
+      { __typename?: 'CategoryEdge' }
+      & { node: (
+        { __typename?: 'Category' }
+        & Pick<Category, 'label'>
+        & { products: (
+          { __typename?: 'ProductConnection' }
+          & { edges: Array<(
+            { __typename?: 'ProductEdge' }
+            & { node: (
+              { __typename?: 'Product' }
+              & Pick<Product, 'label'>
+            ) }
+          )>, pageInfo: (
+            { __typename?: 'PageInfo' }
+            & Pick<PageInfo, 'hasNextPage' | 'endCursor'>
+          ) }
+        ) }
+      ) }
+    )>, pageInfo: (
+      { __typename?: 'PageInfo' }
+      & Pick<PageInfo, 'hasNextPage' | 'endCursor'>
+    ) }
+  ) }
+);

--- a/src/utils/all-categories.graphql
+++ b/src/utils/all-categories.graphql
@@ -1,0 +1,25 @@
+# used in `fetchAllPages.spec.ts`
+query AllCategories($first: Int!, $after: String!) {
+  categories(first: $first, after: $after) {
+    edges {
+      node {
+        label
+        products(first: 10) {
+          edges {
+            node {
+              label
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}

--- a/src/utils/fetchAllPages.spec.ts
+++ b/src/utils/fetchAllPages.spec.ts
@@ -1,35 +1,9 @@
-import { gql } from '@manifoldco/gql-zero';
 import fetchMock from 'fetch-mock';
 import { Query } from '../types/graphql';
 import fetchAllPages, { MissingPageInfo } from './fetchAllPages';
 import { createGraphqlFetch } from './graphqlFetch';
 
-const query = gql`
-  query CATEGORIES($first: Int!, $after: String!) {
-    categories(first: $first, after: $after) {
-      edges {
-        node {
-          label
-          products(first: 10) {
-            edges {
-              node {
-                label
-              }
-            }
-            pageInfo {
-              hasNextPage
-              endCursor
-            }
-          }
-        }
-      }
-      pageInfo {
-        hasNextPage
-        endCursor
-      }
-    }
-  }
-`;
+import allCategoriesQuery from './all-categories.graphql';
 
 const firstPage = {
   categories: {
@@ -248,7 +222,7 @@ describe('Fetching all pages of a GraphQL connection', () => {
       expect.assertions(1);
 
       return fetchAllPages({
-        query,
+        query: allCategoriesQuery,
         nextPage: { first: 3, after: '' },
         getConnection: (q: Query) => q.categories,
         graphqlFetch: createGraphqlFetch({}),
@@ -275,7 +249,7 @@ describe('Fetching all pages of a GraphQL connection', () => {
       );
 
     const entries = await fetchAllPages({
-      query,
+      query: allCategoriesQuery,
       nextPage: { first: 3, after: '' },
       getConnection: (q: Query) => q.categories,
       graphqlFetch: createGraphqlFetch({}),


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

It's gone! 🎉 `gql-zero` can be removed from our dependencies!

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

No functionality changes. This is just cleaning up the already-removed dependency.

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
