### PR TITLE
Remove mocked products screenshot

### DIFF
--- a/src/components/manifold-marketplace/manifold-marketplace-happo.ts
+++ b/src/components/manifold-marketplace/manifold-marketplace-happo.ts
@@ -1,6 +1,5 @@
 import { connection } from '../../global/app';
 import { GraphqlFetch, GraphqlResponseBody } from '../../utils/graphqlFetch';
-import { ProductsQuery } from '../../types/graphql';
 
 export const skeleton = () => {
   const conn = document.createElement('manifold-connection');
@@ -27,46 +26,6 @@ export const allProducts = () => {
 
   const grid = document.createElement('manifold-marketplace');
   grid.hideUntilReady = true;
-
-  document.body.appendChild(grid);
-
-  return grid.componentOnReady();
-};
-
-export const mockedProducts = () => {
-  const conn = document.createElement('manifold-connection');
-  document.body.appendChild(conn);
-
-  const grid = document.createElement('manifold-marketplace');
-  grid.hideUntilReady = true;
-  grid.graphqlFetch = (async (): Promise<GraphqlResponseBody<ProductsQuery>> => ({
-    data: {
-      products: {
-        edges: [
-          {
-            node: {
-              id: '1234',
-              label: 'test',
-              displayName: 'Test',
-              logoUrl: 'https://www.placecage.com/c/200/300',
-              tagline: 'Testing',
-              categories: [
-                {
-                  label: 'cms',
-                },
-              ],
-              plans: {
-                edges: [],
-              },
-            },
-          },
-        ],
-        pageInfo: {
-          hasNextPage: false,
-        },
-      },
-    },
-  })) as GraphqlFetch;
 
   document.body.appendChild(grid);
 


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

Since we have marketplace screenshots with real data, we don't really need one for mocked data. And it was just creating Happo diff noise with the randomized Nicolas Cage image.

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
