### PR TITLE
Add npm install test

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -7,12 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 13.x]
+        node-version: [8.x, 10.x, 12.x, 13.x]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
       - run: npm install
-      - run: npm run build
+      - run: npm run test:npm-install
+      - run: npm run test:yarn-install
   bundlesize:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ storybook-static
 .cache
 docs/public
 docs/docs/changelog.md
+
+/test-install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added test to ensure `npm install` works on all supported Node versions
+
 ## [0.9.3] - 2019-01-13
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manifoldco/ui",
   "description": "Manifold UI",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/manifoldco/ui.git"
@@ -60,6 +60,8 @@
     "test:spec": "stencil test --spec",
     "test:coverage": "stencil test --spec --e2e --coverage --maxWorkers=2",
     "test:debug": "node --inspect-brk node_modules/.bin/stencil test --spec --e2e --runInBand",
+    "test:npm-install": "rm -rf test-install && npm run prepare:package && cd pkg && npm link && cd .. && mkdir -p test-install && node scripts/test-install && cd test-install && npm install --save @manifoldco/ui && npm unlink @manifoldco/ui",
+    "test:yarn-install": "rm -rf test-install && npm run prepare:package && cd pkg && yarn link && cd .. && mkdir -p test-install && node scripts/test-install && cd test-install && yarn add @manifoldco/ui && yarn unlink @manifoldco/ui",
     "test:watch": "stencil test --spec --e2e --watchAll",
     "update-version": "node scripts/version-from-git"
   },

--- a/scripts/test-install.js
+++ b/scripts/test-install.js
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/no-var-requires,no-console */
+const fs = require('fs');
+const path = require('path');
+
+const major = process.versions.node.split('.')[0];
+const versionRange = `>=${major} <${parseInt(major, 10) + 1}`;
+console.info(`Testing Node ${process.versions.node} @ ${versionRange}`);
+const packageJSON = `{
+  "name": "test-install",
+  "engines": {
+    "node": "${versionRange}"
+  }
+}
+`;
+
+const testInstallPath = path.resolve(__dirname, '..', 'test-install');
+fs.writeFileSync(path.join(testInstallPath, 'package.json'), packageJSON);


### PR DESCRIPTION
## Reason for change

Adds `npm install` test for all supported Node versions

## Testing

Tests should pass

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
