### PR TITLE
use waitForAuth on resource components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.8] - 2020-03-30
 
 ### Fixed
 
@@ -543,7 +543,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Changed the `manifold-resource-credentials` component to use the standalone `manifold-credentials`
   component.
 
-[unreleased]: https://github.com/manifoldco/ui/compare/v0.9.7...HEAD
+[0.9.8]: https://github.com/manifoldco/ui/compare/v0.9.7...v0.9.8
 [0.9.7]: https://github.com/manifoldco/ui/compare/v0.9.6...v0.9.7
 [0.9.6]: https://github.com/manifoldco/ui/compare/v0.9.5...v0.9.6
 [0.9.5]: https://github.com/manifoldco/ui/compare/v0.9.4...v0.9.5

--- a/src/components/manifold-data-resource-list/manifold-data-resource-list.tsx
+++ b/src/components/manifold-data-resource-list/manifold-data-resource-list.tsx
@@ -1,6 +1,7 @@
 import { h, Component, Prop, State, Event, EventEmitter, Element } from '@stencil/core';
 
 import { connection } from '../../global/app';
+import { waitForAuthToken } from '../../utils/auth';
 import logger, { loadMark } from '../../utils/logger';
 import fetchAllPages from '../../utils/fetchAllPages';
 import { GraphqlFetch } from '../../utils/graphqlFetch';
@@ -38,7 +39,17 @@ export class ManifoldDataResourceList {
   @Event({ eventName: 'manifold-resourceList-click', bubbles: true }) clickEvent: EventEmitter;
 
   @loadMark()
-  componentWillLoad() {
+  async componentWillLoad() {
+    // if auth token missing, wait
+    if (!connection.getAuthToken()) {
+      await waitForAuthToken(
+        () => connection.authToken,
+        connection.waitTime,
+        () => Promise.resolve()
+      );
+    }
+
+    // start polling
     this.fetchResources();
     if (!this.paused) {
       this.interval = window.setInterval(() => this.fetchResources(), 3000);

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,11 @@ export async function ensureAuthToken() {
     return connection.authToken;
   }
 
-  await waitForAuthToken(() => connection.authToken, connection.waitTime, Promise.resolve);
+  await waitForAuthToken(
+    () => connection.authToken,
+    connection.waitTime,
+    () => Promise.resolve()
+  );
 
   return connection.authToken;
 }


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

Uses `waitForAuth()` on `<manifold-resource-list>`, `<manifold-data-resource-list>`, and `<manifold-resource-container>`

## Testing

This has been tested in Render Dashboard locally and I’m unable to get an auth error locally now 🎉 
<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [x] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
