### PR TITLE
enable configurable features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Support for configurable features in plan selector.
+
 ## [0.9.0]
 
 ### Removed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manifoldco/ui",
   "description": "Manifold UI",
-  "version": "0.8.0",
+  "version": "1.0.0-rc.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/manifoldco/ui.git"

--- a/src/components/manifold-plan-menu/manifold-plan-menu.tsx
+++ b/src/components/manifold-plan-menu/manifold-plan-menu.tsx
@@ -5,6 +5,18 @@ import { PlanEdge } from '../../types/graphql';
 import logger from '../../utils/logger';
 import loadMark from '../../utils/loadMark';
 
+const sortPlans = (plans: PlanEdge[]): PlanEdge[] => {
+  const nonconfigurablePlans = plans.filter(
+    plan => plan.node.configurableFeatures && plan.node.configurableFeatures.edges.length === 0
+  );
+
+  const configurablePlans = plans.filter(
+    plan => plan.node.configurableFeatures && plan.node.configurableFeatures.edges.length > 0
+  );
+
+  return [...nonconfigurablePlans, ...configurablePlans];
+};
+
 @Component({
   tag: 'manifold-plan-menu',
   styleUrl: 'manifold-plan-menu.css',
@@ -21,9 +33,10 @@ export class ManifoldPlanMenu {
   @logger()
   render() {
     if (this.plans) {
+      const sortedPlans = sortPlans(this.plans);
       return (
         <ul class="plan-list">
-          {this.plans.map(({ node: plan }, i) => {
+          {sortedPlans.map(({ node: plan }, i) => {
             const isSelected = this.selectedPlanId ? plan.id === this.selectedPlanId : i === 0;
             const isConfigurable =
               plan.configurableFeatures && plan.configurableFeatures.edges.length > 0;

--- a/src/components/manifold-plan-selector/manifold-plan-selector.tsx
+++ b/src/components/manifold-plan-selector/manifold-plan-selector.tsx
@@ -71,8 +71,8 @@ export class ManifoldPlanSelector {
 
       if (data.product.plans) {
         const plans = this.freePlans
-          ? this.filterFreeOnly(this.filterOutConfigurable(data.product.plans.edges))
-          : this.filterOutConfigurable(data.product.plans.edges);
+          ? this.filterFreeOnly(data.product.plans.edges)
+          : data.product.plans.edges;
 
         // TODO: Make GraphQL sort by free AND cost
         this.plans = [...plans].sort(a => (a.node.free ? -1 : 0));
@@ -109,12 +109,12 @@ export class ManifoldPlanSelector {
   }
 
   // TODO: remove this once configurable plans are supported
-  filterOutConfigurable(plans: PlanEdge[]) {
-    return plans.filter(
-      ({ node: { configurableFeatures } }) =>
-        !configurableFeatures || configurableFeatures.edges.length === 0
-    );
-  }
+  // filterOutConfigurable(plans: PlanEdge[]) {
+  //   return plans.filter(
+  //     ({ node: { configurableFeatures } }) =>
+  //       !configurableFeatures || configurableFeatures.edges.length === 0
+  //   );
+  // }
 
   @logger()
   render() {

--- a/src/components/manifold-plan-selector/manifold-plan-selector.tsx
+++ b/src/components/manifold-plan-selector/manifold-plan-selector.tsx
@@ -108,14 +108,6 @@ export class ManifoldPlanSelector {
     return plans.filter(({ node: { free } }) => free);
   }
 
-  // TODO: remove this once configurable plans are supported
-  // filterOutConfigurable(plans: PlanEdge[]) {
-  //   return plans.filter(
-  //     ({ node: { configurableFeatures } }) =>
-  //       !configurableFeatures || configurableFeatures.edges.length === 0
-  //   );
-  // }
-
   @logger()
   render() {
     const regions =

--- a/stories/data/product-labels.js
+++ b/stories/data/product-labels.js
@@ -27,6 +27,8 @@ export default [
   'logdna',
   'mailgun',
   'memcachier-cache',
+  'nodechef-app-container',
+  'nodechef-mongodb',
   'oauth-io',
   'pdfshift',
   'piio',


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

- Enable configurable features in plan selector.

The UI for configurable features was never actually removed so we can add it back by simply not filtering out configurable features from the plan data. There are a few issues with the current data we get from the GraphQL API that needs to be handled before releasing configurable plans:

- ~[Nice to have] Configurable plans are not sorted to be last (this can be fixed on the frontend but eventually the API should match the order of the UI).~
- [Required] Minimum value for number features appears to be incorrect. In dashboard, JawsDB MySQL has storage minimum 5 and backups minimum 1, but both are 0 in GraphQL.
- [Required] The upgradable/downgradable flags for features don't exist in the GraphQL API, making it impossible to limit plan resizing (only relevant for resizing plans)
- [Nice to have] The descriptions for features don't exist in the GraphQL API.
- [Nice to have] cost of individual features is missing from the GraphQL API. We would need this in order to display the added cost of a feature to the user.

Some of these have issues already, I will create issues for any that don't.

One that will require more investigation:

I'm unsure if we switched provisioning over to GraphQL, and if we did, can the GraphQL mutation accept a list of configurable features to provision a resource based on the values provided?

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->
- Test plan selector for JawsDB custom plan, and all NodeChef plans.
- Ensure cost is calculated correctly for configurable features.

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
