### PR TITLE
Revert local OAuth URL

### DIFF
--- a/src/utils/connections.ts
+++ b/src/utils/connections.ts
@@ -21,7 +21,7 @@ export const connections: Connections = {
     provisioning: 'http://api.provisioning.arigato.tools/v1',
     connector: 'http://api.connector.arigato.tools/v1',
     graphql: 'http://graphql.arigato.tools/graphql',
-    oauth: 'http://signin.arigato.tools/signin/oauth/web',
+    oauth: 'http://login.arigato.tools/signin/oauth/web',
   },
   stage: {
     billing: 'https://api.billing.stage.manifold.co/v1',


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

Reverts #779

## Reason for change

The OAuth callback URL was reverted back to `login.arigato.tools/...` in manifoldco/logo#589, so I'm updating `ui` to match (and get docker compose working once more)

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

No functionality changes. Test with docker compose

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
