### PR TITLE
Bump version to 0.9.14 to match released version on NPM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.13-0.9.14] - 2020-07-17
+
+- Bump version for NPM
+
 ## [0.9.12] - 2020-07-16
 
 - Remove "AI/ML" category since it has no products

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@manifoldco/ui",
   "description": "Manifold UI",
-  "version": "0.9.12",
+  "version": "0.9.14",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/manifoldco/ui.git"


### PR DESCRIPTION
## Reason for change

- Bump the package.json and tag version to match the NPM release for 0.9.14