### PR TITLE
One timeout to rule them all

### DIFF
--- a/src/components/manifold-resource-container/manifold-resource-container.tsx
+++ b/src/components/manifold-resource-container/manifold-resource-container.tsx
@@ -63,13 +63,9 @@ export class ManifoldResourceContainer {
       this.resourceLoad.emit();
     }
 
-    if (
-      this.refetchUntilValid &&
-      (errors ||
-        !data ||
-        !data.resource ||
-        data.resource.status.label !== ResourceStatusLabel.Available)
-    ) {
+    const resourceNotAvailable = data?.resource?.status.label !== ResourceStatusLabel.Available;
+
+    if (this.refetchUntilValid && (errors || resourceNotAvailable)) {
       this.timeout = window.setTimeout(() => this.fetchResource(this.resourceLabel), 3000);
     }
   };

--- a/src/components/manifold-resource-container/manifold-resource-container.tsx
+++ b/src/components/manifold-resource-container/manifold-resource-container.tsx
@@ -65,15 +65,12 @@ export class ManifoldResourceContainer {
 
     if (
       this.refetchUntilValid &&
-      (!data || !data.resource || data.resource.status.label !== ResourceStatusLabel.Available)
+      (errors ||
+        !data ||
+        !data.resource ||
+        data.resource.status.label !== ResourceStatusLabel.Available)
     ) {
       this.timeout = window.setTimeout(() => this.fetchResource(this.resourceLabel), 3000);
-    }
-
-    if (errors) {
-      if (this.refetchUntilValid) {
-        this.timeout = window.setTimeout(() => this.fetchResource(this.resourceLabel), 3000);
-      }
     }
   };
 


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

When the `manifold-resource-container` gets a GraphQL error, it seems that it's actually setting _two_ timeouts to re-fetch the resource. Only one of these timeouts gets cleared when the component unmounts, so the other timeout keeps on going.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

This issue was discovered when testing team resources, so it's probably best to test this on Render as follows:

1. Make sure you're part of a team
2. Switch to the team context
3. Create a new resource
4. Click on the resource you created
5. Observe the GraphQL polling loop occurring on the resource page
6. Navigate to the home page
7. Make sure it's no longer polling

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
