### PR TITLE
Replace space and slash with dash in category search

### DIFF
--- a/src/components/manifold-marketplace-grid/utils.ts
+++ b/src/components/manifold-marketplace-grid/utils.ts
@@ -6,11 +6,12 @@ export function filteredServices(filter: string, services?: ProductEdge[]): Prod
   }
 
   const searchTerm = filter.toLocaleLowerCase();
+  const categorySearchTerm = searchTerm.replace(' ', '-').replace(' ', '/');
   return services.filter(s => {
     const searchTargets = [s.node.label, s.node.displayName.toLocaleLowerCase()].concat(
       s.node.categories.map(c => c.label)
     );
-    return searchTargets.some(t => t.includes(searchTerm));
+    return searchTargets.some(t => t.includes(searchTerm) || t.includes(categorySearchTerm));
   });
 }
 


### PR DESCRIPTION
## Reason for change

Searching on the marketplace component for a category with a space or forward slash character would cause the search to return no results, even if the category has products. This updates the search to include a search on the term with spaces and slashes replaced with a dash, to match the category labels.

References manifoldco/engineering#11461