### PR TITLE
Add colouring for Chec products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.11] - 2020-07-15
+
+- Add Chec gradient colors.
+
 ## [0.9.10] - 2020-04-24
 
 ### Added

--- a/src/components/manifold-product-page/manifold-product-page.css
+++ b/src/components/manifold-product-page/manifold-product-page.css
@@ -50,6 +50,7 @@
   --manifold-g-websolr: linear-gradient(to right top, #0e517e, #218ab5);
   --manifold-g-zerosix: linear-gradient(to right top, #252a2e, #344068);
   --manifold-g-ziggeo: linear-gradient(to right top, #743252, #ba445e);
+  --manifold-g-chec: linear-gradient(to right top, #28608D, #2C7C9F);
 
   /* Categories */
   --manifold-c-authentication: #1a4898;

--- a/stories/data/product-labels.js
+++ b/stories/data/product-labels.js
@@ -10,6 +10,7 @@ export default [
   'cloudamqp',
   'cloudcube',
   'custom-recognition',
+  'chec',
   'db33-mysql',
   'dumper',
   'elegant-cms',


### PR DESCRIPTION
## Reason for change

- Add gradient colouring for _Commerce.js by Chec_ for their product page.

## Checklist

<!-- are all the steps completed? -->

- [x] **CHANGELOG**: The **Unreleased** section of CHANGELOG was updated
- [ ] ~**Prop changes**: [docs][docs] were updated~
- [ ] ~**Prop changes**: E2E tests were updated, testing from the highest level possible~
- [x] **Platform testing**: If this change should be [tested against a platform][platform-testing], has it been?

[docs]: https://ui.sandbox.manifold.co
[platform-testing]: https://app.gitbook.com/@manifold/s/engineering/playbooks/testing-your-code-against-a-platform
