### PR TITLE
add read-only setting for resource plan configurable features

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     },
     {
       "path": "./dist/esm/manifold-number-input*.js",
-      "maxSize": "36 kB",
+      "maxSize": "40 kB",
       "compression": "none"
     }
   ],

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -410,6 +410,7 @@ export namespace Components {
     'selectedFeatures'?: Gateway.FeatureMap;
   }
   interface ManifoldPlanDetails {
+    'configuredFeatures'?: Gateway.FeatureMap;
     'isExistingResource'?: boolean;
     'plan'?: Plan;
     'product'?: Product;
@@ -1455,6 +1456,7 @@ declare namespace LocalJSX {
     'selectedFeatures'?: Gateway.FeatureMap;
   }
   interface ManifoldPlanDetails {
+    'configuredFeatures'?: Gateway.FeatureMap;
     'isExistingResource'?: boolean;
     'onManifold-planSelector-change'?: (event: CustomEvent<any>) => void;
     'onManifold-planSelector-load'?: (event: CustomEvent<any>) => void;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -373,6 +373,7 @@ export namespace Components {
   }
   interface ManifoldNumberInput {
     'decrementDisabledLabel'?: string;
+    'disabled'?: boolean;
     'error'?: string;
     'increment': number;
     'incrementDisabledLabel'?: string;
@@ -412,6 +413,7 @@ export namespace Components {
     'isExistingResource'?: boolean;
     'plan'?: Plan;
     'product'?: Product;
+    'readOnly'?: boolean;
     'region'?: Region;
     'regions'?: string[];
     'resourceRegion'?: string;
@@ -584,6 +586,7 @@ export namespace Components {
   }
   interface ManifoldSelect {
     'defaultValue'?: string;
+    'disabled'?: boolean;
     'name': string;
     'options': Option[];
     'required'?: boolean;
@@ -1413,6 +1416,7 @@ declare namespace LocalJSX {
   }
   interface ManifoldNumberInput {
     'decrementDisabledLabel'?: string;
+    'disabled'?: boolean;
     'error'?: string;
     'increment'?: number;
     'incrementDisabledLabel'?: string;
@@ -1456,6 +1460,7 @@ declare namespace LocalJSX {
     'onManifold-planSelector-load'?: (event: CustomEvent<any>) => void;
     'plan'?: Plan;
     'product'?: Product;
+    'readOnly'?: boolean;
     'region'?: Region;
     'regions'?: string[];
     'resourceRegion'?: string;
@@ -1632,6 +1637,7 @@ declare namespace LocalJSX {
   }
   interface ManifoldSelect {
     'defaultValue'?: string;
+    'disabled'?: boolean;
     'name'?: string;
     'onUpdateValue'?: (event: CustomEvent<any>) => void;
     'options'?: Option[];

--- a/src/components/manifold-active-plan/manifold-active-plan.tsx
+++ b/src/components/manifold-active-plan/manifold-active-plan.tsx
@@ -60,13 +60,13 @@ export class ManifoldActivePlan {
       />,
       <manifold-plan-details
         isExistingResource={this.isExistingResource}
+        configuredFeatures={formatGatewayFeatures(this.selectedResource?.configuredFeatures?.edges)}
         plan={this.selectedPlan}
         product={this.product}
         regions={this.regions}
         resourceRegion={resourceRegion}
         scrollLocked={true}
         region={this.selectedResource && this.selectedResource.region}
-        configuredFeatures={formatGatewayFeatures(this.selectedResource?.configuredFeatures?.edges)}
       >
         <manifold-forward-slot slot="cta">
           <slot name="cta" />

--- a/src/components/manifold-active-plan/manifold-active-plan.tsx
+++ b/src/components/manifold-active-plan/manifold-active-plan.tsx
@@ -2,6 +2,8 @@ import { h, Component, State, Prop, Watch } from '@stencil/core';
 import logger from '../../utils/logger';
 import loadMark from '../../utils/loadMark';
 import { Product, PlanEdge, Resource } from '../../types/graphql';
+import { formatGatewayFeatures } from '../../utils/configuredFeatures';
+
 @Component({
   tag: 'manifold-active-plan',
   styleUrl: 'manifold-active-plan.css',
@@ -49,7 +51,7 @@ export class ManifoldActivePlan {
     const resourceRegion =
       (this.selectedResource && this.selectedResource.region && this.selectedResource.region.id) ||
       undefined;
-
+    console.log('PLAN', formatGatewayFeatures(this.selectedResource?.configuredFeatures?.edges));
     return [
       <manifold-plan-menu
         plans={this.plans}
@@ -64,6 +66,7 @@ export class ManifoldActivePlan {
         resourceRegion={resourceRegion}
         scrollLocked={true}
         region={this.selectedResource && this.selectedResource.region}
+        configuredFeatures={formatGatewayFeatures(this.selectedResource?.configuredFeatures?.edges)}
       >
         <manifold-forward-slot slot="cta">
           <slot name="cta" />

--- a/src/components/manifold-active-plan/manifold-active-plan.tsx
+++ b/src/components/manifold-active-plan/manifold-active-plan.tsx
@@ -51,7 +51,7 @@ export class ManifoldActivePlan {
     const resourceRegion =
       (this.selectedResource && this.selectedResource.region && this.selectedResource.region.id) ||
       undefined;
-    console.log('PLAN', formatGatewayFeatures(this.selectedResource?.configuredFeatures?.edges));
+
     return [
       <manifold-plan-menu
         plans={this.plans}

--- a/src/components/manifold-mock-resource/manifold-mock-resource.tsx
+++ b/src/components/manifold-mock-resource/manifold-mock-resource.tsx
@@ -95,6 +95,9 @@ const GraphQLResource: GetResourceQuery['resource'] = {
   },
   region: { id: '235n4f9pxf8eyraj3y159x89z6jer', displayName: 'All Regions' },
   status: { label: ResourceStatusLabel.Available, message: 'Available' },
+  configuredFeatures: {
+    edges: [],
+  },
 };
 
 @Component({ tag: 'manifold-mock-resource' })

--- a/src/components/manifold-number-input/manifold-number-input.tsx
+++ b/src/components/manifold-number-input/manifold-number-input.tsx
@@ -10,6 +10,7 @@ import loadMark from '../../utils/loadMark';
 })
 export class ManifoldNumberInput {
   @Prop() error?: string;
+  @Prop() disabled?: boolean;
   @Prop() decrementDisabledLabel?: string;
   @Prop() incrementDisabledLabel?: string;
   @Prop() increment: number = 1;
@@ -82,7 +83,7 @@ export class ManifoldNumberInput {
             tabindex="-1"
             class="decrement"
             onClick={() => this.setValue(this.value - this.increment)}
-            disabled={this.lowerBoundReached}
+            disabled={this.lowerBoundReached || this.disabled}
           >
             <manifold-icon icon={minus} />
           </button>
@@ -97,6 +98,7 @@ export class ManifoldNumberInput {
           required
           step={this.increment}
           value={this.value}
+          disabled={this.disabled}
         />
         <manifold-tooltip
           labelText={
@@ -109,7 +111,7 @@ export class ManifoldNumberInput {
             tabindex="-1"
             class="increment"
             onClick={() => this.setValue(this.value + this.increment)}
-            disabled={this.upperBoundReached}
+            disabled={this.upperBoundReached || this.disabled}
           >
             <manifold-icon icon={plus} />
           </button>

--- a/src/components/manifold-plan-details/components/ConfigurableFeature.tsx
+++ b/src/components/manifold-plan-details/components/ConfigurableFeature.tsx
@@ -7,12 +7,14 @@ interface ConfigurableFeatureProps {
   configurableFeature?: PlanConfigurableFeatureEdge;
   onChange: (e: CustomEvent) => void;
   value?: string | number | boolean;
+  readOnly?: boolean;
 }
 
 const ConfigurableFeature: FunctionalComponent<ConfigurableFeatureProps> = ({
   configurableFeature,
   onChange,
   value,
+  readOnly,
 }) => {
   if (!configurableFeature) {
     return [];
@@ -54,6 +56,7 @@ const ConfigurableFeature: FunctionalComponent<ConfigurableFeatureProps> = ({
             options={selectOptions}
             onUpdateValue={onChange}
             defaultValue={(defaultOption && `${defaultOption.value}`) || undefined}
+            disabled={readOnly}
           />
         </dd>,
       ];
@@ -79,6 +82,7 @@ const ConfigurableFeature: FunctionalComponent<ConfigurableFeatureProps> = ({
             onUpdateValue={onChange}
             unit={numericDetails.unit}
             value={typeof value === 'number' ? value : undefined}
+            disabled={readOnly}
           />
         </dd>,
       ];
@@ -93,6 +97,7 @@ const ConfigurableFeature: FunctionalComponent<ConfigurableFeatureProps> = ({
             defaultValue={!!value}
             name={label}
             onUpdateValue={(e: CustomEvent) => onChange && onChange(e)}
+            disabled={readOnly}
           />
         </dd>,
       ];

--- a/src/components/manifold-plan-details/components/ConfigurableFeature.tsx
+++ b/src/components/manifold-plan-details/components/ConfigurableFeature.tsx
@@ -2,6 +2,7 @@ import { h, FunctionalComponent } from '@stencil/core';
 import { $ } from '../../../utils/currency';
 import { PlanConfigurableFeatureEdge, PlanFeatureType } from '../../../types/graphql';
 import { Option } from '../../../types/Select';
+import { fixedDisplayValue } from './FixedFeature';
 
 interface ConfigurableFeatureProps {
   configurableFeature?: PlanConfigurableFeatureEdge;
@@ -34,6 +35,31 @@ const ConfigurableFeature: FunctionalComponent<ConfigurableFeatureProps> = ({
    * </manifold-tooltip>
    */
 
+  if (readOnly) {
+    let displayValue;
+
+    switch (typeof value) {
+      case 'boolean':
+        displayValue = fixedDisplayValue(
+          featureOptions?.find(o => o.value === `${value ? 'true' : 'false'}`)?.displayName
+        );
+        break;
+      case 'string':
+        displayValue = fixedDisplayValue(featureOptions?.find(o => o.value === value)?.displayName);
+        break;
+      case 'number':
+        displayValue = `${value} ${numericDetails && numericDetails.unit}`;
+        break;
+      default:
+        displayValue = <em>No value selected.</em>;
+    }
+
+    return [
+      <dt class="feature-name">{displayName}</dt>,
+      <dd class="feature-value">{displayValue}</dd>,
+    ];
+  }
+
   switch (type) {
     // string
     case PlanFeatureType.String: {
@@ -56,7 +82,6 @@ const ConfigurableFeature: FunctionalComponent<ConfigurableFeatureProps> = ({
             options={selectOptions}
             onUpdateValue={onChange}
             defaultValue={(defaultOption && `${defaultOption.value}`) || undefined}
-            disabled={readOnly}
           />
         </dd>,
       ];

--- a/src/components/manifold-plan-details/components/FixedFeature.tsx
+++ b/src/components/manifold-plan-details/components/FixedFeature.tsx
@@ -1,0 +1,38 @@
+import { h, FunctionalComponent } from '@stencil/core';
+import { check } from '@manifoldco/icons';
+import { PlanFixedFeatureEdge } from '../../../types/graphql';
+
+export const fixedDisplayValue = (displayValue: string = '') => {
+  // normalize true/false features
+  if (['true', 'yes'].includes(displayValue.toLowerCase())) {
+    return (
+      <span class="value" data-value="true">
+        <manifold-icon class="icon" icon={check} marginRight /> YES
+      </span>
+    );
+  }
+  if (['false', 'no', 'none'].includes(displayValue.toLowerCase())) {
+    return (
+      <span class="value" data-value="false">
+        NO
+      </span>
+    );
+  }
+  return displayValue;
+};
+
+interface FixedFeatureProps {
+  fixedFeature: PlanFixedFeatureEdge;
+}
+
+const FixedFeature: FunctionalComponent<FixedFeatureProps> = ({ fixedFeature }) => {
+  const {
+    node: { displayName, displayValue },
+  } = fixedFeature;
+  return [
+    <dt class="feature-name">{displayName}</dt>,
+    <dd class="feature-value">{fixedDisplayValue(displayValue)}</dd>,
+  ];
+};
+
+export default FixedFeature;

--- a/src/components/manifold-plan-details/manifold-plan-details.spec.ts
+++ b/src/components/manifold-plan-details/manifold-plan-details.spec.ts
@@ -50,6 +50,7 @@ describe('<manifold-plan-details>', () => {
             regionId: region && region.id,
             regionName: region && region.displayName,
             freePlan: paidPlan.free,
+            configuredFeatures: {},
           },
         })
       );
@@ -79,6 +80,7 @@ describe('<manifold-plan-details>', () => {
             regionId: region && region.id,
             regionName: region && region.displayName,
             freePlan: freePlan.free,
+            configuredFeatures: {},
           },
         })
       );

--- a/src/components/manifold-plan-details/manifold-plan-details.tsx
+++ b/src/components/manifold-plan-details/manifold-plan-details.tsx
@@ -71,12 +71,6 @@ export class ManifoldPlanDetails {
     this.regionId = newRegion;
   }
 
-  @Watch('configuredFeatures') configuredFeaturesChange(configuredFeatures: Gateway.FeatureMap) {
-    if (this.plan) {
-      this.resetFeatures(this.plan, configuredFeatures);
-    }
-  }
-
   @loadMark()
   componentWillLoad() {
     if (this.resourceRegion) {
@@ -102,11 +96,6 @@ export class ManifoldPlanDetails {
       // reset features
       this.resetFeatures(this.plan, this.configuredFeatures);
     }
-
-    console.log('componentWillLoad', {
-      configuredFeatures: this.configuredFeatures,
-      readOnly: this.readOnly,
-    });
   }
 
   handleChangeValue = ({ detail: { name, value } }: CustomEvent) => {
@@ -203,15 +192,13 @@ export class ManifoldPlanDetails {
     return options;
   }
 
-  resetFeatures = (plan: Plan, configuredFeatures?: Gateway.FeatureMap) => {
-    if (plan.configurableFeatures && configuredFeatures) {
-      console.log('reset', {
-        configuredFeatures: this.configuredFeatures,
-        readOnly: this.readOnly,
-      });
-      this.features = this.readOnly
-        ? configuredFeatures
-        : configurableFeatureDefaults(plan.configurableFeatures.edges);
+  resetFeatures = (plan: Plan, configuredFeatures: Gateway.FeatureMap = {}) => {
+    if (plan.configurableFeatures) {
+      if (this.readOnly && this.isExistingResource) {
+        this.features = configuredFeatures;
+      } else {
+        this.features = configurableFeatureDefaults(plan.configurableFeatures.edges);
+      }
     } else {
       this.features = {};
     }
@@ -219,10 +206,6 @@ export class ManifoldPlanDetails {
 
   @logger()
   render() {
-    console.log('render', {
-      configuredFeatures: this.configuredFeatures,
-      readOnly: this.readOnly,
-    });
     if (this.plan && this.product) {
       return (
         <section

--- a/src/components/manifold-plan-details/manifold-plan-details.tsx
+++ b/src/components/manifold-plan-details/manifold-plan-details.tsx
@@ -28,6 +28,7 @@ interface EventDetail {
 })
 export class ManifoldPlanDetails {
   @Element() el: HTMLElement;
+  @Prop() readOnly?: boolean = false;
   @Prop() isExistingResource?: boolean = false;
   @Prop() scrollLocked?: boolean = false;
   @Prop() plan?: Plan;
@@ -252,6 +253,7 @@ export class ManifoldPlanDetails {
                     onChange={this.handleChangeValue}
                     configurableFeature={configurableFeature}
                     value={this.features[configurableFeature.node.label]}
+                    readOnly={this.readOnly}
                   />
                 ))}
             </dl>

--- a/src/components/manifold-plan-details/manifold-plan-details.tsx
+++ b/src/components/manifold-plan-details/manifold-plan-details.tsx
@@ -19,7 +19,7 @@ interface EventDetail {
   regionId?: string;
   regionName?: string;
   freePlan: boolean;
-  configuredfeatures?: Gateway.FeatureMap;
+  configuredFeatures?: Gateway.FeatureMap;
 }
 
 @Component({
@@ -53,7 +53,7 @@ export class ManifoldPlanDetails {
       regionId: defaultRegion && defaultRegion.id,
       regionName: defaultRegion && defaultRegion.displayName,
       freePlan: newPlan.free,
-      // configuredFeatures: this.features,
+      configuredFeatures: this.features,
     };
 
     if (!oldPlan) {
@@ -78,8 +78,7 @@ export class ManifoldPlanDetails {
   }
 
   @loadMark()
-  @loadMark()
-  componentDidLoad() {
+  componentWillLoad() {
     if (this.resourceRegion) {
       this.regionId = this.resourceRegion;
     }
@@ -96,12 +95,18 @@ export class ManifoldPlanDetails {
         regionId: defaultRegion && defaultRegion.id,
         regionName: defaultRegion && defaultRegion.displayName,
         freePlan: this.plan.free,
-        // configuredFeatures: this.features,
+        configuredFeatures: this.features,
       };
       this.planLoad.emit(detail);
+
       // reset features
-      this.resetFeatures(this.plan);
+      this.resetFeatures(this.plan, this.configuredFeatures);
     }
+
+    console.log('componentWillLoad', {
+      configuredFeatures: this.configuredFeatures,
+      readOnly: this.readOnly,
+    });
   }
 
   handleChangeValue = ({ detail: { name, value } }: CustomEvent) => {
@@ -118,7 +123,7 @@ export class ManifoldPlanDetails {
         regionId: defaultRegion && defaultRegion.id,
         regionName: defaultRegion && defaultRegion.displayName,
         freePlan: this.plan.free,
-        // configuredFeatures: features,
+        configuredFeatures: features,
       };
       this.planUpdate.emit(detail);
     }
@@ -140,7 +145,7 @@ export class ManifoldPlanDetails {
         regionId: e.detail.value,
         regionName: defaultRegion && defaultRegion.displayName,
         freePlan: this.plan.free,
-        // configuredFeatures: this.features,
+        configuredFeatures: this.features,
       };
       this.planUpdate.emit(detail);
     }
@@ -199,9 +204,14 @@ export class ManifoldPlanDetails {
   }
 
   resetFeatures = (plan: Plan, configuredFeatures?: Gateway.FeatureMap) => {
-    if (plan.configurableFeatures) {
-      this.features =
-        configuredFeatures || configurableFeatureDefaults(plan.configurableFeatures.edges);
+    if (plan.configurableFeatures && configuredFeatures) {
+      console.log('reset', {
+        configuredFeatures: this.configuredFeatures,
+        readOnly: this.readOnly,
+      });
+      this.features = this.readOnly
+        ? configuredFeatures
+        : configurableFeatureDefaults(plan.configurableFeatures.edges);
     } else {
       this.features = {};
     }
@@ -209,6 +219,10 @@ export class ManifoldPlanDetails {
 
   @logger()
   render() {
+    console.log('render', {
+      configuredFeatures: this.configuredFeatures,
+      readOnly: this.readOnly,
+    });
     if (this.plan && this.product) {
       return (
         <section

--- a/src/components/manifold-plan-selector/resource.graphql
+++ b/src/components/manifold-plan-selector/resource.graphql
@@ -4,7 +4,6 @@ query Resource($resourceLabel: String!) {
       edges {
         node {
           label
-
           ... on BooleanConfiguredFeature {
             booleanValue: value
           }

--- a/src/components/manifold-plan-selector/resource.graphql
+++ b/src/components/manifold-plan-selector/resource.graphql
@@ -1,5 +1,22 @@
 query Resource($resourceLabel: String!) {
   resource(label: $resourceLabel) {
+    configuredFeatures(first: 500) {
+      edges {
+        node {
+          label
+
+          ... on BooleanConfiguredFeature {
+            booleanValue: value
+          }
+          ... on NumberConfiguredFeature {
+            numberValue: value
+          }
+          ... on StringConfiguredFeature {
+            stringValue: value
+          }
+        }
+      }
+    }
     region {
       id
       displayName

--- a/src/components/manifold-resource-container/resource.graphql
+++ b/src/components/manifold-resource-container/resource.graphql
@@ -10,6 +10,23 @@ query getResource($resourceLabel: String!) {
       label
       message
     }
+    configuredFeatures(first: 500) {
+      edges {
+        node {
+          label
+
+          ... on BooleanConfiguredFeature {
+            booleanValue: value
+          }
+          ... on NumberConfiguredFeature {
+            numberValue: value
+          }
+          ... on StringConfiguredFeature {
+            stringValue: value
+          }
+        }
+      }
+    }
     plan {
       id
       label
@@ -101,6 +118,8 @@ query getResource($resourceLabel: String!) {
               cost
             }
             numericDetails {
+              min
+              max
               unit
               costTiers {
                 limit

--- a/src/components/manifold-resource-container/resource.graphql
+++ b/src/components/manifold-resource-container/resource.graphql
@@ -14,7 +14,6 @@ query getResource($resourceLabel: String!) {
       edges {
         node {
           label
-
           ... on BooleanConfiguredFeature {
             booleanValue: value
           }

--- a/src/components/manifold-resource-plan/manifold-resource-plan.tsx
+++ b/src/components/manifold-resource-plan/manifold-resource-plan.tsx
@@ -26,7 +26,7 @@ export class ManifoldResourcePlan {
         </manifold-plan-details>
       );
     }
-    console.log('RESOURCE', formatGatewayFeatures(this.gqlData?.configuredFeatures?.edges));
+
     return (
       <manifold-plan-details
         scrollLocked={false}

--- a/src/components/manifold-resource-plan/manifold-resource-plan.tsx
+++ b/src/components/manifold-resource-plan/manifold-resource-plan.tsx
@@ -31,12 +31,12 @@ export class ManifoldResourcePlan {
     return (
       <manifold-plan-details
         scrollLocked={false}
+        configuredFeatures={formatGatewayFeatures(this.gqlData?.configuredFeatures?.edges)}
+        isExistingResource
+        readOnly
         plan={this.gqlData.plan}
         product={this.gqlData.plan.product as Product}
         region={this.gqlData.region as Region}
-        isExistingResource
-        configuredFeatures={formatGatewayFeatures(this.gqlData?.configuredFeatures?.edges)}
-        readOnly={true}
       >
         <manifold-forward-slot slot="cta">
           <slot name="cta" />

--- a/src/components/manifold-resource-plan/manifold-resource-plan.tsx
+++ b/src/components/manifold-resource-plan/manifold-resource-plan.tsx
@@ -27,6 +27,7 @@ export class ManifoldResourcePlan {
       );
     }
 
+    // TODO: remove `as` and update types
     return (
       <manifold-plan-details
         scrollLocked={false}
@@ -35,7 +36,7 @@ export class ManifoldResourcePlan {
         region={this.gqlData.region as Region}
         isExistingResource
         configuredFeatures={formatGatewayFeatures(this.gqlData?.configuredFeatures?.edges)}
-        readOnly
+        readOnly={true}
       >
         <manifold-forward-slot slot="cta">
           <slot name="cta" />

--- a/src/components/manifold-resource-plan/manifold-resource-plan.tsx
+++ b/src/components/manifold-resource-plan/manifold-resource-plan.tsx
@@ -4,6 +4,7 @@ import ResourceTunnel from '../../data/resource';
 import logger from '../../utils/logger';
 import loadMark from '../../utils/loadMark';
 import { GetResourceQuery, Product, Region } from '../../types/graphql';
+import { formatGatewayFeatures } from '../../utils/configuredFeatures';
 
 @Component({ tag: 'manifold-resource-plan' })
 export class ManifoldResourcePlan {
@@ -25,8 +26,7 @@ export class ManifoldResourcePlan {
         </manifold-plan-details>
       );
     }
-
-    // TODO: remove `as` and update types
+    console.log('RESOURCE', formatGatewayFeatures(this.gqlData?.configuredFeatures?.edges));
     return (
       <manifold-plan-details
         scrollLocked={false}
@@ -34,6 +34,7 @@ export class ManifoldResourcePlan {
         product={this.gqlData.plan.product as Product}
         region={this.gqlData.region as Region}
         isExistingResource
+        configuredFeatures={formatGatewayFeatures(this.gqlData?.configuredFeatures?.edges)}
         readOnly
       >
         <manifold-forward-slot slot="cta">

--- a/src/components/manifold-resource-plan/manifold-resource-plan.tsx
+++ b/src/components/manifold-resource-plan/manifold-resource-plan.tsx
@@ -34,6 +34,7 @@ export class ManifoldResourcePlan {
         product={this.gqlData.plan.product as Product}
         region={this.gqlData.region as Region}
         isExistingResource
+        readOnly
       >
         <manifold-forward-slot slot="cta">
           <slot name="cta" />

--- a/src/components/manifold-select/manifold-select.tsx
+++ b/src/components/manifold-select/manifold-select.tsx
@@ -13,6 +13,7 @@ export class ManifoldSelect {
   @Prop() name: string;
   @Prop() options: Option[] = [];
   @Prop() required?: boolean;
+  @Prop() disabled?: boolean;
   @Event() updateValue: EventEmitter;
   @Watch('defaultValue') watchHandler(newVal: string) {
     this.updateValue.emit({ name: this.name, value: newVal });
@@ -32,7 +33,12 @@ export class ManifoldSelect {
   @logger()
   render() {
     return (
-      <select name={this.name} required={this.required} onChange={this.onChangeHandler}>
+      <select
+        name={this.name}
+        required={this.required}
+        onChange={this.onChangeHandler}
+        disabled={this.disabled}
+      >
         {this.options.map(({ label, value }) => (
           <option value={value} selected={value === this.defaultValue}>
             {label}

--- a/src/spec/graphql.schema.json
+++ b/src/spec/graphql.schema.json
@@ -495,6 +495,80 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "region",
+            "description": "",
+            "args": [
+              {
+                "name": "id",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Region",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "regions",
+            "description": "",
+            "args": [
+              {
+                "name": "first",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "after",
+                "description": "",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "orderBy",
+                "description": "",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "RegionsOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "RegionConnection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -4863,6 +4937,43 @@
             "deprecationReason": null
           },
           {
+            "name": "configuredFeatures",
+            "description": "",
+            "args": [
+              {
+                "name": "first",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "after",
+                "description": "",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ConfiguredFeatureConnection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "credentials",
             "description": "",
             "args": [
@@ -5028,6 +5139,143 @@
           }
         ],
         "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ConfiguredFeatureConnection",
+        "description": "",
+        "fields": [
+          {
+            "name": "pageInfo",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "edges",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ConfiguredFeatureEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ConfiguredFeatureEdge",
+        "description": "",
+        "fields": [
+          {
+            "name": "cursor",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INTERFACE",
+                "name": "ConfiguredFeature",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INTERFACE",
+        "name": "ConfiguredFeature",
+        "description": "",
+        "fields": [
+          {
+            "name": "label",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "BooleanConfiguredFeature",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "NumberConfiguredFeature",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "StringConfiguredFeature",
+            "ofType": null
+          }
+        ]
       },
       {
         "kind": "OBJECT",
@@ -7517,6 +7765,55 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "BooleanConfiguredFeature",
+        "description": "",
+        "fields": [
+          {
+            "name": "label",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "value",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "ConfiguredFeature",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "InvoicePreviewOrderBy",
         "description": "",
@@ -7570,6 +7867,104 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "NumberConfiguredFeature",
+        "description": "",
+        "fields": [
+          {
+            "name": "label",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "value",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "ConfiguredFeature",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "StringConfiguredFeature",
+        "description": "",
+        "fields": [
+          {
+            "name": "label",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "value",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "ConfiguredFeature",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
         "possibleTypes": null
       }
     ],

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -10,6 +10,12 @@ export type Scalars = {
   Time: any,
 };
 
+export type BooleanConfiguredFeature = ConfiguredFeature & {
+   __typename?: 'BooleanConfiguredFeature',
+  label: Scalars['String'],
+  value: Scalars['Boolean'],
+};
+
 export enum CalculationType {
   Prorate = 'PRORATE',
   UsageTier = 'USAGE_TIER'
@@ -65,6 +71,22 @@ export enum ConfigurableFeaturesOrderByField {
   Label = 'LABEL',
   DisplayName = 'DISPLAY_NAME'
 }
+
+export type ConfiguredFeature = {
+  label: Scalars['String'],
+};
+
+export type ConfiguredFeatureConnection = {
+   __typename?: 'ConfiguredFeatureConnection',
+  pageInfo: PageInfo,
+  edges: Array<ConfiguredFeatureEdge>,
+};
+
+export type ConfiguredFeatureEdge = {
+   __typename?: 'ConfiguredFeatureEdge',
+  cursor: Scalars['String'],
+  node: ConfiguredFeature,
+};
 
 export type CreateProfileAuthTokenInput = {
   profileId: Scalars['ProfileIdentity'],
@@ -301,6 +323,12 @@ export type MutationUpdateProfileStateArgs = {
 
 export type Node = {
   id: Scalars['ID'],
+};
+
+export type NumberConfiguredFeature = ConfiguredFeature & {
+   __typename?: 'NumberConfiguredFeature',
+  label: Scalars['String'],
+  value: Scalars['Int'],
 };
 
 export enum OrderByDirection {
@@ -678,6 +706,8 @@ export type Query = {
   profiles?: Maybe<ProfileConnection>,
   invoice?: Maybe<Invoice>,
   lineItem?: Maybe<LineItem>,
+  region?: Maybe<Region>,
+  regions?: Maybe<RegionConnection>,
 };
 
 
@@ -759,6 +789,18 @@ export type QueryLineItemArgs = {
   id: Scalars['ID']
 };
 
+
+export type QueryRegionArgs = {
+  id: Scalars['ID']
+};
+
+
+export type QueryRegionsArgs = {
+  first: Scalars['Int'],
+  after?: Maybe<Scalars['String']>,
+  orderBy?: Maybe<RegionsOrderBy>
+};
+
 export type Region = Node & {
    __typename?: 'Region',
   id: Scalars['ID'],
@@ -806,7 +848,14 @@ export type Resource = Node & {
   region?: Maybe<Region>,
   owner?: Maybe<Profile>,
   createdAt?: Maybe<Scalars['Time']>,
+  configuredFeatures?: Maybe<ConfiguredFeatureConnection>,
   credentials?: Maybe<CredentialConnection>,
+};
+
+
+export type ResourceConfiguredFeaturesArgs = {
+  first: Scalars['Int'],
+  after?: Maybe<Scalars['String']>
 };
 
 
@@ -851,6 +900,12 @@ export type RevenueShare = {
   platform: Scalars['Int'],
   manifold: Scalars['Int'],
   fees: Scalars['Int'],
+};
+
+export type StringConfiguredFeature = ConfiguredFeature & {
+   __typename?: 'StringConfiguredFeature',
+  label: Scalars['String'],
+  value: Scalars['String'],
 };
 
 export type SubLineItem = {
@@ -1434,7 +1489,25 @@ export type ResourceQuery = (
   { __typename?: 'Query' }
   & { resource: Maybe<(
     { __typename?: 'Resource' }
-    & { region: Maybe<(
+    & { configuredFeatures: Maybe<(
+      { __typename?: 'ConfiguredFeatureConnection' }
+      & { edges: Array<(
+        { __typename?: 'ConfiguredFeatureEdge' }
+        & { node: (
+          { __typename?: 'BooleanConfiguredFeature' }
+          & Pick<BooleanConfiguredFeature, 'label'>
+          & { booleanValue: BooleanConfiguredFeature['value'] }
+        ) | (
+          { __typename?: 'NumberConfiguredFeature' }
+          & Pick<NumberConfiguredFeature, 'label'>
+          & { numberValue: NumberConfiguredFeature['value'] }
+        ) | (
+          { __typename?: 'StringConfiguredFeature' }
+          & Pick<StringConfiguredFeature, 'label'>
+          & { stringValue: StringConfiguredFeature['value'] }
+        ) }
+      )> }
+    )>, region: Maybe<(
       { __typename?: 'Region' }
       & Pick<Region, 'id' | 'displayName'>
     )>, plan: Maybe<(
@@ -1611,7 +1684,25 @@ export type GetResourceQuery = (
     )>, status: (
       { __typename?: 'ResourceStatus' }
       & Pick<ResourceStatus, 'label' | 'message'>
-    ), plan: Maybe<(
+    ), configuredFeatures: Maybe<(
+      { __typename?: 'ConfiguredFeatureConnection' }
+      & { edges: Array<(
+        { __typename?: 'ConfiguredFeatureEdge' }
+        & { node: (
+          { __typename?: 'BooleanConfiguredFeature' }
+          & Pick<BooleanConfiguredFeature, 'label'>
+          & { booleanValue: BooleanConfiguredFeature['value'] }
+        ) | (
+          { __typename?: 'NumberConfiguredFeature' }
+          & Pick<NumberConfiguredFeature, 'label'>
+          & { numberValue: NumberConfiguredFeature['value'] }
+        ) | (
+          { __typename?: 'StringConfiguredFeature' }
+          & Pick<StringConfiguredFeature, 'label'>
+          & { stringValue: StringConfiguredFeature['value'] }
+        ) }
+      )> }
+    )>, plan: Maybe<(
       { __typename?: 'Plan' }
       & Pick<Plan, 'id' | 'label' | 'displayName' | 'state' | 'cost' | 'free'>
       & { regions: Maybe<(
@@ -1680,7 +1771,7 @@ export type GetResourceQuery = (
               & Pick<PlanConfigurableFeatureOption, 'displayName' | 'value' | 'cost'>
             )>>, numericDetails: Maybe<(
               { __typename?: 'PlanConfigurableFeatureNumericDetails' }
-              & Pick<PlanConfigurableFeatureNumericDetails, 'unit'>
+              & Pick<PlanConfigurableFeatureNumericDetails, 'min' | 'max' | 'unit'>
               & { costTiers: Maybe<Array<(
                 { __typename?: 'PlanFeatureCostTier' }
                 & Pick<PlanFeatureCostTier, 'limit' | 'cost'>

--- a/src/utils/configuredFeatures.ts
+++ b/src/utils/configuredFeatures.ts
@@ -28,9 +28,9 @@ export const formatConfiguredFeatures = (
 
 export const formatGatewayFeatures = (
   configuredFeatures?: ConfiguredFeatureGraphQL[]
-): Gateway.FeatureMap | undefined => {
+): Gateway.FeatureMap => {
   if (!configuredFeatures || configuredFeatures?.length === 0) {
-    return undefined;
+    return {};
   }
   return Array.isArray(configuredFeatures)
     ? configuredFeatures.reduce(
@@ -42,5 +42,5 @@ export const formatGatewayFeatures = (
         }),
         {}
       )
-    : undefined;
+    : {};
 };

--- a/src/utils/configuredFeatures.ts
+++ b/src/utils/configuredFeatures.ts
@@ -1,0 +1,46 @@
+import { Gateway } from 'types/gateway';
+
+export interface ConfiguredFeatureGraphQL {
+  node: {
+    label: string;
+    booleanValue?: boolean;
+    numberValue?: number;
+    stringValue?: string;
+  };
+}
+
+export interface ConfiguredFeature {
+  label: string;
+  value?: string;
+}
+
+const isDefined = (x: unknown) => typeof x !== 'undefined';
+
+export const formatConfiguredFeatures = (
+  configuredFeatures: ConfiguredFeatureGraphQL[]
+): ConfiguredFeature[] =>
+  configuredFeatures.map(({ node: { label, ...f } }) => ({
+    label,
+    ...(isDefined(f.booleanValue) ? { value: `${f.booleanValue}` } : {}),
+    ...(isDefined(f.numberValue) ? { value: `${f.numberValue}` } : {}),
+    ...(isDefined(f.stringValue) ? { value: f.stringValue } : {}),
+  }));
+
+export const formatGatewayFeatures = (
+  configuredFeatures?: ConfiguredFeatureGraphQL[]
+): Gateway.FeatureMap | undefined => {
+  if (!configuredFeatures || configuredFeatures?.length === 0) {
+    return undefined;
+  }
+  return Array.isArray(configuredFeatures)
+    ? configuredFeatures.reduce(
+        (featureMap, { node: f }) => ({
+          ...featureMap,
+          ...(isDefined(f.booleanValue) ? { [f.label]: f.booleanValue } : {}),
+          ...(isDefined(f.numberValue) ? { [f.label]: f.numberValue } : {}),
+          ...(isDefined(f.stringValue) ? { [f.label]: f.stringValue } : {}),
+        }),
+        {}
+      )
+    : undefined;
+};

--- a/src/utils/configuredFeatures.ts
+++ b/src/utils/configuredFeatures.ts
@@ -9,22 +9,7 @@ export interface ConfiguredFeatureGraphQL {
   };
 }
 
-export interface ConfiguredFeature {
-  label: string;
-  value?: string;
-}
-
 const isDefined = (x: unknown) => typeof x !== 'undefined';
-
-export const formatConfiguredFeatures = (
-  configuredFeatures: ConfiguredFeatureGraphQL[]
-): ConfiguredFeature[] =>
-  configuredFeatures.map(({ node: { label, ...f } }) => ({
-    label,
-    ...(isDefined(f.booleanValue) ? { value: `${f.booleanValue}` } : {}),
-    ...(isDefined(f.numberValue) ? { value: `${f.numberValue}` } : {}),
-    ...(isDefined(f.stringValue) ? { value: f.stringValue } : {}),
-  }));
 
 export const formatGatewayFeatures = (
   configuredFeatures?: ConfiguredFeatureGraphQL[]

--- a/src/utils/plan.ts
+++ b/src/utils/plan.ts
@@ -158,7 +158,6 @@ export function configurableFeatureDefaults(configurableFeatures: PlanConfigurab
   const defaultFeatures: Gateway.FeatureMap = {};
 
   configurableFeatures.forEach(({ node: { label, numericDetails, featureOptions, type } }) => {
-    // console.log(label, type, numericDetails, featureOptions);
     switch (type) {
       case PlanFeatureType.Boolean: {
         defaultFeatures[label] = featureOptions?.[0].value === 'true';

--- a/src/utils/plan.ts
+++ b/src/utils/plan.ts
@@ -160,7 +160,7 @@ export function configurableFeatureDefaults(configurableFeatures: PlanConfigurab
   configurableFeatures.forEach(({ node: { label, numericDetails, featureOptions, type } }) => {
     switch (type) {
       case PlanFeatureType.Boolean: {
-        defaultFeatures[label] = featureOptions?.[0].value === 'true';
+        defaultFeatures[label] = false;
         break;
       }
       case PlanFeatureType.Number:

--- a/src/utils/plan.ts
+++ b/src/utils/plan.ts
@@ -157,17 +157,22 @@ export function planCost(restFetch: RestFetch, { planID, features, init }: PlanC
 export function configurableFeatureDefaults(configurableFeatures: PlanConfigurableFeatureEdge[]) {
   const defaultFeatures: Gateway.FeatureMap = {};
 
-  configurableFeatures.forEach(({ node: { label, numericDetails, options, type } }) => {
-    // if number feature
-    if (numericDetails) {
-      defaultFeatures[label] = numericDetails.min;
-    } else if (options && options[0]) {
-      const { label: value } = options[0];
-      if (type === PlanFeatureType.Boolean) {
-        defaultFeatures[label] = value === 'true';
-      } else {
-        defaultFeatures[label] = value;
+  configurableFeatures.forEach(({ node: { label, numericDetails, featureOptions, type } }) => {
+    // console.log(label, type, numericDetails, featureOptions);
+    switch (type) {
+      case PlanFeatureType.Boolean: {
+        defaultFeatures[label] = featureOptions?.[0].value === 'true';
+        break;
       }
+      case PlanFeatureType.Number:
+        defaultFeatures[label] = numericDetails?.min;
+        break;
+      case PlanFeatureType.String:
+        defaultFeatures[label] = featureOptions?.[0].value;
+        break;
+      default:
+        defaultFeatures[label] = undefined;
+        break;
     }
   });
 


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

Prevent inputs from being changed when viewing a resource plan. Only allow editing when resizing a plan. 

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->
These changes will require thorough testing of the plan selector, creating/resizing a resource, and vieing resource details. 

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
