### PR TITLE
Remove AI/ML category to avoid flashing empty category on manifold-marketplace-grid load

### DIFF
--- a/src/data/marketplace.ts
+++ b/src/data/marketplace.ts
@@ -35,7 +35,6 @@ const skeletonProducts: Catalog.Product[] = [
       name: 'David Leger',
       tagline: 'David Leger: lover of cats, conqueror of front-ends',
       tags: [
-        'ai-ml',
         'database',
         'logging',
         'memory-store',

--- a/src/spec/mock/products.ts
+++ b/src/spec/mock/products.ts
@@ -2845,12 +2845,6 @@ const products: ProductEdge[] = [
           label: 'worker',
           products: emptyProducts,
         },
-        {
-          displayName: 'AI / ML',
-          id: '00000000000000000000000000000',
-          label: 'ai-ml',
-          products: emptyProducts,
-        },
       ],
       displayName: 'ZeroSix Cloud Compute Platform',
       documentationUrl: 'https://zerosix.ai/frequently-asked-questions/',
@@ -2879,7 +2873,7 @@ const products: ProductEdge[] = [
       supportEmail: 'support@zerosix.ai',
       tagline:
         'ZeroSix Marketplace provides access to compute power specifically for Machine Learning and Artificial Intelligence.',
-      tags: ['ai-ml', 'worker'],
+      tags: ['worker'],
       termsUrl: 'https://zerosix.ai/privacy-policy/',
       valueProps: [
         {

--- a/src/utils/fetchAllPages.spec.ts
+++ b/src/utils/fetchAllPages.spec.ts
@@ -10,25 +10,6 @@ const firstPage = {
     edges: [
       {
         node: {
-          label: 'ai-ml',
-          products: {
-            edges: [
-              {
-                node: {
-                  label: 'zerosix',
-                },
-              },
-            ],
-            pageInfo: {
-              hasNextPage: false,
-              endCursor:
-                'fch78ybgcmh3m8h25gh66xbjedqq48hu48r30c1k6hhq8vb4ehm3ec3375rp8e3ne5pqeuvgccw78dvaerwpudtmertkgt3pc9hqgx9qd9w6guk36gh2r8kfe9j6awh279xquz8',
-            },
-          },
-        },
-      },
-      {
-        node: {
           label: 'authentication',
           products: {
             edges: [

--- a/src/utils/marketplace.ts
+++ b/src/utils/marketplace.ts
@@ -1,6 +1,5 @@
 import {
   activity,
-  ai,
   cpu,
   credit_card,
   database,
@@ -29,15 +28,12 @@ export function formatCategoryLabel(tag: string): string {
   switch (tag) {
     case 'cms':
       return 'CMS';
-    case 'ai-ml':
-      return 'AI/ML';
     default:
       return tag.replace(/-/g, ' ');
   }
 }
 
 export const categoryIcon: { [key: string]: string } = {
-  'ai-ml': ai,
   api: plug,
   authentication: shield,
   cms: file,


### PR DESCRIPTION
Remove the `ai-ml` category as no product exist to fit that category, and fix `manifold-marketplace-grid` loading, where the empty "AI/ML" category flickers with a loading state.