### PR TITLE
Add additional safety check for mutation observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Support for configurable features in plan selector.
+- Added safety check for MutationObserver when initializing UI.
 
 ## [0.9.0]
 
 ### Removed
-- `resourceLabel` prop on `<manifold-data-product-logo>` component (previously deprecated in favor of `<manifold-data-resource-logo>`).
+
+- `resourceLabel` prop on `<manifold-data-product-logo>` component (previously deprecated in favor
+  of `<manifold-data-resource-logo>`).
 - `manifold-service-card` component (previously deprecated in favor of `manifold-product-card`).
 
 ## [0.8.0]
@@ -26,7 +29,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Screenshots now display full images (uncropped). (#751)
-- `manifold-data-rename-button` success message now contains the returned updated label value as opposed to the submitted label value. (#756)
+- `manifold-data-rename-button` success message now contains the returned updated label value as
+  opposed to the submitted label value. (#756)
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -125,5 +125,8 @@
     "testcafe": "^1.5.0",
     "wait-on": "^3.3.0",
     "webpack": "^4.41.2"
+  },
+  "engines": {
+    "node": "12.13.x"
   }
 }

--- a/src/global/app.ts
+++ b/src/global/app.ts
@@ -18,7 +18,11 @@ function mutationCallback(mutationsList: MutationRecord[]) {
   mutationsList
     .filter(mutation => mutation.type === 'childList')
     .forEach(mutation => {
-      if (mutation.addedNodes && mutation.addedNodes.length > 1) {
+      if (
+        mutation.addedNodes &&
+        Array.isArray(mutation.addedNodes) &&
+        mutation.addedNodes.length > 1
+      ) {
         mutation.addedNodes.forEach((node: HTMLElement) => {
           if (node.tagName && node.tagName.startsWith('MANIFOLD-')) {
             mark(node, 'load');

--- a/src/global/app.ts
+++ b/src/global/app.ts
@@ -18,7 +18,7 @@ function mutationCallback(mutationsList: MutationRecord[]) {
   mutationsList
     .filter(mutation => mutation.type === 'childList')
     .forEach(mutation => {
-      if (mutation.addedNodes) {
+      if (mutation.addedNodes && mutation.addedNodes.length > 1) {
         mutation.addedNodes.forEach((node: HTMLElement) => {
           if (node.tagName && node.tagName.startsWith('MANIFOLD-')) {
             mark(node, 'load');

--- a/src/global/app.ts
+++ b/src/global/app.ts
@@ -18,11 +18,7 @@ function mutationCallback(mutationsList: MutationRecord[]) {
   mutationsList
     .filter(mutation => mutation.type === 'childList')
     .forEach(mutation => {
-      if (
-        mutation.addedNodes &&
-        Array.isArray(mutation.addedNodes) &&
-        mutation.addedNodes.length > 1
-      ) {
+      if (Array.isArray(mutation.addedNodes) && mutation.addedNodes.length > 1) {
         mutation.addedNodes.forEach((node: HTMLElement) => {
           if (node.tagName && node.tagName.startsWith('MANIFOLD-')) {
             mark(node, 'load');


### PR DESCRIPTION


<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

Adds a check for the custom length property of MutationRecord.addedNodes before attempting a forEach.

## Testing

Affected code is on the initialization of ui, so just ensure ui loads on the browser as normal.

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
