### PR TITLE
Add a small happo test to show how the fetch can be overridden on components

### DIFF
--- a/src/components/manifold-marketplace/manifold-marketplace-happo.ts
+++ b/src/components/manifold-marketplace/manifold-marketplace-happo.ts
@@ -1,5 +1,6 @@
 import connection from '../../state/connection';
-import { GraphqlFetch } from '../../utils/graphqlFetch';
+import { GraphqlFetch, GraphqlResponseBody } from '../../utils/graphqlFetch';
+import { ProductsQuery } from '../../types/graphql';
 
 export const skeleton = () => {
   const conn = document.createElement('manifold-connection');
@@ -26,6 +27,46 @@ export const allProducts = () => {
 
   const grid = document.createElement('manifold-marketplace');
   grid.hideUntilReady = true;
+
+  document.body.appendChild(grid);
+
+  return grid.componentOnReady();
+};
+
+export const mockedProducts = () => {
+  const conn = document.createElement('manifold-connection');
+  document.body.appendChild(conn);
+
+  const grid = document.createElement('manifold-marketplace');
+  grid.hideUntilReady = true;
+  grid.graphqlFetch = (async (): Promise<GraphqlResponseBody<ProductsQuery>> => ({
+    data: {
+      products: {
+        edges: [
+          {
+            node: {
+              id: '1234',
+              label: 'test',
+              displayName: 'Test',
+              logoUrl: 'https://www.placecage.com/c/200/300',
+              tagline: 'Testing',
+              categories: [
+                {
+                  label: 'cms',
+                },
+              ],
+              plans: {
+                edges: [],
+              },
+            },
+          },
+        ],
+        pageInfo: {
+          hasNextPage: false,
+        },
+      },
+    },
+  })) as GraphqlFetch;
 
   document.body.appendChild(grid);
 


### PR DESCRIPTION
## Reason for change

This PR aims at making sure that this behavior works and is not broken by subsequent PRs, it will be necessary for onboarding platforms who might not want to use our catalog data when making proof of concept.


## Testing

Run Happo

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [x] **Prop changes**: [docs][docs] were updated
- [x] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [x] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
