### PR TITLE
Add owner id to resource container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Optionally accept ownerId in `manifold-resource-container` to fetch the resource by owner.
+
+### Fixed
+
+- Eliminated double refetch loop when `manifold-resource-container` encounters errors fetching the
+  resource.
+
 ## [0.9.4]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -6392,9 +6392,9 @@
       "dev": true
     },
     "@types/puppeteer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-2.0.1.tgz",
-      "integrity": "sha512-G8vEyU83Bios+dzs+DZGpAirDmMqRhfFBJCkFrg+A5+6n5EPPHxwBLImJto3qjh0mrBXbLBCyuahhhtTrAfR5g==",
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-1.20.4.tgz",
+      "integrity": "sha512-T/kFgyLnYWk0H94hxI0HbOLnqHvzBRpfS0F0oo9ESGI24oiC2fEjDcMbBjuK3wH7VLsaIsp740vVXVzR1dsMNg==",
       "dev": true,
       "requires": {
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manifoldco/ui",
   "description": "Manifold UI",
-  "version": "0.9.4-rc.0",
+  "version": "0.9.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/manifoldco/ui.git"
@@ -100,7 +100,7 @@
     "@storybook/html": "^5.2.5",
     "@types/fetch-mock": "^7.3.1",
     "@types/jest": "24.0.23",
-    "@types/puppeteer": "2.0.1",
+    "@types/puppeteer": "1.20.4",
     "@typescript-eslint/eslint-plugin": "^1.13.0",
     "@typescript-eslint/parser": "^1.13.0",
     "babel-loader": "^8.0.6",
@@ -125,8 +125,8 @@
     "stylelint-config-prettier": "^7.0.0",
     "stylelint-config-rational-order": "^0.1.2",
     "stylelint-config-standard": "^19.0.0",
-    "ts-loader": "^6.2.1",
     "testcafe": "^1.5.0",
+    "ts-loader": "^6.2.1",
     "wait-on": "^4.0.0",
     "webpack": "^4.41.2"
   }

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -519,6 +519,10 @@ export namespace Components {
     */
     'graphqlFetch'?: GraphqlFetch;
     /**
+    * OwnerId to filter resources by
+    */
+    'ownerId'?: string;
+    /**
     * Set whether or not to refetch the resource from the api until it is in an available and valid state
     */
     'refetchUntilValid'?: boolean;
@@ -1575,6 +1579,10 @@ declare namespace LocalJSX {
     */
     'graphqlFetch'?: GraphqlFetch;
     'onManifold-resource-load'?: (event: CustomEvent<any>) => void;
+    /**
+    * OwnerId to filter resources by
+    */
+    'ownerId'?: string;
     /**
     * Set whether or not to refetch the resource from the api until it is in an available and valid state
     */

--- a/src/components/manifold-plan-selector/resource.graphql
+++ b/src/components/manifold-plan-selector/resource.graphql
@@ -16,9 +16,6 @@ query Resource($resourceLabel: String!) {
         }
       }
     }
-    status {
-      label
-    }
     region {
       id
       displayName

--- a/src/components/manifold-plan-selector/resource.graphql
+++ b/src/components/manifold-plan-selector/resource.graphql
@@ -16,6 +16,9 @@ query Resource($resourceLabel: String!) {
         }
       }
     }
+    status {
+      label
+    }
     region {
       id
       displayName

--- a/src/components/manifold-resource-container/manifold-resource-container.tsx
+++ b/src/components/manifold-resource-container/manifold-resource-container.tsx
@@ -7,6 +7,7 @@ import loadMark from '../../utils/loadMark';
 import { ResourceStatusLabel, GetResourceQuery } from '../../types/graphql';
 import { GraphqlFetch } from '../../utils/graphqlFetch';
 import query from './resource.graphql';
+import queryWithOwner from './resource-with-owner.graphql';
 
 @Component({ tag: 'manifold-resource-container' })
 export class ManifoldResourceContainer {
@@ -17,6 +18,8 @@ export class ManifoldResourceContainer {
   @Prop() resourceLabel?: string;
   /** Set whether or not to refetch the resource from the api until it is in an available and valid state */
   @Prop() refetchUntilValid?: boolean = false;
+  /** OwnerId to filter resources by */
+  @Prop() ownerId?: string;
   @State() gqlData?: GetResourceQuery['resource'];
   @State() loading: boolean = true;
   @State() timeout?: number;
@@ -51,8 +54,8 @@ export class ManifoldResourceContainer {
     }
 
     const { data, errors } = await this.graphqlFetch<GetResourceQuery>({
-      query,
-      variables: { resourceLabel },
+      query: this.ownerId ? queryWithOwner : query,
+      variables: { resourceLabel, owner: this.ownerId },
       element: this.el,
     });
 
@@ -63,7 +66,7 @@ export class ManifoldResourceContainer {
       this.resourceLoad.emit();
     }
 
-    const resourceNotAvailable = data?.resource?.status.label !== ResourceStatusLabel.Available;
+    const resourceNotAvailable = data?.resource?.status?.label !== ResourceStatusLabel.Available;
 
     if (this.refetchUntilValid && (errors || resourceNotAvailable)) {
       this.timeout = window.setTimeout(() => this.fetchResource(this.resourceLabel), 3000);

--- a/src/components/manifold-resource-container/resource-with-owner.graphql
+++ b/src/components/manifold-resource-container/resource-with-owner.graphql
@@ -1,4 +1,4 @@
-query RESOURCE_WITH_OWNER($resourceLabel: String!, $owner: ProfileIdentity!) {
+query ResourceWithOwner($resourceLabel: String!, $owner: ProfileIdentity!) {
   resource(label: $resourceLabel, owner: $owner) {
     id
     label

--- a/src/components/manifold-resource-container/resource-with-owner.graphql
+++ b/src/components/manifold-resource-container/resource-with-owner.graphql
@@ -1,0 +1,133 @@
+query RESOURCE_WITH_OWNER($resourceLabel: String!, $owner: ProfileIdentity!) {
+  resource(label: $resourceLabel, owner: $owner) {
+    id
+    label
+    region {
+      id
+      displayName
+    }
+    status {
+      label
+      message
+    }
+    configuredFeatures(first: 500) {
+      edges {
+        node {
+          label
+          ... on BooleanConfiguredFeature {
+            booleanValue: value
+          }
+          ... on NumberConfiguredFeature {
+            numberValue: value
+          }
+          ... on StringConfiguredFeature {
+            stringValue: value
+          }
+        }
+      }
+    }
+    plan {
+      id
+      label
+      displayName
+      state
+      cost
+      free
+      regions(first: 20) {
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+          hasPreviousPage
+        }
+        edges {
+          node {
+            id
+            displayName
+            platform
+            dataCenter
+          }
+          cursor
+        }
+      }
+      product {
+        id
+        displayName
+        tagline
+        label
+        logoUrl
+      }
+      fixedFeatures(first: 20) {
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+          hasPreviousPage
+        }
+        edges {
+          cursor
+          node {
+            id
+            label
+            displayName
+            displayValue
+          }
+        }
+      }
+      meteredFeatures(first: 20) {
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+          hasPreviousPage
+        }
+        edges {
+          cursor
+          node {
+            id
+            label
+            displayName
+            numericDetails {
+              unit
+              costTiers {
+                limit
+                cost
+              }
+            }
+          }
+        }
+      }
+      configurableFeatures(first: 20) {
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+          hasPreviousPage
+        }
+        edges {
+          cursor
+          node {
+            id
+            label
+            displayName
+            type
+            featureOptions {
+              displayName
+              value
+              cost
+            }
+            numericDetails {
+              min
+              max
+              unit
+              costTiers {
+                limit
+                cost
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/spec/graphql.schema.json
+++ b/src/spec/graphql.schema.json
@@ -824,6 +824,16 @@
           },
           {
             "kind": "OBJECT",
+            "name": "ProductFixedFeature",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "ProductMeteredFeature",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "Invoice",
             "ofType": null
           },
@@ -1469,6 +1479,147 @@
                 "name": "ProductListing",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fixedFeatures",
+            "description": "",
+            "args": [
+              {
+                "name": "first",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "after",
+                "description": "",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "orderBy",
+                "description": "",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ProductFixedFeaturesOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ProductFixedFeatureConnection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "meteredFeatures",
+            "description": "",
+            "args": [
+              {
+                "name": "first",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "after",
+                "description": "",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "orderBy",
+                "description": "",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ProductMeteredFeaturesOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ProductMeteredFeatureConnection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "configurableFeatures",
+            "description": "",
+            "args": [
+              {
+                "name": "first",
+                "description": "",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "after",
+                "description": "",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "orderBy",
+                "description": "",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ProductConfigurableFeaturesOrderBy",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ProductConfigurableFeatureConnection",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3975,6 +4126,881 @@
         "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ProductFixedFeaturesOrderBy",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "field",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ProductFixedFeaturesOrderByField",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "direction",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "OrderByDirection",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "ProductFixedFeaturesOrderByField",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "LABEL",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProductFixedFeatureConnection",
+        "description": "",
+        "fields": [
+          {
+            "name": "pageInfo",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "edges",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ProductFixedFeatureEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProductFixedFeatureEdge",
+        "description": "",
+        "fields": [
+          {
+            "name": "cursor",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ProductFixedFeature",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProductFixedFeature",
+        "description": "",
+        "fields": [
+          {
+            "name": "id",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "label",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "displayName",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "featureOptions",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProductFixedFeatureOption",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Node",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProductFixedFeatureOption",
+        "description": "",
+        "fields": [
+          {
+            "name": "value",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "displayName",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ProductMeteredFeaturesOrderBy",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "field",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ProductMeteredFeaturesOrderByField",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "direction",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "OrderByDirection",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "ProductMeteredFeaturesOrderByField",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "LABEL",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProductMeteredFeatureConnection",
+        "description": "",
+        "fields": [
+          {
+            "name": "pageInfo",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "edges",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ProductMeteredFeatureEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProductMeteredFeatureEdge",
+        "description": "",
+        "fields": [
+          {
+            "name": "cursor",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ProductMeteredFeature",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProductMeteredFeature",
+        "description": "",
+        "fields": [
+          {
+            "name": "id",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "label",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "displayName",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "numericOptions",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProductMeteredFeatureNumericOptions",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Node",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProductMeteredFeatureNumericOptions",
+        "description": "",
+        "fields": [
+          {
+            "name": "label",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "displayName",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "numericDetails",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ProductMeteredFeatureNumericDetails",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProductMeteredFeatureNumericDetails",
+        "description": "",
+        "fields": [
+          {
+            "name": "unit",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costTiers",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ProductFeatureCostTier",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProductFeatureCostTier",
+        "description": "",
+        "fields": [
+          {
+            "name": "limit",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cost",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ProductConfigurableFeaturesOrderBy",
+        "description": "",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "field",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ProductConfigurableFeaturesOrderByField",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "direction",
+            "description": "",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "OrderByDirection",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "ProductConfigurableFeaturesOrderByField",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "LABEL",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProductConfigurableFeatureConnection",
+        "description": "",
+        "fields": [
+          {
+            "name": "pageInfo",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "edges",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ProductConfigurableFeatureEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProductConfigurableFeatureEdge",
+        "description": "",
+        "fields": [
+          {
+            "name": "cursor",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INTERFACE",
+                "name": "ProductConfigurableFeature",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INTERFACE",
+        "name": "ProductConfigurableFeature",
+        "description": "",
+        "fields": [
+          {
+            "name": "label",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "displayName",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "ProductBooleanConfigurableFeature",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "ProductNumberConfigurableFeature",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "ProductStringConfigurableFeature",
+            "ofType": null
+          }
+        ]
       },
       {
         "kind": "SCALAR",
@@ -7987,6 +9013,430 @@
           {
             "kind": "INTERFACE",
             "name": "ConfiguredFeature",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProductBooleanConfigurableFeature",
+        "description": "",
+        "fields": [
+          {
+            "name": "label",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "displayName",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "featureOptions",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProductConfigurableFeatureOption",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "ProductConfigurableFeature",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProductConfigurableFeatureOption",
+        "description": "",
+        "fields": [
+          {
+            "name": "value",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "displayName",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cost",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProductConfigurableFeatureNumericDetails",
+        "description": "",
+        "fields": [
+          {
+            "name": "increment",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "min",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "max",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unit",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "costTiers",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ProductFeatureCostTier",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProductConfigurableFeatureNumericOptions",
+        "description": "",
+        "fields": [
+          {
+            "name": "label",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "displayName",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "numericDetails",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ProductConfigurableFeatureNumericDetails",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProductNumberConfigurableFeature",
+        "description": "",
+        "fields": [
+          {
+            "name": "label",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "displayName",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "numericOptions",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProductConfigurableFeatureNumericOptions",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "ProductConfigurableFeature",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProductStringConfigurableFeature",
+        "description": "",
+        "fields": [
+          {
+            "name": "label",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "displayName",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "featureOptions",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProductConfigurableFeatureOption",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "ProductConfigurableFeature",
             "ofType": null
           }
         ],

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1855,13 +1855,13 @@ export type ResourceCardQuery = (
   )> }
 );
 
-export type Resource_With_OwnerQueryVariables = {
+export type ResourceWithOwnerQueryVariables = {
   resourceLabel: Scalars['String'],
   owner: Scalars['ProfileIdentity']
 };
 
 
-export type Resource_With_OwnerQuery = (
+export type ResourceWithOwnerQuery = (
   { __typename?: 'Query' }
   & { resource: Maybe<(
     { __typename?: 'Resource' }

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -559,6 +559,9 @@ export type Product = Node & {
   linkedCategories?: Maybe<CategoryConnection>,
   settings: ProductSettings,
   listing: ProductListing,
+  fixedFeatures?: Maybe<ProductFixedFeatureConnection>,
+  meteredFeatures?: Maybe<ProductMeteredFeatureConnection>,
+  configurableFeatures?: Maybe<ProductConfigurableFeatureConnection>,
 };
 
 
@@ -576,6 +579,83 @@ export type ProductLinkedCategoriesArgs = {
   after?: Maybe<Scalars['String']>,
   orderBy?: Maybe<CategoryOrderBy>
 };
+
+
+export type ProductFixedFeaturesArgs = {
+  first: Scalars['Int'],
+  after?: Maybe<Scalars['String']>,
+  orderBy?: Maybe<ProductFixedFeaturesOrderBy>
+};
+
+
+export type ProductMeteredFeaturesArgs = {
+  first: Scalars['Int'],
+  after?: Maybe<Scalars['String']>,
+  orderBy?: Maybe<ProductMeteredFeaturesOrderBy>
+};
+
+
+export type ProductConfigurableFeaturesArgs = {
+  first: Scalars['Int'],
+  after?: Maybe<Scalars['String']>,
+  orderBy?: Maybe<ProductConfigurableFeaturesOrderBy>
+};
+
+export type ProductBooleanConfigurableFeature = ProductConfigurableFeature & {
+   __typename?: 'ProductBooleanConfigurableFeature',
+  label: Scalars['String'],
+  displayName: Scalars['String'],
+  featureOptions?: Maybe<Array<ProductConfigurableFeatureOption>>,
+};
+
+export type ProductConfigurableFeature = {
+  label: Scalars['String'],
+  displayName: Scalars['String'],
+};
+
+export type ProductConfigurableFeatureConnection = {
+   __typename?: 'ProductConfigurableFeatureConnection',
+  pageInfo: PageInfo,
+  edges: Array<ProductConfigurableFeatureEdge>,
+};
+
+export type ProductConfigurableFeatureEdge = {
+   __typename?: 'ProductConfigurableFeatureEdge',
+  cursor: Scalars['String'],
+  node: ProductConfigurableFeature,
+};
+
+export type ProductConfigurableFeatureNumericDetails = {
+   __typename?: 'ProductConfigurableFeatureNumericDetails',
+  increment: Scalars['Int'],
+  min: Scalars['Int'],
+  max: Scalars['Int'],
+  unit: Scalars['String'],
+  costTiers: Array<ProductFeatureCostTier>,
+};
+
+export type ProductConfigurableFeatureNumericOptions = {
+   __typename?: 'ProductConfigurableFeatureNumericOptions',
+  label: Scalars['String'],
+  displayName: Scalars['String'],
+  numericDetails: ProductConfigurableFeatureNumericDetails,
+};
+
+export type ProductConfigurableFeatureOption = {
+   __typename?: 'ProductConfigurableFeatureOption',
+  value: Scalars['String'],
+  displayName: Scalars['String'],
+  cost: Scalars['Int'],
+};
+
+export type ProductConfigurableFeaturesOrderBy = {
+  field: ProductConfigurableFeaturesOrderByField,
+  direction: OrderByDirection,
+};
+
+export enum ProductConfigurableFeaturesOrderByField {
+  Label = 'LABEL'
+}
 
 export type ProductConnection = {
    __typename?: 'ProductConnection',
@@ -595,12 +675,102 @@ export type ProductEdge = {
   cursor: Scalars['String'],
 };
 
+export type ProductFeatureCostTier = {
+   __typename?: 'ProductFeatureCostTier',
+  limit: Scalars['Int'],
+  cost: Scalars['Int'],
+};
+
+export type ProductFixedFeature = Node & {
+   __typename?: 'ProductFixedFeature',
+  id: Scalars['ID'],
+  label: Scalars['String'],
+  displayName: Scalars['String'],
+  featureOptions?: Maybe<Array<ProductFixedFeatureOption>>,
+};
+
+export type ProductFixedFeatureConnection = {
+   __typename?: 'ProductFixedFeatureConnection',
+  pageInfo: PageInfo,
+  edges: Array<ProductFixedFeatureEdge>,
+};
+
+export type ProductFixedFeatureEdge = {
+   __typename?: 'ProductFixedFeatureEdge',
+  cursor: Scalars['String'],
+  node: ProductFixedFeature,
+};
+
+export type ProductFixedFeatureOption = {
+   __typename?: 'ProductFixedFeatureOption',
+  value: Scalars['String'],
+  displayName: Scalars['String'],
+};
+
+export type ProductFixedFeaturesOrderBy = {
+  field: ProductFixedFeaturesOrderByField,
+  direction: OrderByDirection,
+};
+
+export enum ProductFixedFeaturesOrderByField {
+  Label = 'LABEL'
+}
+
 export type ProductListing = {
    __typename?: 'ProductListing',
   beta: Scalars['Boolean'],
   new: Scalars['Boolean'],
   featured: Scalars['Boolean'],
   comingSoon: Scalars['Boolean'],
+};
+
+export type ProductMeteredFeature = Node & {
+   __typename?: 'ProductMeteredFeature',
+  id: Scalars['ID'],
+  label: Scalars['String'],
+  displayName: Scalars['String'],
+  numericOptions?: Maybe<Array<ProductMeteredFeatureNumericOptions>>,
+};
+
+export type ProductMeteredFeatureConnection = {
+   __typename?: 'ProductMeteredFeatureConnection',
+  pageInfo: PageInfo,
+  edges: Array<ProductMeteredFeatureEdge>,
+};
+
+export type ProductMeteredFeatureEdge = {
+   __typename?: 'ProductMeteredFeatureEdge',
+  cursor: Scalars['String'],
+  node: ProductMeteredFeature,
+};
+
+export type ProductMeteredFeatureNumericDetails = {
+   __typename?: 'ProductMeteredFeatureNumericDetails',
+  unit: Scalars['String'],
+  costTiers: Array<ProductFeatureCostTier>,
+};
+
+export type ProductMeteredFeatureNumericOptions = {
+   __typename?: 'ProductMeteredFeatureNumericOptions',
+  label: Scalars['String'],
+  displayName: Scalars['String'],
+  numericDetails: ProductMeteredFeatureNumericDetails,
+};
+
+export type ProductMeteredFeaturesOrderBy = {
+  field: ProductMeteredFeaturesOrderByField,
+  direction: OrderByDirection,
+};
+
+export enum ProductMeteredFeaturesOrderByField {
+  Label = 'LABEL'
+}
+
+export type ProductNumberConfigurableFeature = ProductConfigurableFeature & {
+   __typename?: 'ProductNumberConfigurableFeature',
+  label: Scalars['String'],
+  displayName: Scalars['String'],
+  numericOptions?: Maybe<Array<ProductConfigurableFeatureNumericOptions>>,
 };
 
 export type ProductOrderBy = {
@@ -631,6 +801,13 @@ export enum ProductState {
   New = 'NEW',
   Upcoming = 'UPCOMING'
 }
+
+export type ProductStringConfigurableFeature = ProductConfigurableFeature & {
+   __typename?: 'ProductStringConfigurableFeature',
+  label: Scalars['String'],
+  displayName: Scalars['String'],
+  featureOptions?: Maybe<Array<ProductConfigurableFeatureOption>>,
+};
 
 export type Profile = {
    __typename?: 'Profile',
@@ -1675,6 +1852,48 @@ export type ResourceCardQuery = (
       { __typename?: 'ResourceStatus' }
       & Pick<ResourceStatus, 'label'>
     ) }
+  )> }
+);
+
+export type Resource_With_OwnerQueryVariables = {
+  resourceLabel: Scalars['String'],
+  owner: Scalars['ProfileIdentity']
+};
+
+
+export type Resource_With_OwnerQuery = (
+  { __typename?: 'Query' }
+  & { resource: Maybe<(
+    { __typename?: 'Resource' }
+    & { configuredFeatures: Maybe<(
+      { __typename?: 'ConfiguredFeatureConnection' }
+      & { edges: Array<(
+        { __typename?: 'ConfiguredFeatureEdge' }
+        & { node: (
+          { __typename?: 'BooleanConfiguredFeature' }
+          & Pick<BooleanConfiguredFeature, 'label'>
+          & { booleanValue: BooleanConfiguredFeature['value'] }
+        ) | (
+          { __typename?: 'NumberConfiguredFeature' }
+          & Pick<NumberConfiguredFeature, 'label'>
+          & { numberValue: NumberConfiguredFeature['value'] }
+        ) | (
+          { __typename?: 'StringConfiguredFeature' }
+          & Pick<StringConfiguredFeature, 'label'>
+          & { stringValue: StringConfiguredFeature['value'] }
+        ) }
+      )> }
+    )>, region: Maybe<(
+      { __typename?: 'Region' }
+      & Pick<Region, 'id' | 'displayName'>
+    )>, plan: Maybe<(
+      { __typename?: 'Plan' }
+      & Pick<Plan, 'id'>
+      & { product: Maybe<(
+        { __typename?: 'Product' }
+        & Pick<Product, 'label'>
+      )> }
+    )> }
   )> }
 );
 

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1865,7 +1865,14 @@ export type Resource_With_OwnerQuery = (
   { __typename?: 'Query' }
   & { resource: Maybe<(
     { __typename?: 'Resource' }
-    & { configuredFeatures: Maybe<(
+    & Pick<Resource, 'id' | 'label'>
+    & { region: Maybe<(
+      { __typename?: 'Region' }
+      & Pick<Region, 'id' | 'displayName'>
+    )>, status: (
+      { __typename?: 'ResourceStatus' }
+      & Pick<ResourceStatus, 'label' | 'message'>
+    ), configuredFeatures: Maybe<(
       { __typename?: 'ConfiguredFeatureConnection' }
       & { edges: Array<(
         { __typename?: 'ConfiguredFeatureEdge' }
@@ -1883,15 +1890,83 @@ export type Resource_With_OwnerQuery = (
           & { stringValue: StringConfiguredFeature['value'] }
         ) }
       )> }
-    )>, region: Maybe<(
-      { __typename?: 'Region' }
-      & Pick<Region, 'id' | 'displayName'>
     )>, plan: Maybe<(
       { __typename?: 'Plan' }
-      & Pick<Plan, 'id'>
-      & { product: Maybe<(
+      & Pick<Plan, 'id' | 'label' | 'displayName' | 'state' | 'cost' | 'free'>
+      & { regions: Maybe<(
+        { __typename?: 'RegionConnection' }
+        & { pageInfo: (
+          { __typename?: 'PageInfo' }
+          & Pick<PageInfo, 'startCursor' | 'endCursor' | 'hasNextPage' | 'hasPreviousPage'>
+        ), edges: Array<(
+          { __typename?: 'RegionEdge' }
+          & Pick<RegionEdge, 'cursor'>
+          & { node: (
+            { __typename?: 'Region' }
+            & Pick<Region, 'id' | 'displayName' | 'platform' | 'dataCenter'>
+          ) }
+        )> }
+      )>, product: Maybe<(
         { __typename?: 'Product' }
-        & Pick<Product, 'label'>
+        & Pick<Product, 'id' | 'displayName' | 'tagline' | 'label' | 'logoUrl'>
+      )>, fixedFeatures: Maybe<(
+        { __typename?: 'PlanFixedFeatureConnection' }
+        & { pageInfo: (
+          { __typename?: 'PageInfo' }
+          & Pick<PageInfo, 'startCursor' | 'endCursor' | 'hasNextPage' | 'hasPreviousPage'>
+        ), edges: Array<(
+          { __typename?: 'PlanFixedFeatureEdge' }
+          & Pick<PlanFixedFeatureEdge, 'cursor'>
+          & { node: (
+            { __typename?: 'PlanFixedFeature' }
+            & Pick<PlanFixedFeature, 'id' | 'label' | 'displayName' | 'displayValue'>
+          ) }
+        )> }
+      )>, meteredFeatures: Maybe<(
+        { __typename?: 'PlanMeteredFeatureConnection' }
+        & { pageInfo: (
+          { __typename?: 'PageInfo' }
+          & Pick<PageInfo, 'startCursor' | 'endCursor' | 'hasNextPage' | 'hasPreviousPage'>
+        ), edges: Array<(
+          { __typename?: 'PlanMeteredFeatureEdge' }
+          & Pick<PlanMeteredFeatureEdge, 'cursor'>
+          & { node: (
+            { __typename?: 'PlanMeteredFeature' }
+            & Pick<PlanMeteredFeature, 'id' | 'label' | 'displayName'>
+            & { numericDetails: (
+              { __typename?: 'PlanMeteredFeatureNumericDetails' }
+              & Pick<PlanMeteredFeatureNumericDetails, 'unit'>
+              & { costTiers: Maybe<Array<(
+                { __typename?: 'PlanFeatureCostTier' }
+                & Pick<PlanFeatureCostTier, 'limit' | 'cost'>
+              )>> }
+            ) }
+          ) }
+        )> }
+      )>, configurableFeatures: Maybe<(
+        { __typename?: 'PlanConfigurableFeatureConnection' }
+        & { pageInfo: (
+          { __typename?: 'PageInfo' }
+          & Pick<PageInfo, 'startCursor' | 'endCursor' | 'hasNextPage' | 'hasPreviousPage'>
+        ), edges: Array<(
+          { __typename?: 'PlanConfigurableFeatureEdge' }
+          & Pick<PlanConfigurableFeatureEdge, 'cursor'>
+          & { node: (
+            { __typename?: 'PlanConfigurableFeature' }
+            & Pick<PlanConfigurableFeature, 'id' | 'label' | 'displayName' | 'type'>
+            & { featureOptions: Maybe<Array<(
+              { __typename?: 'PlanConfigurableFeatureOption' }
+              & Pick<PlanConfigurableFeatureOption, 'displayName' | 'value' | 'cost'>
+            )>>, numericDetails: Maybe<(
+              { __typename?: 'PlanConfigurableFeatureNumericDetails' }
+              & Pick<PlanConfigurableFeatureNumericDetails, 'min' | 'max' | 'unit'>
+              & { costTiers: Maybe<Array<(
+                { __typename?: 'PlanFeatureCostTier' }
+                & Pick<PlanFeatureCostTier, 'limit' | 'cost'>
+              )>> }
+            )> }
+          ) }
+        )> }
       )> }
     )> }
   )> }


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

![image](https://user-images.githubusercontent.com/374078/75705623-5849f580-5c81-11ea-8d29-475167de39b8.png)

## Reason for change

We need to be able to display resource details when viewing the resource in a team context.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

The below requires changes to the Render dashboard in order to pass through the owner ID. Render also makes a query that needs to pass this along, so that also needs to be adjusted.

1. Make sure you're part of a team
1. Log into Render
1. Switch to your team context
1. Go to the Addons tab
1. If any resources exist, click on them
1. If a resource doesn't exist, create one, and then click on it in the Addons page
1. The resource should display successfully without errors

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
