### PR TITLE
Enable dependabot automerge updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -16,3 +16,7 @@ update_configs:
       - match:
           dependency_name: 'puppeteer' # Version-managed by Stencil
           version_requirement: '*'
+    automerged_updates:
+      - match:
+          dependency_type: "all"
+          update_type: "all"


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

Dependabot PRs are auto-approving, but they're not auto-merging. Adding the `automerged_updates` configuration should allow for them to be merged. It's not clear to me, though, whether or not it will respect the `ignored_updates` section.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
