### PR TITLE
Remove note about individually declared elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,6 @@ declare global {
 
 This will expose the types from Stencil to JSX, and you’ll be able to get typechecking as you write.
 
-_Note: Every element will have to be declared manually, at least until [this PR][ts-fix] is merged
-in TypeScript core._
 
 ### Ember, Angular, Vue, and others
 


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

The TypeScript setup section still had a note saying that type definitions had to be declared for each web component individually, which is no longer the case.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
