### PR TITLE
Add owner-id to more components

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -9,35 +9,35 @@ jobs:
       matrix:
         node-version: [10.x, 12.x, 13.x]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
       - run: npm install
       - run: npm run build
   bundlesize:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
       - run: npm install
       - run: npm run bundlesize
   changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
       - run: npm install
       - run: npm run format:changelog
   schema:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
       - run: npm install
       - run: npm run test:schema
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
       - run: npm install
       - run: npm run test:coverage
@@ -45,7 +45,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
       - run: npm install
       - run: npm run lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.5]
+## [Unreleased]
+
+### Fixed
+
+- Fixed `owner-id` not being used in all resource components.
+
+## [0.9.5] - 2020-03-02
 
 ### Added
 
@@ -16,7 +22,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Eliminated double refetch loop when `manifold-resource-container` encounters errors fetching the
   resource.
 
-## [0.9.4]
+## [0.9.4] - 2020-01-30
 
 ### Added
 
@@ -518,8 +524,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Changed the `manifold-resource-credentials` component to use the standalone `manifold-credentials`
   component.
 
-
-[0.9.5]: https://github.com/manifoldco/ui/compare/v0.9.3...v0.9.5
+[unreleased]: https://github.com/manifoldco/ui/compare/v0.9.5...HEAD
+[0.9.5]: https://github.com/manifoldco/ui/compare/v0.9.4...v0.9.5
 [0.9.4]: https://github.com/manifoldco/ui/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/manifoldco/ui/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/manifoldco/ui/compare/v0.9.1...v0.9.2

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -20,8 +20,10 @@ import {
   Region,
   Resource,
   ResourceCredentialsQuery,
+  ResourceCredentialsQueryVariables,
   ResourceStatusLabel,
   ResourceWithCredentialsQuery,
+  ResourceWithCredentialsQueryVariables,
 } from './types/graphql';
 import {
   Subscriber,
@@ -93,6 +95,7 @@ export namespace Components {
     * _(hidden)_ Passed by `<manifold-connection>`
     */
     'graphqlFetch'?: GraphqlFetch;
+    'ownerId'?: string;
     'refresh': () => Promise<void>;
     /**
     * The label of the resource to fetch credentials for
@@ -111,6 +114,7 @@ export namespace Components {
     */
     'graphqlFetch'?: GraphqlFetch;
     'noCredentials'?: boolean;
+    'ownerId'?: string;
     'resourceLabel'?: string;
     'showCredentials': () => Promise<void>;
   }
@@ -125,6 +129,7 @@ export namespace Components {
     */
     'graphqlFetch'?: GraphqlFetch;
     'loading'?: boolean;
+    'ownerId'?: string;
     /**
     * resource ID
     */
@@ -143,6 +148,7 @@ export namespace Components {
     * Disable auto-updates?
     */
     'label'?: string;
+    'ownerId'?: string;
     'paused'?: boolean;
   }
   interface ManifoldDataProductLogo {
@@ -164,6 +170,7 @@ export namespace Components {
     * _(hidden)_
     */
     'graphqlFetch'?: GraphqlFetch;
+    'ownerId'?: string;
     /**
     * URL-friendly slug (e.g. `"jawsdb-mysql"`)
     */
@@ -218,6 +225,7 @@ export namespace Components {
     * The new label to give to the resource
     */
     'newLabel'?: string;
+    'ownerId'?: string;
     /**
     * The id of the resource to rename, will be fetched if not set
     */
@@ -233,6 +241,7 @@ export namespace Components {
     * _(hidden)_ Passed by `<manifold-connection>`
     */
     'graphqlFetch'?: GraphqlFetch;
+    'ownerId'?: string;
     'planId'?: string;
     'resourceId'?: string;
     'resourceLabel'?: string;
@@ -268,6 +277,7 @@ export namespace Components {
     * _(hidden)_
     */
     'graphqlFetch'?: GraphqlFetch;
+    'ownerId'?: string;
     /**
     * Look up product logo from resource
     */
@@ -280,6 +290,7 @@ export namespace Components {
     */
     'graphqlFetch'?: GraphqlFetch;
     'loading'?: boolean;
+    'ownerId'?: string;
     /**
     * The id of the resource to rename, will be fetched if not set
     */
@@ -375,6 +386,7 @@ export namespace Components {
   }
   interface ManifoldNoCredentials {
     'graphqlFetch'?: GraphqlFetch;
+    'ownerId'?: string;
     'resourceLabel'?: string;
   }
   interface ManifoldNumberInput {
@@ -441,6 +453,7 @@ export namespace Components {
     */
     'graphqlFetch'?: GraphqlFetch;
     'hideUntilReady'?: boolean;
+    'ownerId'?: string;
     /**
     * URL-friendly slug (e.g. `"jawsdb-mysql"`)
     */
@@ -500,6 +513,7 @@ export namespace Components {
     */
     'graphqlFetch'?: GraphqlFetch;
     'label'?: string;
+    'ownerId'?: string;
     'preserveEvent'?: boolean;
     'resourceLinkFormat'?: string;
   }
@@ -535,11 +549,13 @@ export namespace Components {
     'gqlData'?: GetResourceQuery['resource'];
     'loading'?: boolean;
     'noCredentials'?: boolean;
+    'ownerId'?: string;
   }
   interface ManifoldResourceDeprovision {
     'disabled'?: boolean;
     'gqlData'?: GetResourceQuery['resource'];
     'loading'?: boolean;
+    'ownerId'?: string;
   }
   interface ManifoldResourceList {
     /**
@@ -579,11 +595,13 @@ export namespace Components {
     * The new label to give to the resource
     */
     'newLabel'?: string;
+    'ownerId'?: string;
   }
   interface ManifoldResourceSso {
     'disabled'?: boolean;
     'gqlData'?: GetResourceQuery['resource'];
     'loading'?: boolean;
+    'ownerId'?: string;
   }
   interface ManifoldResourceStatus {
     'gqlData'?: GetResourceQuery['resource'];
@@ -1127,6 +1145,7 @@ declare namespace LocalJSX {
     'graphqlFetch'?: GraphqlFetch;
     'onManifold-copyCredentials-error'?: (event: CustomEvent<any>) => void;
     'onManifold-copyCredentials-success'?: (event: CustomEvent<any>) => void;
+    'ownerId'?: string;
     /**
     * The label of the resource to fetch credentials for
     */
@@ -1144,6 +1163,7 @@ declare namespace LocalJSX {
     */
     'graphqlFetch'?: GraphqlFetch;
     'noCredentials'?: boolean;
+    'ownerId'?: string;
     'resourceLabel'?: string;
   }
   interface ManifoldCredentialsView {
@@ -1161,6 +1181,7 @@ declare namespace LocalJSX {
     'onManifold-deprovisionButton-click'?: (event: CustomEvent<any>) => void;
     'onManifold-deprovisionButton-error'?: (event: CustomEvent<any>) => void;
     'onManifold-deprovisionButton-success'?: (event: CustomEvent<any>) => void;
+    'ownerId'?: string;
     /**
     * resource ID
     */
@@ -1180,6 +1201,7 @@ declare namespace LocalJSX {
     */
     'label'?: string;
     'onManifold-hasResource-load'?: (event: CustomEvent<any>) => void;
+    'ownerId'?: string;
     'paused'?: boolean;
   }
   interface ManifoldDataProductLogo {
@@ -1201,6 +1223,7 @@ declare namespace LocalJSX {
     * _(hidden)_
     */
     'graphqlFetch'?: GraphqlFetch;
+    'ownerId'?: string;
     /**
     * URL-friendly slug (e.g. `"jawsdb-mysql"`)
     */
@@ -1263,6 +1286,7 @@ declare namespace LocalJSX {
     'onManifold-renameButton-error'?: (event: CustomEvent<any>) => void;
     'onManifold-renameButton-invalid'?: (event: CustomEvent<any>) => void;
     'onManifold-renameButton-success'?: (event: CustomEvent<any>) => void;
+    'ownerId'?: string;
     /**
     * The id of the resource to rename, will be fetched if not set
     */
@@ -1281,6 +1305,7 @@ declare namespace LocalJSX {
     'onManifold-resizeButton-click'?: (event: CustomEvent<any>) => void;
     'onManifold-resizeButton-error'?: (event: CustomEvent<any>) => void;
     'onManifold-resizeButton-success'?: (event: CustomEvent<any>) => void;
+    'ownerId'?: string;
     'planId'?: string;
     'resourceId'?: string;
     'resourceLabel'?: string;
@@ -1317,6 +1342,7 @@ declare namespace LocalJSX {
     * _(hidden)_
     */
     'graphqlFetch'?: GraphqlFetch;
+    'ownerId'?: string;
     /**
     * Look up product logo from resource
     */
@@ -1332,6 +1358,7 @@ declare namespace LocalJSX {
     'onManifold-ssoButton-click'?: (event: CustomEvent<any>) => void;
     'onManifold-ssoButton-error'?: (event: CustomEvent<any>) => void;
     'onManifold-ssoButton-success'?: (event: CustomEvent<any>) => void;
+    'ownerId'?: string;
     /**
     * The id of the resource to rename, will be fetched if not set
     */
@@ -1428,6 +1455,7 @@ declare namespace LocalJSX {
   }
   interface ManifoldNoCredentials {
     'graphqlFetch'?: GraphqlFetch;
+    'ownerId'?: string;
     'resourceLabel'?: string;
   }
   interface ManifoldNumberInput {
@@ -1498,6 +1526,7 @@ declare namespace LocalJSX {
     */
     'graphqlFetch'?: GraphqlFetch;
     'hideUntilReady'?: boolean;
+    'ownerId'?: string;
     /**
     * URL-friendly slug (e.g. `"jawsdb-mysql"`)
     */
@@ -1559,6 +1588,7 @@ declare namespace LocalJSX {
     */
     'graphqlFetch'?: GraphqlFetch;
     'label'?: string;
+    'ownerId'?: string;
     'preserveEvent'?: boolean;
     'resourceLinkFormat'?: string;
   }
@@ -1596,11 +1626,13 @@ declare namespace LocalJSX {
     'gqlData'?: GetResourceQuery['resource'];
     'loading'?: boolean;
     'noCredentials'?: boolean;
+    'ownerId'?: string;
   }
   interface ManifoldResourceDeprovision {
     'disabled'?: boolean;
     'gqlData'?: GetResourceQuery['resource'];
     'loading'?: boolean;
+    'ownerId'?: string;
   }
   interface ManifoldResourceList {
     /**
@@ -1640,11 +1672,13 @@ declare namespace LocalJSX {
     * The new label to give to the resource
     */
     'newLabel'?: string;
+    'ownerId'?: string;
   }
   interface ManifoldResourceSso {
     'disabled'?: boolean;
     'gqlData'?: GetResourceQuery['resource'];
     'loading'?: boolean;
+    'ownerId'?: string;
   }
   interface ManifoldResourceStatus {
     'gqlData'?: GetResourceQuery['resource'];

--- a/src/components/manifold-copy-credentials/credentials.graphql
+++ b/src/components/manifold-copy-credentials/credentials.graphql
@@ -1,5 +1,5 @@
-query ResourceWithCredentials($resourceLabel: String!) {
-  resource(label: $resourceLabel) {
+query ResourceWithCredentials($resourceLabel: String!, $owner: ProfileIdentity) {
+  resource(label: $resourceLabel, owner: $owner) {
     credentials(first: 100) {
       edges {
         node {

--- a/src/components/manifold-copy-credentials/manifold-copy-credentials.spec.ts
+++ b/src/components/manifold-copy-credentials/manifold-copy-credentials.spec.ts
@@ -103,6 +103,30 @@ describe('<manifold-copy-credentials>', () => {
       // expect button is disabled from error
       expect(button.getAttribute('disabled')).not.toBeNull();
     });
+
+    it('[owner-id]: uses if passed', async () => {
+      element.resourceLabel = 'my-resource';
+      element.ownerId = 'my-owner-id';
+      const { root } = page;
+      if (!root) {
+        throw new Error('<manifold-copy-credentials> not found in document');
+      }
+      root.appendChild(element);
+      // wait for creds to fetch
+      await page.waitForChanges();
+
+      // simulate button click
+      const button = root.querySelector('button');
+      if (button) {
+        button.click();
+      }
+
+      const [[_, firstRequest]] = fetchMock.calls();
+      const body = JSON.parse(`${firstRequest && firstRequest.body}`);
+      const { variables } = body;
+
+      expect(variables.owner).toBe('my-owner-id');
+    });
   });
 
   describe('v0 events', () => {

--- a/src/components/manifold-copy-credentials/manifold-copy-credentials.tsx
+++ b/src/components/manifold-copy-credentials/manifold-copy-credentials.tsx
@@ -15,7 +15,10 @@ import { GraphqlFetch } from '../../utils/graphqlFetch';
 import { connection } from '../../global/app';
 import logger, { loadMark } from '../../utils/logger';
 import query from './credentials.graphql';
-import { ResourceWithCredentialsQuery } from '../../types/graphql';
+import {
+  ResourceWithCredentialsQuery,
+  ResourceWithCredentialsQueryVariables,
+} from '../../types/graphql';
 
 interface ErrorDetail {
   message: string;
@@ -33,6 +36,7 @@ export class ManifoldCopyCredentials {
   @Prop() graphqlFetch?: GraphqlFetch = connection.graphqlFetch;
   /** The label of the resource to fetch credentials for */
   @Prop() resourceLabel?: string;
+  @Prop() ownerId?: string;
   @State() credentials?: string;
   @Event({ eventName: 'manifold-copyCredentials-error', bubbles: true }) error: EventEmitter;
   @Event({ eventName: 'manifold-copyCredentials-success', bubbles: true }) success: EventEmitter;
@@ -58,16 +62,20 @@ export class ManifoldCopyCredentials {
 
   @Method()
   async refresh() {
-    if (!this.graphqlFetch) {
+    if (!this.graphqlFetch || !this.resourceLabel) {
       return;
     }
 
     // disable button while loading
     this.credentials = undefined;
 
+    const variables: ResourceWithCredentialsQueryVariables = {
+      resourceLabel: this.resourceLabel,
+      owner: this.ownerId,
+    };
     const { data, errors } = await this.graphqlFetch<ResourceWithCredentialsQuery>({
       query,
-      variables: { resourceLabel: this.resourceLabel },
+      variables,
       element: this.el,
     });
 

--- a/src/components/manifold-credentials/manifold-credentials.spec.ts
+++ b/src/components/manifold-credentials/manifold-credentials.spec.ts
@@ -30,6 +30,7 @@ const credentialsHTML = credentials
 
 interface Props {
   resourceLabel?: string;
+  ownerId?: string;
 }
 
 async function setup(props: Props) {
@@ -46,6 +47,7 @@ async function setup(props: Props) {
     setAuthToken: jest.fn(),
   });
   component.resourceLabel = props.resourceLabel;
+  component.ownerId = props.ownerId;
 
   const root = page.root as HTMLDivElement;
   root.appendChild(component);
@@ -103,6 +105,23 @@ describe('<manifold-credentials>', () => {
       const toast = page.root && page.root.querySelector('manifold-toast');
       expect(toast).not.toBeNull();
       expect(toast && toast.innerText).toBe('resource not found');
+    });
+
+    it('[owner-id]: uses if passed', async () => {
+      const { page, component } = await setup({
+        resourceLabel: 'my-resource',
+        ownerId: 'my-owner-id',
+      });
+
+      // simulate button click to fetch credentials, and wait for page to update
+      await component.showCredentials();
+      await page.waitForChanges();
+
+      const [[_, firstRequest]] = fetchMock.calls();
+      const body = JSON.parse(`${firstRequest && firstRequest.body}`);
+      const { variables } = body;
+
+      expect(variables.owner).toBe('my-owner-id');
     });
   });
 });

--- a/src/components/manifold-credentials/manifold-credentials.tsx
+++ b/src/components/manifold-credentials/manifold-credentials.tsx
@@ -1,6 +1,6 @@
 import { h, Element, Component, Method, Prop, State } from '@stencil/core';
 
-import { ResourceCredentialsQuery } from '../../types/graphql';
+import { ResourceCredentialsQuery, ResourceCredentialsQueryVariables } from '../../types/graphql';
 import { GraphqlFetch, GraphqlError } from '../../utils/graphqlFetch';
 import { connection } from '../../global/app';
 import logger, { loadMark } from '../../utils/logger';
@@ -11,8 +11,9 @@ export class ManifoldCredentials {
   @Element() el: HTMLElement;
   /** _(hidden)_ */
   @Prop() graphqlFetch?: GraphqlFetch = connection.graphqlFetch;
-  @Prop() resourceLabel?: string = '';
   @Prop() noCredentials?: boolean = false;
+  @Prop() ownerId?: string;
+  @Prop() resourceLabel?: string = '';
   @State() credentials?: ResourceCredentialsQuery['resource']['credentials']['edges'];
   @State() errors?: GraphqlError[];
   @State() loading?: boolean = false;
@@ -35,9 +36,13 @@ export class ManifoldCredentials {
     this.loading = true;
     this.credentials = undefined;
 
+    const variables: ResourceCredentialsQueryVariables = {
+      resourceLabel: this.resourceLabel,
+      owner: this.ownerId,
+    };
     const { data, errors } = await this.graphqlFetch<ResourceCredentialsQuery>({
       query: resourceCredentialsQuery,
-      variables: { resourceLabel: this.resourceLabel },
+      variables,
       element: this.el,
     });
 
@@ -61,7 +66,7 @@ export class ManifoldCredentials {
   render() {
     if (this.noCredentials || (this.credentials && this.credentials.length === 0)) {
       return (
-        <manifold-no-credentials resourceLabel={this.resourceLabel}>
+        <manifold-no-credentials resourceLabel={this.resourceLabel} ownerId={this.ownerId}>
           <manifold-forward-slot slot="show-button">
             <slot name="show-button" />
           </manifold-forward-slot>

--- a/src/components/manifold-credentials/resourceCredentials.graphql
+++ b/src/components/manifold-credentials/resourceCredentials.graphql
@@ -1,5 +1,5 @@
-query ResourceCredentials($resourceLabel: String!) {
-  resource(label: $resourceLabel) {
+query ResourceCredentials($resourceLabel: String!, $owner: ProfileIdentity) {
+  resource(label: $resourceLabel, owner: $owner) {
     credentials(first: 25) {
       edges {
         node {

--- a/src/components/manifold-data-deprovision-button/delete.graphql
+++ b/src/components/manifold-data-deprovision-button/delete.graphql
@@ -1,5 +1,5 @@
-mutation DeleteResource($resourceId: ID!) {
-  deleteResource(input: { resourceId: $resourceId }) {
+mutation DeleteResource($resourceId: ID!, $owner: ID) {
+  deleteResource(input: { resourceId: $resourceId, ownerId: $owner }) {
     data {
       id
       label

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.spec.ts
@@ -8,6 +8,7 @@ import resource from '../../spec/mock/elegant-cms/resource';
 interface Props {
   resourceId?: string;
   resourceLabel?: string;
+  ownerId?: string;
 }
 
 const graphqlEndpoint = 'http://test.com/graphql';
@@ -24,6 +25,7 @@ async function setup(props: Props) {
     wait: () => 10,
     setAuthToken: jest.fn(),
   });
+  component.ownerId = props.ownerId;
   component.resourceId = props.resourceId;
   component.resourceLabel = props.resourceLabel;
 
@@ -69,6 +71,23 @@ describe('<manifold-data-deprovision-button>', () => {
     it('[resource-id]: doesn’t fetch ID if set', async () => {
       await setup({ resourceId: 'resource-id', resourceLabel: 'resource-label' });
       expect(fetchMock.called(`begin:${graphqlEndpoint}`)).toBe(false);
+    });
+
+    it('[owner-id]: uses if passed', async () => {
+      const { page } = await setup({ resourceId: 'resource-id', ownerId: 'my-owner-id' });
+
+      // simulate button click
+      const button = page.root && page.root.querySelector('button');
+      if (button) {
+        button.click();
+      }
+      await page.waitForChanges();
+
+      const [[_, firstRequest]] = fetchMock.calls();
+      const body = JSON.parse(`${firstRequest && firstRequest.body}`);
+      const { variables } = body;
+
+      expect(variables.owner).toBe('my-owner-id');
     });
   });
 

--- a/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
+++ b/src/components/manifold-data-deprovision-button/manifold-data-deprovision-button.tsx
@@ -8,6 +8,7 @@ import {
   DeleteResourceMutation,
   ResourceIdQuery,
   ResourceIdQueryVariables,
+  DeleteResourceMutationVariables,
 } from '../../types/graphql';
 
 import resourceIdQuery from '../queries/resource-id.graphql';
@@ -31,6 +32,7 @@ export class ManifoldDataDeprovisionButton {
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() graphqlFetch?: GraphqlFetch = connection.graphqlFetch;
   @Prop() disabled?: boolean;
+  @Prop() ownerId?: string;
   /** resource ID */
   @Prop({ mutable: true }) resourceId?: string = '';
   /** The label of the resource to deprovision */
@@ -68,11 +70,13 @@ export class ManifoldDataDeprovisionButton {
       resourceLabel: this.resourceLabel || '',
     });
 
+    const variables: DeleteResourceMutationVariables = {
+      resourceId: this.resourceId,
+      owner: this.ownerId,
+    };
     const { data, errors } = await this.graphqlFetch<DeleteResourceMutation>({
       query: deleteMutation,
-      variables: {
-        resourceId: this.resourceId,
-      },
+      variables,
       element: this.el,
     });
 
@@ -103,7 +107,7 @@ export class ManifoldDataDeprovisionButton {
       return;
     }
 
-    const variables: ResourceIdQueryVariables = { resourceLabel };
+    const variables: ResourceIdQueryVariables = { resourceLabel, owner: this.ownerId };
     const { data } = await this.graphqlFetch<ResourceIdQuery>({
       query: resourceIdQuery,
       variables,

--- a/src/components/manifold-data-has-resource/first-resource.graphql
+++ b/src/components/manifold-data-has-resource/first-resource.graphql
@@ -1,5 +1,5 @@
-query FirstResource {
-  resources(first: 1) {
+query FirstResource($owner: ProfileIdentity) {
+  resources(first: 1, owner: $owner) {
     edges {
       node {
         label

--- a/src/components/manifold-data-has-resource/manifold-data-has-resource.spec.ts
+++ b/src/components/manifold-data-has-resource/manifold-data-has-resource.spec.ts
@@ -17,11 +17,12 @@ const multiResources = {
 };
 
 interface Setup {
+  ownerId?: string;
   onLoad?: (e: Event) => void;
   label?: string;
 }
 
-async function setup({ onLoad, label }: Setup) {
+async function setup({ onLoad, label, ownerId }: Setup) {
   const page = await newSpecPage({
     components: [ManifoldDataHasResource],
     html: '<div></div>',
@@ -37,6 +38,7 @@ async function setup({ onLoad, label }: Setup) {
   component.graphqlFetch = createGraphqlFetch({ endpoint: () => graphqlEndpoint });
   component.paused = true;
   component.label = label;
+  component.ownerId = ownerId;
 
   if (onLoad) {
     page.doc.addEventListener('manifold-hasResource-load', onLoad);
@@ -90,6 +92,16 @@ describe('<manifold-data-has-resource>', () => {
       const { component } = await setup({ label: 'my-resource' });
 
       expect(component.shadowRoot).toEqualHtml(`<slot name="has-resource"></slot>`);
+    });
+
+    it('[owner-id]: uses if passed', async () => {
+      await setup({ label: 'my-resource', ownerId: 'my-owner-id' });
+
+      const [[_, firstRequest]] = fetchMock.calls();
+      const body = JSON.parse(`${firstRequest && firstRequest.body}`);
+      const { variables } = body;
+
+      expect(variables.owner).toBe('my-owner-id');
     });
   });
 

--- a/src/components/manifold-data-has-resource/manifold-data-has-resource.tsx
+++ b/src/components/manifold-data-has-resource/manifold-data-has-resource.tsx
@@ -25,6 +25,7 @@ export class ManifoldDataHasResource {
   @Prop() graphqlFetch?: GraphqlFetch = connection.graphqlFetch;
   /** Disable auto-updates? */
   @Prop() label?: string;
+  @Prop() ownerId?: string;
   @Prop() paused?: boolean = false;
   @State() interval?: number;
   @State() hasResource?: boolean;
@@ -63,6 +64,7 @@ export class ManifoldDataHasResource {
 
     const variables: ResourceByLabelQueryVariables | FirstResourceQueryVariables = {
       resourceLabel: label,
+      owner: this.ownerId,
     };
     const { data } = await this.graphqlFetch<ResourceByLabelQuery & FirstResourceQuery>({
       query: label ? resourceByLabelQuery : firstResourceQuery,

--- a/src/components/manifold-data-has-resource/resource-by-label.graphql
+++ b/src/components/manifold-data-has-resource/resource-by-label.graphql
@@ -1,5 +1,5 @@
-query ResourceByLabel($resourceLabel: String!) {
-  resource(label: $resourceLabel) {
+query ResourceByLabel($resourceLabel: String!, $owner: ProfileIdentity) {
+  resource(label: $resourceLabel, owner: $owner) {
     label
   }
 }

--- a/src/components/manifold-data-product-name/manifold-data-product-name.spec.ts
+++ b/src/components/manifold-data-product-name/manifold-data-product-name.spec.ts
@@ -12,7 +12,7 @@ const products = {
 const graphqlEndpoint = 'http://test.com/graphql';
 
 describe('<manifold-data-product-name>', () => {
-  describe('v0 API', () => {
+  describe('v0 props', () => {
     let page: SpecPage;
     let element: HTMLManifoldDataProductNameElement;
 
@@ -109,6 +109,20 @@ describe('<manifold-data-product-name>', () => {
 
       const name = root.querySelector('manifold-data-product-name') as HTMLElement;
       expect(name.innerHTML).toBe('Product name not found');
+    });
+
+    it('[owner-id]: uses if passed', async () => {
+      element.resourceLabel = 'mailgun';
+      element.ownerId = 'my-owner-id';
+      const root = page.root as HTMLElement;
+      root.appendChild(element);
+      await page.waitForChanges();
+
+      const [[_, firstRequest]] = fetchMock.calls();
+      const body = JSON.parse(`${firstRequest && firstRequest.body}`);
+      const { variables } = body;
+
+      expect(variables.owner).toBe('my-owner-id');
     });
   });
 });

--- a/src/components/manifold-data-product-name/manifold-data-product-name.tsx
+++ b/src/components/manifold-data-product-name/manifold-data-product-name.tsx
@@ -18,6 +18,7 @@ export class ManifoldDataProductName {
   @Element() el: HTMLElement;
   /** _(hidden)_ */
   @Prop() graphqlFetch?: GraphqlFetch = connection.graphqlFetch;
+  @Prop() ownerId?: string;
   /** URL-friendly slug (e.g. `"jawsdb-mysql"`) */
   @Prop() productLabel?: string;
   /** Look up product name from resource */
@@ -69,7 +70,7 @@ export class ManifoldDataProductName {
 
     this.productName = undefined;
 
-    const variables: ResourceProductNameQueryVariables = { resourceLabel };
+    const variables: ResourceProductNameQueryVariables = { resourceLabel, owner: this.ownerId };
     const { data, errors } = await this.graphqlFetch<ResourceProductNameQuery>({
       query: resourceProductNameQuery,
       variables,

--- a/src/components/manifold-data-product-name/resource-product-name.graphql
+++ b/src/components/manifold-data-product-name/resource-product-name.graphql
@@ -1,5 +1,5 @@
-query ResourceProductName($resourceLabel: String!) {
-  resource(label: $resourceLabel) {
+query ResourceProductName($resourceLabel: String!, $owner: ProfileIdentity) {
+  resource(label: $resourceLabel, owner: $owner) {
     plan {
       product {
         displayName

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.spec.ts
@@ -9,6 +9,7 @@ interface Props {
   disabled?: boolean;
   loading?: boolean;
   newLabel: string;
+  ownerId?: string;
   resourceId?: string;
   resourceLabel: string;
 }
@@ -27,6 +28,7 @@ async function setup(props: Props) {
   });
   component.disabled = props.disabled;
   component.loading = props.loading;
+  component.ownerId = props.ownerId;
   component.newLabel = props.newLabel;
   component.resourceId = props.resourceId;
   component.resourceLabel = props.resourceLabel;
@@ -92,6 +94,16 @@ describe('<manifold-data-rename-button>', () => {
       const button = page.root && page.root.querySelector('button');
       expect(button && button.getAttribute('disabled')).not.toBeNull();
     });
+
+    it('[owner-id]: uses if passed', async () => {
+      await setup({ resourceLabel: 'my-resource', newLabel: 'new-label', ownerId: 'my-owner-id' });
+
+      const [[_, firstRequest]] = fetchMock.calls();
+      const body = JSON.parse(`${firstRequest && firstRequest.body}`);
+      const { variables } = body;
+
+      expect(variables.owner).toBe('my-owner-id');
+    });
   });
 
   describe('v0 events', () => {
@@ -99,8 +111,9 @@ describe('<manifold-data-rename-button>', () => {
       const newLabel = 'success-next';
       const resourceId = 'success-id';
       const resourceLabel = 'success-label';
+      const ownerId = 'success-owner';
 
-      const { page } = await setup({ newLabel, resourceId, resourceLabel });
+      const { page } = await setup({ newLabel, resourceId, resourceLabel, ownerId });
 
       const mockClick = jest.fn();
 
@@ -114,7 +127,7 @@ describe('<manifold-data-rename-button>', () => {
       button.click();
 
       expect(mockClick).toBeCalledWith(
-        expect.objectContaining({ detail: { newLabel, resourceLabel, resourceId } })
+        expect.objectContaining({ detail: { newLabel, resourceLabel, resourceId, ownerId } })
       );
     });
 
@@ -122,7 +135,8 @@ describe('<manifold-data-rename-button>', () => {
       const newLabel = 'x';
       const resourceId = 'invalid-id';
       const resourceLabel = 'invalid-label';
-      const { page } = await setup({ newLabel, resourceId, resourceLabel });
+      const ownerId = 'invalid-owner';
+      const { page } = await setup({ newLabel, resourceId, resourceLabel, ownerId });
 
       const button = page.root && page.root.querySelector('button');
       if (!button) {
@@ -141,6 +155,7 @@ describe('<manifold-data-rename-button>', () => {
             newLabel,
             resourceLabel,
             resourceId,
+            ownerId,
           },
         })
       );
@@ -150,7 +165,8 @@ describe('<manifold-data-rename-button>', () => {
       const newLabel = '🦞🦞🦞';
       const resourceId = 'invalid-id';
       const resourceLabel = 'invalid-label';
-      const { page } = await setup({ newLabel, resourceId, resourceLabel });
+      const ownerId = 'invalid-owner';
+      const { page } = await setup({ newLabel, resourceId, resourceLabel, ownerId });
 
       const button = page.root && page.root.querySelector('button');
       if (!button) {
@@ -170,6 +186,7 @@ describe('<manifold-data-rename-button>', () => {
             newLabel,
             resourceLabel,
             resourceId,
+            ownerId,
           },
         })
       );
@@ -179,7 +196,8 @@ describe('<manifold-data-rename-button>', () => {
       const newLabel = 'error-next';
       const resourceId = 'error-id';
       const resourceLabel = 'error-label';
-      const { page } = await setup({ newLabel, resourceId, resourceLabel });
+      const ownerId = 'error-owner';
+      const { page } = await setup({ newLabel, resourceId, resourceLabel, ownerId });
 
       const button = page.root && page.root.querySelector('button');
       if (!button) {
@@ -197,7 +215,7 @@ describe('<manifold-data-rename-button>', () => {
       expect(fetchMock.called('begin:https://api.manifold.co/graphql')).toBe(true);
       expect(mockClick).toHaveBeenCalledWith(
         expect.objectContaining({
-          detail: { message: 'resource not found', newLabel, resourceLabel, resourceId },
+          detail: { message: 'resource not found', newLabel, resourceLabel, resourceId, ownerId },
         })
       );
     });
@@ -206,7 +224,8 @@ describe('<manifold-data-rename-button>', () => {
       const newLabel = 'logdna'; // Test relies on logdna here because fetchMock returns the logdna mock resource
       const resourceId = 'success-id';
       const resourceLabel = 'success-label';
-      const { page } = await setup({ newLabel, resourceId, resourceLabel });
+      const ownerId = 'success-owner';
+      const { page } = await setup({ newLabel, resourceId, resourceLabel, ownerId });
 
       const button = page.root && page.root.querySelector('button');
       if (!button) {
@@ -229,6 +248,7 @@ describe('<manifold-data-rename-button>', () => {
             newLabel,
             resourceLabel,
             resourceId,
+            ownerId,
           },
         })
       );

--- a/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
+++ b/src/components/manifold-data-rename-button/manifold-data-rename-button.tsx
@@ -17,6 +17,7 @@ interface ClickMessage {
   newLabel?: string;
   resourceLabel: string;
   resourceId: string;
+  ownerId?: string;
 }
 
 interface InvalidMessage {
@@ -24,6 +25,7 @@ interface InvalidMessage {
   newLabel?: string;
   resourceLabel: string;
   resourceId: string;
+  ownerId?: string;
 }
 
 interface SuccessMessage {
@@ -31,6 +33,7 @@ interface SuccessMessage {
   newLabel?: string;
   resourceLabel: string;
   resourceId: string;
+  ownerId?: string;
 }
 
 interface ErrorMessage {
@@ -38,6 +41,7 @@ interface ErrorMessage {
   newLabel?: string;
   resourceLabel: string;
   resourceId?: string;
+  ownerId?: string;
 }
 
 @Component({ tag: 'manifold-data-rename-button' })
@@ -45,6 +49,7 @@ export class ManifoldDataRenameButton {
   @Element() el: HTMLElement;
   /** _(hidden)_ */
   @Prop() graphqlFetch?: GraphqlFetch = connection.graphqlFetch;
+  @Prop() ownerId?: string;
   /** The label of the resource to rename */
   @Prop() resourceLabel?: string;
   /** The new label to give to the resource */
@@ -83,6 +88,7 @@ export class ManifoldDataRenameButton {
       resourceLabel: this.resourceLabel || '',
       newLabel,
       resourceId: this.resourceId,
+      ownerId: this.ownerId,
     };
 
     // invalid event
@@ -142,7 +148,7 @@ export class ManifoldDataRenameButton {
       return;
     }
 
-    const variables: ResourceIdQueryVariables = { resourceLabel };
+    const variables: ResourceIdQueryVariables = { resourceLabel, owner: this.ownerId };
     const { data, errors } = await this.graphqlFetch<ResourceIdQuery>({
       query: resourceIdQuery,
       variables,
@@ -169,6 +175,7 @@ export class ManifoldDataRenameButton {
         newLabel: this.newLabel,
         resourceId: this.resourceId,
         resourceLabel: this.resourceLabel || '',
+        ownerId: this.ownerId,
       };
       console.error(detail.message);
       this.error.emit(detail);

--- a/src/components/manifold-data-resize-button/manifold-data-resize-button.spec.ts
+++ b/src/components/manifold-data-resize-button/manifold-data-resize-button.spec.ts
@@ -5,9 +5,10 @@ import { createGraphqlFetch, GraphqlError } from '../../utils/graphqlFetch';
 import resource from '../../spec/mock/elegant-cms/resource';
 
 interface Props {
+  ownerId?: string;
   planId?: string;
-  resourceLabel?: string;
   resourceId?: string;
+  resourceLabel?: string;
 }
 
 const graphqlEndpoint = 'http://test.com/graphql';
@@ -20,9 +21,10 @@ async function setup(props: Props) {
 
   const component = page.doc.createElement('manifold-data-resize-button');
   component.graphqlFetch = createGraphqlFetch({ endpoint: () => graphqlEndpoint });
+  component.ownerId = props.ownerId;
   component.planId = props.planId;
-  component.resourceLabel = props.resourceLabel;
   component.resourceId = props.resourceId;
+  component.resourceLabel = props.resourceLabel;
 
   const root = page.root as HTMLDivElement;
   root.appendChild(component);
@@ -62,6 +64,16 @@ describe('<manifold-data-resize-button>', () => {
       await setup({ resourceLabel: 'my-resource' });
       expect(fetchMock.called(`begin:${graphqlEndpoint}`)).toBe(true);
     });
+
+    it('[owner-id]: uses if passed', async () => {
+      await setup({ resourceLabel: 'my-resource', ownerId: 'my-owner-id' });
+
+      const [[_, firstRequest]] = fetchMock.calls();
+      const body = JSON.parse(`${firstRequest && firstRequest.body}`);
+      const { variables } = body;
+
+      expect(variables.owner).toBe('my-owner-id');
+    });
   });
 
   describe('v0 events', () => {
@@ -69,8 +81,9 @@ describe('<manifold-data-resize-button>', () => {
       const planId = 'plan-id';
       const resourceLabel = 'click-resource-label';
       const resourceId = 'click-resource-id';
+      const ownerId = 'click-owner-id';
 
-      const { page } = await setup({ planId, resourceId, resourceLabel });
+      const { page } = await setup({ planId, resourceId, resourceLabel, ownerId });
       const button = page.root && page.root.querySelector('button');
       if (!button) {
         throw new Error('button not found in document');
@@ -88,6 +101,7 @@ describe('<manifold-data-resize-button>', () => {
             planId,
             resourceLabel,
             resourceId,
+            ownerId,
           },
         })
       );
@@ -97,8 +111,9 @@ describe('<manifold-data-resize-button>', () => {
       const planId = 'plan-id';
       const resourceLabel = 'error-resource-label';
       const resourceId = 'error-resource-id';
+      const ownerId = 'error-owner-id';
 
-      const { page } = await setup({ planId, resourceId, resourceLabel });
+      const { page } = await setup({ planId, resourceId, resourceLabel, ownerId });
       const button = page.root && page.root.querySelector('button');
       if (!button) {
         throw new Error('button not found in document');
@@ -117,6 +132,7 @@ describe('<manifold-data-resize-button>', () => {
             planId,
             resourceId,
             resourceLabel,
+            ownerId,
           },
         })
       );
@@ -126,8 +142,9 @@ describe('<manifold-data-resize-button>', () => {
       const planId = 'plan-id';
       const resourceLabel = 'success-resource-label';
       const resourceId = 'success-resource-id';
+      const ownerId = 'success-owner-id';
 
-      const { page } = await setup({ planId, resourceId, resourceLabel });
+      const { page } = await setup({ planId, resourceId, resourceLabel, ownerId });
       const button = page.root && page.root.querySelector('button');
       if (!button) {
         throw new Error('button not found in document');
@@ -143,6 +160,7 @@ describe('<manifold-data-resize-button>', () => {
         expect.objectContaining({
           detail: {
             message: `${resource.label} successfully updated to ${planId}`,
+            ownerId,
             planId,
             resourceId,
             resourceLabel: resource.label, // we’re mocking the response here so it’ll be different

--- a/src/components/manifold-data-resize-button/manifold-data-resize-button.tsx
+++ b/src/components/manifold-data-resize-button/manifold-data-resize-button.tsx
@@ -19,6 +19,7 @@ interface ClickMessage {
   resourceId: string;
   resourceLabel: string;
   configuredFeatures?: ConfiguredFeatureInput[];
+  ownerId?: string;
 }
 
 interface SuccessMessage {
@@ -26,6 +27,7 @@ interface SuccessMessage {
   planId?: string;
   resourceId?: string;
   resourceLabel?: string;
+  ownerId?: string;
 }
 
 interface ErrorMessage {
@@ -34,6 +36,7 @@ interface ErrorMessage {
   resourceLabel?: string;
   planId?: string;
   configuredFeatures?: ConfiguredFeatureInput[];
+  ownerId?: string;
 }
 
 @Component({ tag: 'manifold-data-resize-button' })
@@ -41,6 +44,7 @@ export class ManifoldDataResizeButton {
   @Element() el: HTMLElement;
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() graphqlFetch?: GraphqlFetch = connection.graphqlFetch;
+  @Prop() ownerId?: string;
   @Prop() planId?: string;
   @Prop() resourceLabel?: string;
   @Prop() configuredFeatures?: ConfiguredFeatureInput[];
@@ -64,7 +68,7 @@ export class ManifoldDataResizeButton {
       return;
     }
 
-    const variables: ResourceIdQueryVariables = { resourceLabel };
+    const variables: ResourceIdQueryVariables = { resourceLabel, owner: this.ownerId };
     const { data } = await this.graphqlFetch<ResourceIdQuery>({
       query: resourceIdQuery,
       variables,
@@ -87,6 +91,7 @@ export class ManifoldDataResizeButton {
       resourceLabel: this.resourceLabel,
       resourceId: this.resourceId,
       configuredFeatures: this.configuredFeatures,
+      ownerId: this.ownerId,
     };
     this.click.emit(clickDetail);
 
@@ -94,6 +99,7 @@ export class ManifoldDataResizeButton {
       resourceId: this.resourceId,
       planId: this.planId,
       configuredFeatures: this.configuredFeatures,
+      owner: this.ownerId,
     };
 
     const { data, errors } = await this.graphqlFetch<ResourceChangePlanMutation>({
@@ -109,6 +115,7 @@ export class ManifoldDataResizeButton {
         planId: this.planId,
         resourceId: this.resourceId,
         resourceLabel: data.updateResourcePlan.data.label,
+        ownerId: this.ownerId,
       };
       this.success.emit(success);
     }
@@ -122,6 +129,7 @@ export class ManifoldDataResizeButton {
           resourceId: this.resourceId,
           resourceLabel: this.resourceLabel,
           configuredFeatures: this.configuredFeatures,
+          ownerId: this.ownerId,
         };
         this.error.emit(error);
       });

--- a/src/components/manifold-data-resize-button/updatePlan.graphql
+++ b/src/components/manifold-data-resize-button/updatePlan.graphql
@@ -2,9 +2,15 @@ mutation ResourceChangePlan(
   $resourceId: ID!
   $planId: ID!
   $configuredFeatures: [ConfiguredFeatureInput!]
+  $owner: ID
 ) {
   updateResourcePlan(
-    input: { resourceId: $resourceId, newPlanID: $planId, configuredFeatures: $configuredFeatures }
+    input: {
+      resourceId: $resourceId
+      newPlanID: $planId
+      configuredFeatures: $configuredFeatures
+      ownerId: $owner
+    }
   ) {
     data {
       id

--- a/src/components/manifold-data-resource-logo/manifold-data-resource-logo.tsx
+++ b/src/components/manifold-data-resource-logo/manifold-data-resource-logo.tsx
@@ -4,7 +4,7 @@ import { GraphqlFetch } from '../../utils/graphqlFetch';
 import { connection } from '../../global/app';
 import logger, { loadMark } from '../../utils/logger';
 import resourceQuery from './resource.graphql';
-import { ResourceLogoQuery } from '../../types/graphql';
+import { ResourceLogoQuery, ResourceLogoQueryVariables } from '../../types/graphql';
 
 interface ProductState {
   logoUrl: string;
@@ -18,6 +18,7 @@ export class ManifoldDataResourceLogo {
   @Prop() alt?: string;
   /** _(hidden)_ */
   @Prop() graphqlFetch?: GraphqlFetch = connection.graphqlFetch;
+  @Prop() ownerId?: string;
   /** Look up product logo from resource */
   @Prop() resourceLabel?: string;
   @State() product?: ProductState;
@@ -32,15 +33,17 @@ export class ManifoldDataResourceLogo {
   }
 
   fetchResource = async (resourceLabel?: string) => {
-    if (!this.graphqlFetch || !this.resourceLabel) {
+    if (!this.graphqlFetch || !resourceLabel) {
       return;
     }
 
     this.product = undefined;
 
+    const variables: ResourceLogoQueryVariables = { resourceLabel, owner: this.ownerId };
+
     const { data } = await this.graphqlFetch<ResourceLogoQuery>({
       query: resourceQuery,
-      variables: { resourceLabel },
+      variables,
       element: this.el,
     });
 

--- a/src/components/manifold-data-resource-logo/resource.graphql
+++ b/src/components/manifold-data-resource-logo/resource.graphql
@@ -1,5 +1,5 @@
-query ResourceLogo($resourceLabel: String!) {
-  resource(label: $resourceLabel) {
+query ResourceLogo($resourceLabel: String!, $owner: ProfileIdentity) {
+  resource(label: $resourceLabel, owner: $owner) {
     plan {
       product {
         displayName

--- a/src/components/manifold-data-sso-button/manifold-data-sso-button.tsx
+++ b/src/components/manifold-data-sso-button/manifold-data-sso-button.tsx
@@ -36,6 +36,7 @@ export class ManifoldDataSsoButton {
   /** _(hidden)_ */
   @Prop() graphqlFetch?: GraphqlFetch = connection.graphqlFetch;
   @Prop() disabled?: boolean;
+  @Prop() ownerId?: string;
   /** The label of the resource to rename */
   @Prop() resourceLabel?: string;
   /** The id of the resource to rename, will be fetched if not set */
@@ -61,8 +62,8 @@ export class ManifoldDataSsoButton {
 
     const variables: ResourceSsoByIdQueryVariables | ResourceSsoByLabelQueryVariables = this
       .resourceId
-      ? { resourceId: this.resourceId }
-      : { resourceLabel: this.resourceLabel || '' };
+      ? { resourceId: this.resourceId, owner: this.ownerId }
+      : { resourceLabel: this.resourceLabel || '', owner: this.ownerId };
     const { data, errors } = await this.graphqlFetch<
       ResourceSsoByIdQuery | ResourceSsoByLabelQuery
     >({

--- a/src/components/manifold-data-sso-button/sso-id.graphql
+++ b/src/components/manifold-data-sso-button/sso-id.graphql
@@ -1,5 +1,5 @@
-query ResourceSSOByID($resourceId: ID!) {
-  resource(id: $resourceId) {
+query ResourceSSOByID($resourceId: ID!, $owner: ProfileIdentity) {
+  resource(id: $resourceId, owner: $owner) {
     id
     label
     ssoUrl

--- a/src/components/manifold-data-sso-button/sso-label.graphql
+++ b/src/components/manifold-data-sso-button/sso-label.graphql
@@ -1,5 +1,5 @@
-query ResourceSSOByLabel($resourceLabel: String!) {
-  resource(label: $resourceLabel) {
+query ResourceSSOByLabel($resourceLabel: String!, $owner: ProfileIdentity) {
+  resource(label: $resourceLabel, owner: $owner) {
     id
     label
     ssoUrl

--- a/src/components/manifold-mock-resource/manifold-mock-resource.tsx
+++ b/src/components/manifold-mock-resource/manifold-mock-resource.tsx
@@ -6,6 +6,9 @@ import logger, { loadMark } from '../../utils/logger';
 const GraphQLResource: GetResourceQuery['resource'] = {
   id: '268a3d5z80rq7dau0yv25nyf00jfe',
   label: 'logdna-elaborate-old-moss-green-deltoid',
+  owner: {
+    id: 'tea-bounq0r4tttipoufa4ug',
+  },
   plan: {
     id: '23558gd5kaw5z462e3mvaknj5veuj',
     label: 'quaco',

--- a/src/components/manifold-no-credentials/manifold-no-credentials.tsx
+++ b/src/components/manifold-no-credentials/manifold-no-credentials.tsx
@@ -20,6 +20,7 @@ const PLATFORM_DISPLAY_NAMES: { [key: string]: string } = {
 export class ManifoldNoCredentials {
   @Element() el: HTMLElement;
   @Prop() graphqlFetch?: GraphqlFetch = connection.graphqlFetch;
+  @Prop() ownerId?: string;
   @Prop() resourceLabel?: string = '';
   @State()
   message?: string =
@@ -36,7 +37,7 @@ export class ManifoldNoCredentials {
 
     const { data } = await this.graphqlFetch<ResourceNoCredentialsQuery>({
       query: resourceNoCredentialsQuery,
-      variables: { resourceLabel: this.resourceLabel },
+      variables: { resourceLabel: this.resourceLabel, owner: this.ownerId },
       element: this.el,
     });
     const platformName = data && PLATFORM_DISPLAY_NAMES[data.resource.owner.platform.domain];

--- a/src/components/manifold-no-credentials/resourceNoCredentials.graphql
+++ b/src/components/manifold-no-credentials/resourceNoCredentials.graphql
@@ -1,5 +1,5 @@
-query ResourceNoCredentials($resourceLabel: String!) {
-  resource(label: $resourceLabel) {
+query ResourceNoCredentials($resourceLabel: String!, $owner: ProfileIdentity) {
+  resource(label: $resourceLabel, owner: $owner) {
     plan {
       product {
         displayName

--- a/src/components/manifold-plan-selector/manifold-plan-selector.spec.ts
+++ b/src/components/manifold-plan-selector/manifold-plan-selector.spec.ts
@@ -10,7 +10,9 @@ import product from '../../spec/mock/aiven-cassandra/product';
 const graphqlEndpoint = 'http://test.com/graphql';
 
 interface Props {
+  ownerId?: string;
   regions?: string;
+  resourceLabel?: string;
 }
 
 async function setup(props: Props) {
@@ -22,6 +24,8 @@ async function setup(props: Props) {
   const component = page.doc.createElement('manifold-plan-selector');
   component.graphqlFetch = createGraphqlFetch({ endpoint: () => graphqlEndpoint });
   component.productLabel = 'test-product';
+  component.ownerId = props.ownerId;
+  component.resourceLabel = props.resourceLabel;
   component.regions = props.regions;
 
   const root = page.root as HTMLDivElement;
@@ -71,6 +75,16 @@ describe(`<manifold-plan-selector>`, () => {
       expect(optionValues).toContain(one);
       expect(optionValues).toContain(two);
       expect(optionValues).toContain(three);
+    });
+
+    it('[owner-id]: uses if passed', async () => {
+      await setup({ resourceLabel: 'my-resource', ownerId: 'my-owner-id' });
+
+      const [[_, firstRequest]] = fetchMock.calls();
+      const body = JSON.parse(`${firstRequest && firstRequest.body}`);
+      const { variables } = body;
+
+      expect(variables.owner).toBe('my-owner-id');
     });
   });
 });

--- a/src/components/manifold-plan-selector/manifold-plan-selector.tsx
+++ b/src/components/manifold-plan-selector/manifold-plan-selector.tsx
@@ -3,7 +3,12 @@ import { h, Component, Element, State, Prop, Watch } from '@stencil/core';
 import { connection } from '../../global/app';
 import logger, { loadMark } from '../../utils/logger';
 import { GraphqlFetch } from '../../utils/graphqlFetch';
-import { Product, Resource, PlanEdge } from '../../types/graphql';
+import {
+  Product,
+  Resource,
+  PlanEdge,
+  PlanSelectorResourceQueryVariables,
+} from '../../types/graphql';
 
 import plansQuery from './plan-list.graphql';
 import resourceQuery from './resource.graphql';
@@ -15,6 +20,7 @@ export class ManifoldPlanSelector {
   @Prop() freePlans?: boolean;
   /** _(hidden)_ Passed by `<manifold-connection>` */
   @Prop() graphqlFetch?: GraphqlFetch = connection.graphqlFetch;
+  @Prop() ownerId?: string;
   /** URL-friendly slug (e.g. `"jawsdb-mysql"`) */
   @Prop() productLabel?: string;
   /** Specify regions visible */
@@ -86,11 +92,10 @@ export class ManifoldPlanSelector {
 
     this.resource = undefined;
 
+    const variables: PlanSelectorResourceQueryVariables = { resourceLabel, owner: this.ownerId };
     const { data } = await this.graphqlFetch<{ resource?: Resource }>({
       query: resourceQuery,
-      variables: {
-        resourceLabel,
-      },
+      variables,
       element: this.el,
     });
 

--- a/src/components/manifold-plan-selector/resource.graphql
+++ b/src/components/manifold-plan-selector/resource.graphql
@@ -1,5 +1,5 @@
-query Resource($resourceLabel: String!) {
-  resource(label: $resourceLabel) {
+query PlanSelectorResource($resourceLabel: String!, $owner: ProfileIdentity) {
+  resource(label: $resourceLabel, owner: $owner) {
     configuredFeatures(first: 500) {
       edges {
         node {

--- a/src/components/manifold-resource-card/manifold-resource-card.spec.ts
+++ b/src/components/manifold-resource-card/manifold-resource-card.spec.ts
@@ -1,0 +1,46 @@
+import { newSpecPage } from '@stencil/core/testing';
+import fetchMock from 'fetch-mock';
+import { ManifoldResourceCard } from './manifold-resource-card';
+import { createGraphqlFetch } from '../../utils/graphqlFetch';
+
+const graphqlEndpoint = 'http://test.com/graphql';
+
+interface Setup {
+  ownerId?: string;
+  label?: string;
+}
+
+async function setup({ label, ownerId }: Setup) {
+  const page = await newSpecPage({
+    components: [ManifoldResourceCard],
+    html: '<div></div>',
+  });
+
+  const component = page.doc.createElement('manifold-resource-card');
+  component.graphqlFetch = createGraphqlFetch({ endpoint: () => graphqlEndpoint });
+  component.label = label;
+  component.ownerId = ownerId;
+
+  const root = page.root as HTMLDivElement;
+  root.appendChild(component);
+  await page.waitForChanges();
+
+  return { page, component };
+}
+
+describe('<manifold-data-has-resource>', () => {
+  beforeEach(() => fetchMock.mock(`begin:${graphqlEndpoint}`, 200));
+  afterEach(fetchMock.restore);
+
+  describe('v0 props', () => {
+    it('[owner-id]: uses if passed', async () => {
+      await setup({ label: 'my-resource', ownerId: 'my-owner-id' });
+
+      const [[_, firstRequest]] = fetchMock.calls();
+      const body = JSON.parse(`${firstRequest && firstRequest.body}`);
+      const { variables } = body;
+
+      expect(variables.owner).toBe('my-owner-id');
+    });
+  });
+});

--- a/src/components/manifold-resource-card/manifold-resource-card.tsx
+++ b/src/components/manifold-resource-card/manifold-resource-card.tsx
@@ -14,8 +14,9 @@ export class ManifoldResourceCard {
   /** _(hidden)_ */
   @Prop() graphqlFetch?: GraphqlFetch = connection.graphqlFetch;
   @Prop() label?: string;
-  @Prop() resourceLinkFormat?: string;
+  @Prop() ownerId?: string;
   @Prop() preserveEvent?: boolean = false;
+  @Prop() resourceLinkFormat?: string;
   @State() resource?: ResourceCardQuery['resource'];
   @State() errors?: GraphqlError[];
 
@@ -32,7 +33,7 @@ export class ManifoldResourceCard {
     if (!this.graphqlFetch || !resourceLabel) {
       return;
     }
-    const variables: ResourceCardQueryVariables = { resourceLabel };
+    const variables: ResourceCardQueryVariables = { resourceLabel, owner: this.ownerId };
     const { data, errors } = await this.graphqlFetch<ResourceCardQuery>({
       query: resourceCardQuery,
       variables,

--- a/src/components/manifold-resource-card/resource-card.graphql
+++ b/src/components/manifold-resource-card/resource-card.graphql
@@ -1,5 +1,5 @@
-query ResourceCard($resourceLabel: String!) {
-  resource(label: $resourceLabel) {
+query ResourceCard($resourceLabel: String!, $owner: ProfileIdentity) {
+  resource(label: $resourceLabel, owner: $owner) {
     id
     label
     plan {

--- a/src/components/manifold-resource-container/resource.graphql
+++ b/src/components/manifold-resource-container/resource.graphql
@@ -1,5 +1,5 @@
-query getResource($resourceLabel: String!) {
-  resource(label: $resourceLabel) {
+query getResource($resourceLabel: String!, $owner: ProfileIdentity) {
+  resource(label: $resourceLabel, owner: $owner) {
     id
     label
     region {
@@ -9,6 +9,9 @@ query getResource($resourceLabel: String!) {
     status {
       label
       message
+    }
+    owner {
+      id
     }
     configuredFeatures(first: 500) {
       edges {

--- a/src/components/manifold-resource-credentials/manifold-resource-credentials.spec.ts
+++ b/src/components/manifold-resource-credentials/manifold-resource-credentials.spec.ts
@@ -12,6 +12,7 @@ global.setTimeout = jest.fn();
 interface Props {
   gqlData?: GetResourceQuery['resource'];
   loading?: boolean;
+  ownerId?: string;
 }
 
 async function setup(props: Props) {
@@ -23,6 +24,7 @@ async function setup(props: Props) {
   const component = page.doc.createElement('manifold-resource-credentials');
   component.gqlData = props.gqlData;
   component.loading = props.loading;
+  component.ownerId = props.ownerId;
 
   const root = page.root as HTMLDivElement;
   root.appendChild(component);
@@ -54,6 +56,16 @@ describe('<manifold-resource-credentials>', () => {
       const { page } = await setup({ gqlData: resource as GetResourceQuery['resource'] });
       const button = page.root && page.root.querySelector('button');
       expect(button && button.getAttribute('disabled')).toBeNull();
+    });
+
+    it('[owner-id]: passes to child', async () => {
+      const { page } = await setup({
+        gqlData: resource as GetResourceQuery['resource'],
+        loading: false,
+        ownerId: 'my-owner-id',
+      });
+      const credentials = page.root && page.root.querySelector('manifold-credentials');
+      expect(credentials && credentials.ownerId).toBe('my-owner-id');
     });
   });
 });

--- a/src/components/manifold-resource-credentials/manifold-resource-credentials.tsx
+++ b/src/components/manifold-resource-credentials/manifold-resource-credentials.tsx
@@ -6,6 +6,7 @@ import { GetResourceQuery } from '../../types/graphql';
 
 @Component({ tag: 'manifold-resource-credentials' })
 export class ManifoldResourceCredentials {
+  @Prop() ownerId?: string;
   @Prop() gqlData?: GetResourceQuery['resource'];
   @Prop() loading?: boolean = true;
   @Prop() noCredentials?: boolean = false;
@@ -20,7 +21,11 @@ export class ManifoldResourceCredentials {
     }
 
     return (
-      <manifold-credentials resourceLabel={this.gqlData.label} noCredentials={this.noCredentials}>
+      <manifold-credentials
+        ownerId={this.ownerId || this.gqlData.owner.id}
+        resourceLabel={this.gqlData.label}
+        noCredentials={this.noCredentials}
+      >
         <manifold-forward-slot slot="show-button">
           <slot name="show-button" />
         </manifold-forward-slot>

--- a/src/components/manifold-resource-deprovision/manifold-resource-deprovision.spec.ts
+++ b/src/components/manifold-resource-deprovision/manifold-resource-deprovision.spec.ts
@@ -10,6 +10,7 @@ interface Props {
   disabled?: boolean;
   gqlData?: GetResourceQuery['resource'];
   loading?: boolean;
+  ownerId?: string;
 }
 
 async function setup(props: Props) {
@@ -22,6 +23,7 @@ async function setup(props: Props) {
   component.disabled = props.disabled;
   component.gqlData = props.gqlData;
   component.loading = props.loading;
+  component.ownerId = props.ownerId;
 
   const root = page.root as HTMLDivElement;
   root.appendChild(component);
@@ -61,6 +63,12 @@ describe('<manifold-resource-deprovision>', () => {
       const { page } = await setup({ gqlData: resource as GetResourceQuery['resource'] });
       const button = page.root && page.root.querySelector('button');
       expect(button && button.getAttribute('disabled')).toBeNull();
+    });
+
+    it('[owner-id]: passes to child', async () => {
+      const { page } = await setup({ ownerId: 'my-owner-id' });
+      const button = page.root && page.root.querySelector('manifold-data-deprovision-button');
+      expect(button && button.ownerId).toBe('my-owner-id');
     });
   });
 });

--- a/src/components/manifold-resource-deprovision/manifold-resource-deprovision.tsx
+++ b/src/components/manifold-resource-deprovision/manifold-resource-deprovision.tsx
@@ -7,6 +7,7 @@ import { GetResourceQuery } from '../../types/graphql';
 @Component({ tag: 'manifold-resource-deprovision' })
 export class ManifoldResourceDeprovision {
   @Prop() disabled?: boolean;
+  @Prop() ownerId?: string;
   @Prop() gqlData?: GetResourceQuery['resource'];
   @Prop() loading?: boolean = true;
 
@@ -18,9 +19,10 @@ export class ManifoldResourceDeprovision {
     return (
       <manifold-data-deprovision-button
         disabled={this.disabled}
+        loading={this.loading}
+        ownerId={this.ownerId || (this.gqlData && this.gqlData.owner.id)}
         resourceId={this.gqlData && this.gqlData.id}
         resourceLabel={this.gqlData && this.gqlData.label}
-        loading={this.loading}
       >
         <slot />
       </manifold-data-deprovision-button>

--- a/src/components/manifold-resource-rename/manifold-resource-rename.spec.ts
+++ b/src/components/manifold-resource-rename/manifold-resource-rename.spec.ts
@@ -11,6 +11,7 @@ interface Props {
   gqlData?: GetResourceQuery['resource'];
   loading?: boolean;
   newLabel?: string;
+  ownerId?: string;
 }
 
 async function setup(props: Props) {
@@ -24,6 +25,7 @@ async function setup(props: Props) {
   component.gqlData = props.gqlData;
   component.loading = props.loading;
   component.newLabel = props.newLabel;
+  component.ownerId = props.ownerId;
 
   const root = page.root as HTMLDivElement;
   root.appendChild(component);
@@ -66,6 +68,12 @@ describe('<manifold-resource-rename>', () => {
       });
       const button = page.root && page.root.querySelector('button');
       expect(button && button.getAttribute('disabled')).toBeNull();
+    });
+
+    it('[owner-id]: passes to child', async () => {
+      const { page } = await setup({ ownerId: 'my-owner-id' });
+      const button = page.root && page.root.querySelector('manifold-data-rename-button');
+      expect(button && button.ownerId).toBe('my-owner-id');
     });
   });
 });

--- a/src/components/manifold-resource-rename/manifold-resource-rename.tsx
+++ b/src/components/manifold-resource-rename/manifold-resource-rename.tsx
@@ -7,6 +7,7 @@ import { GetResourceQuery } from '../../types/graphql';
 @Component({ tag: 'manifold-resource-rename' })
 export class ManifoldResourceRename {
   @Prop() gqlData?: GetResourceQuery['resource'];
+  @Prop() ownerId?: string;
   @Prop() loading?: boolean = true;
   @Prop() disabled?: boolean;
   /** The new label to give to the resource */
@@ -19,11 +20,12 @@ export class ManifoldResourceRename {
   render() {
     return (
       <manifold-data-rename-button
+        disabled={this.disabled}
+        loading={this.loading}
+        newLabel={this.newLabel}
+        ownerId={this.ownerId || (this.gqlData && this.gqlData.owner.id)}
         resourceId={this.gqlData && this.gqlData.id}
         resourceLabel={this.gqlData && this.gqlData.label}
-        loading={this.loading}
-        disabled={this.disabled}
-        newLabel={this.newLabel}
       >
         <slot />
       </manifold-data-rename-button>

--- a/src/components/manifold-resource-sso/manifold-resource-sso.spec.ts
+++ b/src/components/manifold-resource-sso/manifold-resource-sso.spec.ts
@@ -10,6 +10,7 @@ interface Props {
   disabled?: boolean;
   gqlData?: GetResourceQuery['resource'];
   loading?: boolean;
+  ownerId?: string;
 }
 
 async function setup(props: Props) {
@@ -20,6 +21,7 @@ async function setup(props: Props) {
 
   const component = page.doc.createElement('manifold-resource-sso');
   component.disabled = props.disabled;
+  component.ownerId = props.ownerId;
   component.gqlData = props.gqlData;
   component.loading = props.loading;
 
@@ -58,6 +60,12 @@ describe('<manifold-resource-sso>', () => {
       });
       const button = page.root && page.root.querySelector('button');
       expect(button && button.getAttribute('disabled')).toBeNull();
+    });
+
+    it('[owner-id]: passes to child', async () => {
+      const { page } = await setup({ ownerId: 'my-owner-id' });
+      const button = page.root && page.root.querySelector('manifold-data-sso-button');
+      expect(button && button.ownerId).toBe('my-owner-id');
     });
   });
 });

--- a/src/components/manifold-resource-sso/manifold-resource-sso.tsx
+++ b/src/components/manifold-resource-sso/manifold-resource-sso.tsx
@@ -8,6 +8,7 @@ import { GetResourceQuery } from '../../types/graphql';
 export class ManifoldResourceSso {
   @Prop() disabled?: boolean;
   @Prop() gqlData?: GetResourceQuery['resource'];
+  @Prop() ownerId?: string;
   @Prop() loading?: boolean = true;
 
   @loadMark()
@@ -20,6 +21,7 @@ export class ManifoldResourceSso {
         disabled={this.disabled || !this.gqlData}
         resourceId={this.gqlData && this.gqlData.id}
         resourceLabel={this.gqlData && this.gqlData.label}
+        ownerId={this.ownerId || (this.gqlData && this.gqlData.owner.id)}
         loading={this.loading}
       >
         <slot />

--- a/src/components/queries/resource-id.graphql
+++ b/src/components/queries/resource-id.graphql
@@ -1,5 +1,5 @@
-query ResourceId($resourceLabel: String!) {
-  resource(label: $resourceLabel) {
+query ResourceId($resourceLabel: String!, $owner: ProfileIdentity) {
+  resource(label: $resourceLabel, owner: $owner) {
     id
   }
 }

--- a/src/spec/graphql.schema.json
+++ b/src/spec/graphql.schema.json
@@ -4979,6 +4979,22 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ProductFeatureType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -5001,6 +5017,35 @@
             "ofType": null
           }
         ]
+      },
+      {
+        "kind": "ENUM",
+        "name": "ProductFeatureType",
+        "description": "",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "BOOLEAN",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "STRING",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NUMBER",
+            "description": "",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
       },
       {
         "kind": "SCALAR",
@@ -9057,6 +9102,22 @@
             "deprecationReason": null
           },
           {
+            "name": "type",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ProductFeatureType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "featureOptions",
             "description": "",
             "args": [],
@@ -9343,6 +9404,22 @@
             "deprecationReason": null
           },
           {
+            "name": "type",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ProductFeatureType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "numericOptions",
             "description": "",
             "args": [],
@@ -9405,6 +9482,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ProductFeatureType",
                 "ofType": null
               }
             },

--- a/src/spec/mock/elegant-cms/resource.ts
+++ b/src/spec/mock/elegant-cms/resource.ts
@@ -4,6 +4,8 @@ import {
   ProductCredentialsSupportType,
   ProductState,
   GetResourceQuery,
+  ProfileState,
+  ProfileStateModifier,
   Resource,
   ResourceStatusLabel,
 } from '../../../types/graphql';
@@ -13,8 +15,10 @@ const emptyProducts: ProductConnection = {
   pageInfo: { hasNextPage: false, hasPreviousPage: false },
 };
 
+type ResourceWithOwner = Resource & { owner: any };
+
 // https://graphqlbin.com/v2/6BMYsM
-const resource: GetResourceQuery['resource'] | Resource = {
+const resource: GetResourceQuery['resource'] | ResourceWithOwner = {
   createdAt: '2019-08-23T14:22:50Z',
   credentials: {
     pageInfo: {
@@ -35,6 +39,13 @@ const resource: GetResourceQuery['resource'] | Resource = {
   },
   id: '268ehtybtbaaz9gffw46d36bm0g1a',
   label: 'cms-stage',
+  owner: {
+    id: 'tea-bounq0r4tttipoufa4ug',
+    platform: { id: '', domain: '' },
+    state: ProfileState.Active,
+    stateModifiedBy: ProfileStateModifier.Manifold,
+    subject: '',
+  },
   displayName: 'cms-stage',
   plan: {
     configurableFeatures: { pageInfo: { hasNextPage: false, hasPreviousPage: false }, edges: [] },

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -605,12 +605,14 @@ export type ProductBooleanConfigurableFeature = ProductConfigurableFeature & {
    __typename?: 'ProductBooleanConfigurableFeature',
   label: Scalars['String'],
   displayName: Scalars['String'],
+  type: ProductFeatureType,
   featureOptions?: Maybe<Array<ProductConfigurableFeatureOption>>,
 };
 
 export type ProductConfigurableFeature = {
   label: Scalars['String'],
   displayName: Scalars['String'],
+  type: ProductFeatureType,
 };
 
 export type ProductConfigurableFeatureConnection = {
@@ -680,6 +682,12 @@ export type ProductFeatureCostTier = {
   limit: Scalars['Int'],
   cost: Scalars['Int'],
 };
+
+export enum ProductFeatureType {
+  Boolean = 'BOOLEAN',
+  String = 'STRING',
+  Number = 'NUMBER'
+}
 
 export type ProductFixedFeature = Node & {
    __typename?: 'ProductFixedFeature',
@@ -770,6 +778,7 @@ export type ProductNumberConfigurableFeature = ProductConfigurableFeature & {
    __typename?: 'ProductNumberConfigurableFeature',
   label: Scalars['String'],
   displayName: Scalars['String'],
+  type: ProductFeatureType,
   numericOptions?: Maybe<Array<ProductConfigurableFeatureNumericOptions>>,
 };
 
@@ -806,6 +815,7 @@ export type ProductStringConfigurableFeature = ProductConfigurableFeature & {
    __typename?: 'ProductStringConfigurableFeature',
   label: Scalars['String'],
   displayName: Scalars['String'],
+  type: ProductFeatureType,
   featureOptions?: Maybe<Array<ProductConfigurableFeatureOption>>,
 };
 
@@ -1171,7 +1181,8 @@ export type WithUsage = {
 };
 
 export type ResourceWithCredentialsQueryVariables = {
-  resourceLabel: Scalars['String']
+  resourceLabel: Scalars['String'],
+  owner?: Maybe<Scalars['ProfileIdentity']>
 };
 
 
@@ -1193,7 +1204,8 @@ export type ResourceWithCredentialsQuery = (
 );
 
 export type ResourceCredentialsQueryVariables = {
-  resourceLabel: Scalars['String']
+  resourceLabel: Scalars['String'],
+  owner?: Maybe<Scalars['ProfileIdentity']>
 };
 
 
@@ -1215,7 +1227,8 @@ export type ResourceCredentialsQuery = (
 );
 
 export type DeleteResourceMutationVariables = {
-  resourceId: Scalars['ID']
+  resourceId: Scalars['ID'],
+  owner?: Maybe<Scalars['ID']>
 };
 
 
@@ -1230,7 +1243,9 @@ export type DeleteResourceMutation = (
   ) }
 );
 
-export type FirstResourceQueryVariables = {};
+export type FirstResourceQueryVariables = {
+  owner?: Maybe<Scalars['ProfileIdentity']>
+};
 
 
 export type FirstResourceQuery = (
@@ -1248,7 +1263,8 @@ export type FirstResourceQuery = (
 );
 
 export type ResourceByLabelQueryVariables = {
-  resourceLabel: Scalars['String']
+  resourceLabel: Scalars['String'],
+  owner?: Maybe<Scalars['ProfileIdentity']>
 };
 
 
@@ -1287,7 +1303,8 @@ export type ProductNameQuery = (
 );
 
 export type ResourceProductNameQueryVariables = {
-  resourceLabel: Scalars['String']
+  resourceLabel: Scalars['String'],
+  owner?: Maybe<Scalars['ProfileIdentity']>
 };
 
 
@@ -1401,7 +1418,8 @@ export type RenameResourceMutation = (
 export type ResourceChangePlanMutationVariables = {
   resourceId: Scalars['ID'],
   planId: Scalars['ID'],
-  configuredFeatures?: Maybe<Array<ConfiguredFeatureInput>>
+  configuredFeatures?: Maybe<Array<ConfiguredFeatureInput>>,
+  owner?: Maybe<Scalars['ID']>
 };
 
 
@@ -1478,7 +1496,8 @@ export type Data_ResourcesQuery = (
 );
 
 export type ResourceLogoQueryVariables = {
-  resourceLabel: Scalars['String']
+  resourceLabel: Scalars['String'],
+  owner?: Maybe<Scalars['ProfileIdentity']>
 };
 
 
@@ -1497,7 +1516,8 @@ export type ResourceLogoQuery = (
 );
 
 export type ResourceSsoByIdQueryVariables = {
-  resourceId: Scalars['ID']
+  resourceId: Scalars['ID'],
+  owner?: Maybe<Scalars['ProfileIdentity']>
 };
 
 
@@ -1510,7 +1530,8 @@ export type ResourceSsoByIdQuery = (
 );
 
 export type ResourceSsoByLabelQueryVariables = {
-  resourceLabel: Scalars['String']
+  resourceLabel: Scalars['String'],
+  owner?: Maybe<Scalars['ProfileIdentity']>
 };
 
 
@@ -1559,7 +1580,8 @@ export type ProductsQuery = (
 );
 
 export type ResourceNoCredentialsQueryVariables = {
-  resourceLabel: Scalars['String']
+  resourceLabel: Scalars['String'],
+  owner?: Maybe<Scalars['ProfileIdentity']>
 };
 
 
@@ -1667,12 +1689,13 @@ export type PlanListQuery = (
   )> }
 );
 
-export type ResourceQueryVariables = {
-  resourceLabel: Scalars['String']
+export type PlanSelectorResourceQueryVariables = {
+  resourceLabel: Scalars['String'],
+  owner?: Maybe<Scalars['ProfileIdentity']>
 };
 
 
-export type ResourceQuery = (
+export type PlanSelectorResourceQuery = (
   { __typename?: 'Query' }
   & { resource: Maybe<(
     { __typename?: 'Resource' }
@@ -1833,7 +1856,8 @@ export type ProductQuery = (
 );
 
 export type ResourceCardQueryVariables = {
-  resourceLabel: Scalars['String']
+  resourceLabel: Scalars['String'],
+  owner?: Maybe<Scalars['ProfileIdentity']>
 };
 
 
@@ -1973,7 +1997,8 @@ export type ResourceWithOwnerQuery = (
 );
 
 export type GetResourceQueryVariables = {
-  resourceLabel: Scalars['String']
+  resourceLabel: Scalars['String'],
+  owner?: Maybe<Scalars['ProfileIdentity']>
 };
 
 
@@ -1988,7 +2013,10 @@ export type GetResourceQuery = (
     )>, status: (
       { __typename?: 'ResourceStatus' }
       & Pick<ResourceStatus, 'label' | 'message'>
-    ), configuredFeatures: Maybe<(
+    ), owner: Maybe<(
+      { __typename?: 'Profile' }
+      & Pick<Profile, 'id'>
+    )>, configuredFeatures: Maybe<(
       { __typename?: 'ConfiguredFeatureConnection' }
       & { edges: Array<(
         { __typename?: 'ConfiguredFeatureEdge' }
@@ -2162,7 +2190,8 @@ export type ResourcesQuery = (
 );
 
 export type ResourceIdQueryVariables = {
-  resourceLabel: Scalars['String']
+  resourceLabel: Scalars['String'],
+  owner?: Maybe<Scalars['ProfileIdentity']>
 };
 
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
     "moduleResolution": "node",
     "noImplicitAny": true,
     "noImplicitReturns": true,
-    "noUnusedLocals": true,
     "noUnusedParameters": true,
     "resolveJsonModule": true,
     "strictNullChecks": true,


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

Adds `owner-id` to more components that make resource queries.

Components added:

| Component | Test Added |
|:-------------|:-----------:|
| `<manifold-copy-credentials>` | ✅ |
| `<manifold-credentials>` | ✅ |
| `<manifold-data-deprovision-button>` | ✅ |
| `<manifold-data-has-resource>` | ✅ |
| `<manifold-data-product-name>` | ✅ |
| `<manifold-data-resource-logo>` | ✅ |
| `<manifold-data-resize-button>` | ✅ |
| `<manifold-data-rename-button>` | ✅|
| `<manifold-data-sso-button>` | ✅ |
| `<manifold-no-credentials>` | (covered in `manifold-resource-credentials`) |
| `<manifold-plan-selector>` | ✅ |
| `<manifold-resource-card>` | ✅ |
| `<manifold-resource-credentials>` | ✅ |
| `<manifold-resource-deprovision>` | ✅ |
| `<manifold-resource-rename>` | ✅ |
| `<manifold-resource-sso>` | ✅ |

## Testing

This shouldn’t affect existing functionality. It’s been tested in Render and components seem to work normally, but I’ll need @jelmersnoeck’s help next week as I’m encountering a staging bug with my specific profile.

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [x] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [x] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
