### PR TITLE
wip fix types for API data

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -9,10 +9,8 @@
 import { HTMLStencilElement, JSXBase } from '@stencil/core/internal';
 import {
   GetResourceQuery,
-  Plan,
   PlanEdge,
-  PlanMeteredFeatureEdge,
-  Product,
+  PlanListQuery,
   ProductCardQuery,
   ProductEdge,
   ProductQuery,
@@ -47,8 +45,8 @@ import {
 export namespace Components {
   interface ManifoldActivePlan {
     'isExistingResource'?: boolean;
-    'plans'?: PlanEdge[];
-    'product'?: Product;
+    'plans'?: PlanListQuery['product']['plans']['edges'];
+    'product'?: PlanListQuery['product'];
     'regions'?: string[];
     'selectedResource'?: Resource;
   }
@@ -102,7 +100,7 @@ export namespace Components {
     'baseCost'?: number;
     'compact'?: boolean;
     'configurable'?: boolean;
-    'meteredFeatures': PlanMeteredFeatureEdge[];
+    'meteredFeatures': MeteredFeatures;
   }
   interface ManifoldCredentials {
     /**
@@ -402,7 +400,7 @@ export namespace Components {
     * Compact mode (for plan selector sidebar)
     */
     'compact'?: boolean;
-    'plan'?: Plan;
+    'plan'?: PlanListQuery['product']['plans']['edges'][0]['node'];
     /**
     * _(hidden)_
     */
@@ -414,8 +412,8 @@ export namespace Components {
   }
   interface ManifoldPlanDetails {
     'isExistingResource'?: boolean;
-    'plan'?: Plan;
-    'product'?: Product;
+    'plan'?: PlanListQuery['product']['plans']['edges'][0]['node'];
+    'product'?: PlanListQuery['product'];
     'region'?: Region;
     'regions'?: string[];
     'resourceRegion'?: string;
@@ -1047,8 +1045,8 @@ declare global {
 declare namespace LocalJSX {
   interface ManifoldActivePlan {
     'isExistingResource'?: boolean;
-    'plans'?: PlanEdge[];
-    'product'?: Product;
+    'plans'?: PlanListQuery['product']['plans']['edges'];
+    'product'?: PlanListQuery['product'];
     'regions'?: string[];
     'selectedResource'?: Resource;
   }
@@ -1107,7 +1105,7 @@ declare namespace LocalJSX {
     'baseCost'?: number;
     'compact'?: boolean;
     'configurable'?: boolean;
-    'meteredFeatures'?: PlanMeteredFeatureEdge[];
+    'meteredFeatures'?: MeteredFeatures;
   }
   interface ManifoldCredentials {
     /**
@@ -1429,7 +1427,7 @@ declare namespace LocalJSX {
     * Compact mode (for plan selector sidebar)
     */
     'compact'?: boolean;
-    'plan'?: Plan;
+    'plan'?: PlanListQuery['product']['plans']['edges'][0]['node'];
     /**
     * _(hidden)_
     */
@@ -1443,8 +1441,8 @@ declare namespace LocalJSX {
     'isExistingResource'?: boolean;
     'onManifold-planSelector-change'?: (event: CustomEvent<any>) => void;
     'onManifold-planSelector-load'?: (event: CustomEvent<any>) => void;
-    'plan'?: Plan;
-    'product'?: Product;
+    'plan'?: PlanListQuery['product']['plans']['edges'][0]['node'];
+    'product'?: PlanListQuery['product'];
     'region'?: Region;
     'regions'?: string[];
     'resourceRegion'?: string;

--- a/src/components/manifold-active-plan/manifold-active-plan.tsx
+++ b/src/components/manifold-active-plan/manifold-active-plan.tsx
@@ -1,7 +1,8 @@
 import { h, Component, State, Prop, Watch } from '@stencil/core';
 import logger from '../../utils/logger';
 import loadMark from '../../utils/loadMark';
-import { Product, PlanEdge, Resource } from '../../types/graphql';
+import { Resource, PlanListQuery } from '../../types/graphql';
+
 @Component({
   tag: 'manifold-active-plan',
   styleUrl: 'manifold-active-plan.css',
@@ -9,12 +10,12 @@ import { Product, PlanEdge, Resource } from '../../types/graphql';
 })
 export class ManifoldActivePlan {
   @Prop() isExistingResource?: boolean;
-  @Prop() plans?: PlanEdge[];
-  @Prop() product?: Product;
+  @Prop() plans?: PlanListQuery['product']['plans']['edges'];
+  @Prop() product?: PlanListQuery['product'];
   @Prop() regions?: string[];
   @Prop() selectedResource?: Resource;
   @State() selectedPlanId: string;
-  @Watch('plans') plansChange(newPlans: PlanEdge[]) {
+  @Watch('plans') plansChange(newPlans: PlanListQuery['product']['plans']['edges']) {
     if (this.selectedResource && this.selectedResource.plan && this.selectedResource.plan.id) {
       this.selectPlan(this.selectedResource.plan.id);
     } else if (newPlans && newPlans.length > 0) {

--- a/src/components/manifold-cost-display/manifold-cost-display.tsx
+++ b/src/components/manifold-cost-display/manifold-cost-display.tsx
@@ -3,8 +3,10 @@ import { h, Component, Element, Prop, FunctionalComponent } from '@stencil/core'
 import { $ } from '../../utils/currency';
 import logger from '../../utils/logger';
 import loadMark from '../../utils/loadMark';
-import { PlanMeteredFeatureEdge } from '../../types/graphql';
+import { PlanListQuery } from '../../types/graphql';
 import { meteredFeatureDisplayValue } from '../../utils/plan';
+
+type MeteredFeatures = PlanListQuery['product']['plans']['edges'][0]['node']['meteredFeatures']['edges'];
 
 /**
  * Base Cost
@@ -38,7 +40,7 @@ const BaseCost: FunctionalComponent<BaseCostProps> = props => {
  * Metered Cost
  */
 interface MeteredCostProps {
-  meteredFeatures: PlanMeteredFeatureEdge[];
+  meteredFeatures: MeteredFeatures;
 }
 const MeteredCost: FunctionalComponent<MeteredCostProps> = ({ meteredFeatures }) => {
   if (meteredFeatures.length === 0) {
@@ -62,7 +64,8 @@ export class ManifoldCostDisplay {
   @Element() el: HTMLElement;
   @Prop() baseCost?: number;
   @Prop() compact?: boolean = false;
-  @Prop() meteredFeatures: PlanMeteredFeatureEdge[] = [];
+  @Prop()
+  meteredFeatures: PlanListQuery['product']['plans']['edges'][0]['node']['meteredFeatures']['edges'] = [];
   @Prop() configurable?: boolean = false;
 
   get isFreeMonthly() {

--- a/src/components/manifold-plan-cost/manifold-plan-cost.tsx
+++ b/src/components/manifold-plan-cost/manifold-plan-cost.tsx
@@ -6,14 +6,14 @@ import { planCost, configurableFeatureDefaults } from '../../utils/plan';
 import { RestFetch } from '../../utils/restFetch';
 import logger from '../../utils/logger';
 import loadMark from '../../utils/loadMark';
-import { Plan } from '../../types/graphql';
+import { PlanListQuery } from '../../types/graphql';
 
 @Component({ tag: 'manifold-plan-cost' })
 export class ManifoldPlanCost {
   @Element() el: HTMLElement;
   /** _(hidden)_ */
   @Prop() restFetch?: RestFetch = connection.restFetch;
-  @Prop() plan?: Plan;
+  @Prop() plan?: PlanListQuery['product']['plans']['edges'][0]['node'];
   /** Compact mode (for plan selector sidebar) */
   @Prop() compact?: boolean = false;
   /** User-selected plan features (needed only for customizable) */

--- a/src/components/manifold-plan-details/components/ConfigurableFeature.tsx
+++ b/src/components/manifold-plan-details/components/ConfigurableFeature.tsx
@@ -1,10 +1,12 @@
 import { h, FunctionalComponent } from '@stencil/core';
 
-import { PlanConfigurableFeatureEdge, PlanFeatureType } from '../../../types/graphql';
+import { PlanFeatureType, PlanListQuery } from '../../../types/graphql';
 import { Option } from '../../../types/Select';
 
+type ConfigurableFeatureEdge = PlanListQuery['product']['plans']['edges'][0]['node']['meteredFeatures']['edges'][0];
+
 interface ConfigurableFeatureProps {
-  configurableFeature?: PlanConfigurableFeatureEdge;
+  configurableFeature?: ConfigurableFeatureEdge;
   onChange: (e: CustomEvent) => void;
   value?: string | number | boolean;
 }

--- a/src/components/manifold-plan-details/components/MeteredFeature.tsx
+++ b/src/components/manifold-plan-details/components/MeteredFeature.tsx
@@ -1,9 +1,11 @@
 import { h, FunctionalComponent } from '@stencil/core';
 
-import { PlanMeteredFeatureEdge, PlanMeteredFeatureNumericDetails } from '../../../types/graphql';
+import { PlanMeteredFeatureNumericDetails, PlanListQuery } from '../../../types/graphql';
 import { $ } from '../../../utils/currency';
 import { pluralize } from '../../../utils/string';
 import { featureCost, meteredFeatureDisplayValue, pricingTiers } from '../../../utils/plan';
+
+type MeteredFeatureEdge = PlanListQuery['product']['plans']['edges'][0]['node']['meteredFeatures']['edges'][0];
 
 function meteredFeatureCost(numericDetails: PlanMeteredFeatureNumericDetails) {
   const tiers = pricingTiers(numericDetails);
@@ -36,7 +38,7 @@ function meteredFeatureCost(numericDetails: PlanMeteredFeatureNumericDetails) {
   return [displayValue.cost, displayValue.per ? <small>&nbsp;{displayValue.per}</small> : ''];
 }
 
-const MeteredFeature: FunctionalComponent<{ meteredFeature?: PlanMeteredFeatureEdge }> = ({
+const MeteredFeature: FunctionalComponent<{ meteredFeature?: MeteredFeatureEdge }> = ({
   meteredFeature,
 }) => {
   if (!meteredFeature) {

--- a/src/components/manifold-plan-menu/manifold-plan-menu.tsx
+++ b/src/components/manifold-plan-menu/manifold-plan-menu.tsx
@@ -1,7 +1,7 @@
 import { h, Prop, Component } from '@stencil/core';
 import { check, sliders } from '@manifoldco/icons';
 
-import { PlanEdge } from '../../types/graphql';
+import { PlanEdge, PlanListQuery, GetResourceQuery } from '../../types/graphql';
 import logger from '../../utils/logger';
 import loadMark from '../../utils/loadMark';
 
@@ -11,7 +11,8 @@ import loadMark from '../../utils/loadMark';
   shadow: true,
 })
 export class ManifoldPlanMenu {
-  @Prop() plans?: PlanEdge[];
+  // TODO place PlanEdge[] with types from resource queries.
+  @Prop() plans?: PlanListQuery['product']['plans']['edges'][0]['node']['meteredFeatures']['edges'];
   @Prop() selectedPlanId?: string;
   @Prop() selectPlan: (planId: string) => void = () => null;
 

--- a/src/components/manifold-plan-selector/manifold-plan-selector.tsx
+++ b/src/components/manifold-plan-selector/manifold-plan-selector.tsx
@@ -4,7 +4,7 @@ import connection from '../../state/connection';
 import logger from '../../utils/logger';
 import loadMark from '../../utils/loadMark';
 import { GraphqlFetch } from '../../utils/graphqlFetch';
-import { Product, Resource, PlanEdge } from '../../types/graphql';
+import { Resource, PlanListQuery } from '../../types/graphql';
 
 import plansQuery from './plan-list.graphql';
 import resourceQuery from './resource.graphql';
@@ -23,8 +23,8 @@ export class ManifoldPlanSelector {
   /** Is this tied to an existing resource? */
   @Prop() resourceLabel?: string;
   @Prop() hideUntilReady?: boolean = false;
-  @State() product?: Product;
-  @State() plans?: PlanEdge[];
+  @State() product?: PlanListQuery['product'];
+  @State() plans?: PlanListQuery['product']['plans']['edges'];
   @State() resource?: Resource;
   @State() parsedRegions: string[];
   @Watch('productLabel') productChange(newProduct: string) {
@@ -58,7 +58,7 @@ export class ManifoldPlanSelector {
 
     this.product = undefined;
 
-    const { data } = await this.graphqlFetch({
+    const { data } = await this.graphqlFetch<PlanListQuery>({
       query: plansQuery,
       variables: {
         productLabel,
@@ -104,12 +104,12 @@ export class ManifoldPlanSelector {
     }
   }
 
-  filterFreeOnly(plans: PlanEdge[]) {
+  filterFreeOnly(plans: PlanListQuery['product']['plans']['edges']) {
     return plans.filter(({ node: { free } }) => free);
   }
 
   // TODO: remove this once configurable plans are supported
-  filterOutConfigurable(plans: PlanEdge[]) {
+  filterOutConfigurable(plans: PlanListQuery['product']['plans']['edges']) {
     return plans.filter(
       ({ node: { configurableFeatures } }) =>
         !configurableFeatures || configurableFeatures.edges.length === 0

--- a/src/utils/plan.ts
+++ b/src/utils/plan.ts
@@ -2,11 +2,7 @@ import { Gateway } from '../types/gateway';
 import { $ } from './currency';
 import { pluralize } from './string';
 import { RestFetch } from './restFetch';
-import {
-  PlanMeteredFeatureNumericDetails,
-  PlanConfigurableFeatureEdge,
-  PlanFeatureType,
-} from '../types/graphql';
+import { PlanMeteredFeatureNumericDetails, PlanFeatureType, PlanListQuery } from '../types/graphql';
 
 interface PlanCostOptions {
   planID: string;
@@ -154,7 +150,9 @@ export function planCost(restFetch: RestFetch, { planID, features, init }: PlanC
 /**
  * Get default feature map for configurableFeatures
  */
-export function configurableFeatureDefaults(configurableFeatures: PlanConfigurableFeatureEdge[]) {
+export type ConfigurableFeatures = PlanListQuery['product']['plans']['edges'][0]['node']['configurableFeatures']['edges'];
+
+export function configurableFeatureDefaults(configurableFeatures: ConfigurableFeatures) {
   const defaultFeatures: Gateway.FeatureMap = {};
 
   configurableFeatures.forEach(({ node: { label, numericDetails, options, type } }) => {


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

Use correct types for data coming from GraphQL. This is very much a WIP and types are broken everywhere. just seemed like something that needed more input from others.

There are some queries still using the old types generated from the schema. This is a first pass attempt at trying to fix that. High cohesion though is preventing this from being done easily. There's a need for union types and some types need to deeply select parts of the Query type in order to be correct.

I'd like opinions on how we can use these generated types more easily so that the types don't become a burden to deal with and that they're easy to interpret for us as developers.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
