### PR TITLE
Fix npm package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed `postinstall` script from causing issues when using in remote projects
+
 ## [0.9.6] - 2020-03-10
 
 ### Changed
@@ -530,7 +536,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Changed the `manifold-resource-credentials` component to use the standalone `manifold-credentials`
   component.
 
-[unreleased]: https://github.com/manifoldco/ui/compare/v0.9.5...HEAD
+[unreleased]: https://github.com/manifoldco/ui/compare/v0.9.6...HEAD
+[0.9.6]: https://github.com/manifoldco/ui/compare/v0.9.5...v0.9.6
 [0.9.5]: https://github.com/manifoldco/ui/compare/v0.9.4...v0.9.5
 [0.9.4]: https://github.com/manifoldco/ui/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/manifoldco/ui/compare/v0.9.2...v0.9.3

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ package:
 	cp LICENSE pkg/.
 	cp README.md pkg/.
 	cp package.json pkg/.
+	npm run clean-package-json
 
 release-pr: docker
 	docker tag arigato/$(NAME) arigato/$(NAME):$(RELEASE_VERSION)

--- a/package.json
+++ b/package.json
@@ -10,14 +10,8 @@
   "bugs": {
     "url": "https://github.com/manifoldco/ui/issues"
   },
-  "engines": {
-    "node": ">=10 <=13"
-  },
   "author": "manifoldco",
   "license": "BSD-3-Clause",
-  "files": [
-    "dist/"
-  ],
   "main": "dist/index.js",
   "esnext": "dist/esm",
   "module": "dist/index.mjs",
@@ -32,6 +26,7 @@
     "build:storybook": "npm run build && build-storybook && npm run copy-changelog",
     "build:watch": "npm run update-version && stencil build --watch",
     "bundlesize": "npm run build && npx bundlesize",
+    "clean-package-json": "node scripts/clean-package-json",
     "copy-changelog": "node scripts/copy-changelog",
     "dev": "npm run build:watch & rm -rf dist && wait-on dist/loader/index.cjs.js && npm run storybook",
     "docs": "npm run prepare:docs && cd docs && npm start",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "lint:css": "stylelint 'src/**/*.css'",
     "lint:js": "eslint --ext .js,.ts,.tsx src",
     "now-build": "npm run build:storybook",
-    "postinstall": "npm run update-version",
     "storybook": "start-storybook -p 6006",
     "test": "stencil test --spec --e2e",
     "test:e2e": "stencil test --e2e",

--- a/scripts/clean-package-json.js
+++ b/scripts/clean-package-json.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const path = require('path');
+
+const PACKAGE_JSON_LOCATION = path.resolve(__dirname, '..', 'pkg', 'package.json');
+
+if (!fs.existsSync(PACKAGE_JSON_LOCATION)) {
+  console.error('pkg/package.json not found. Did you forget to build?');
+}
+
+// read file
+const packageJson = JSON.parse(fs.readFileSync(PACKAGE_JSON_LOCATION, 'utf8'));
+
+// clean file
+delete packageJson.files;
+delete packageJson.bundlesize;
+delete packageJson.scripts;
+
+// save file
+fs.writeFileSync(PACKAGE_JSON_LOCATION, JSON.stringify(packageJson, undefined, 2), 'utf8');


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

Due to the new CI process, we were shipping `package.json.scripts` which were causing install problems when installed from npm. This fixes the problem, where our local scripts don’t affect the npm version.

## Testing

Installing from npm works in external project:

![Screen Shot 2020-03-11 at 13 50 53](https://user-images.githubusercontent.com/1369770/76457973-5a0d6a80-639f-11ea-88ff-d573e32361f1.png)

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [x] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
