### PR TITLE
Update links to MaaS authentication docs

### DIFF
--- a/docs/docs/advanced/authentication.md
+++ b/docs/docs/advanced/authentication.md
@@ -30,7 +30,7 @@ Everything else, though, requires auth. This guide covers setting up authenticat
 
 <manifold-toast>
   <div>
-    View the complete authentication guide at <a href="https://docs.manifold.co/docs/platforms-auth-AzsO1HvPT1Hnojsrsb10L">docs.manifold.co</a>
+    View the complete authentication guide at <a href="https://docs.manifold.co/enterprise/launch-a-marketplace/authentication">docs.manifold.co</a>
   </div>
 </manifold-toast>
 
@@ -242,6 +242,6 @@ The wait time defaults to 15 seconds, but is configurable through [the
 manifold-connection][connection] component. You should only use this function if the call you're
 making requires authentication, since public calls to our catalog don't require an auth token.
 
-[authentication]: https://docs.manifold.co/docs/platforms-auth-AzsO1HvPT1Hnojsrsb10L
+[authentication]: https://docs.manifold.co/enterprise/launch-a-marketplace/authentication
 [connection]: /connection
 [oauth2]: https://www.oauth.com/oauth2-servers/access-tokens/authorization-code-request


### PR DESCRIPTION
<!-- *************************************** -->
<!--       🌱 Pull Request Template          -->
<!-- *************************************** -->

<!-- ✅ Linked to ZenHub issue               -->

## Reason for change

- Updates links referring to MaaS authentication.

<!-- What does this change, in plain language? -->
<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- For someone unfamiliar with the issue, how should this be tested? -->

## Checklist

<!-- are all the steps completed? -->

- [ ] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [x] **Prop changes**: [docs][docs] were updated
- [ ] **Prop changes**: E2E tests were updated, testing from the highest level possible
- [ ] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
