### PR TITLE
Update local oauth url

### DIFF
--- a/src/utils/connections.ts
+++ b/src/utils/connections.ts
@@ -21,7 +21,7 @@ export const connections: Connections = {
     provisioning: 'http://api.provisioning.arigato.tools/v1',
     connector: 'http://api.connector.arigato.tools/v1',
     graphql: 'http://graphql.arigato.tools/graphql',
-    oauth: 'http://login.arigato.tools/signin/oauth/web',
+    oauth: 'http://signin.arigato.tools/signin/oauth/web',
   },
   stage: {
     billing: 'https://api.billing.stage.manifold.co/v1',


### PR DESCRIPTION
## Reason for change

This [logo PR](https://github.com/manifoldco/logo/pull/556) updated the location of the OAuth endpoint in docker compose. We need to update UI to match

## Testing

No functionality changes. Test with docker compose

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
