### PR TITLE
Publish docker image for easier testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+name: release
+
+on: [push] # testing
+  #push:
+  #  branches:
+  #    - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - run: make docker-login
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+    - run: make release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: release
 
-on: [push] # testing
-  #push:
-  #  branches:
-  #    - master
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   release:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+NAME?="ui"
+
+VCS_SHA?=$(shell git rev-parse --verify HEAD)
+BUILD_DATE?=$(shell git show -s --date=iso8601-strict --pretty=format:%cd $$VCS_SHA)
+VCS_BRANCH?=$(shell git branch | grep \* | cut -f2 -d' ')
+TAG=$(shell echo $$(git rev-list --count HEAD)$$(git show -s --format=.%ad.%h --date=format:%Y-%m-%d))
+RELEASE_ENV=master
+
+RELEASE_VERSION?=$(shell git describe --always --tags --dirty | sed 's/^v//')
+
+RELEASE_NAME?=$(NAME)
+
+all:
+
+docker:
+	docker build -t arigato/$(NAME) \
+		--label "org.label-schema.build-date"="$(BUILD_DATE)" \
+		--label "org.label-schema.name"="$(RELEASE_NAME)" \
+		--label "org.label-schema.vcs-ref"="$(VCS_SHA)" \
+		--label "org.label-schema.vendor"="Arigato Machine Inc." \
+		--label "org.label-schema.version"="$(TAG)" \
+		--label "org.vcs-branch"="$(VCS_BRANCH)" \
+		.
+
+release-pr: docker
+	docker tag arigato/$(NAME) arigato/$(NAME):$(RELEASE_VERSION)
+	docker push arigato/$(NAME):$(RELEASE_VERSION)
+
+release-master: docker
+	docker tag arigato/$(NAME) arigato/$(NAME):$(TAG)
+	docker push arigato/$(NAME):latest
+	docker push arigato/$(NAME):$(TAG)
+
+release: release-$(RELEASE_ENV)
+
+docker-login:
+	docker login -u="$$DOCKER_USERNAME" -p="$$DOCKER_PASSWORD"


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

Publishes a docker image on all pushes to master

## Reason for change

To make the entire stack easier to test, I'd like to add `manifoldco/ui` to docker compose. To do this, first, we need to publish a docker image.

This PR introduces `make` to the mix, buuut it does not alter the workflow of those working on this project in any way and also matches the what's been implemented in `starcourt`

Assuming that this PR is accepted, I will work with the right people to configure the secrets and create the repo

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

Currently, you will only be able to test `make docker` which builds and tags the image locally. Once fully configured, you should be able to pull `arigato/ui` from docker

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
